### PR TITLE
chore: add opencode GitHub Actions workflow

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -1,0 +1,31 @@
+name: opencode
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+jobs:
+  opencode:
+    if: |
+      contains(github.event.comment.body, '/oc') ||
+      contains(github.event.comment.body, '/opencode')
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+       - name: Checkout repository
+         uses: actions/checkout@v6
+         with:
+           fetch-depth: 1
+           persist-credentials: false
+
+       - name: Run OpenCode
+         uses: anomalyco/opencode/github@latest
+         env:
+           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+         with:
+           model: anthropic/claude-sonnet-4-20250514
+           # share: true
+           # github_token: xxxx


### PR DESCRIPTION
## Summary

- Adds OpenCode GitHub Actions workflow that triggers on issue and PR comments
- Responds to `/oc` or `/opencode` commands in comments
- Uses `anomalyco/opencode/github@latest` action with Anthropic Claude Sonnet model