### PR TITLE
chore: add ruff linting, formatting, and ty type checking

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.6
+    hooks:
+      - id: ruff-format

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,60 @@
+# AGENTS.md
+
+Instructions for AI agents working in this repository.
+
+## Quick Reference
+
+```bash
+# Development setup
+uv sync --group dev  # Install dependencies (includes ruff, ty, pre-commit)
+uv run santai --help # Run CLI
+prek install         # Set up pre-commit hooks (ruff format on commit)
+
+# Install prek (if not already installed)
+uv tool install prek # Install prek globally
+
+# Formatting (runs automatically on commit via pre-commit)
+ruff format .        # Format code
+
+# Linting (recommended, not enforced via hooks)
+ruff check --fix .   # Lint with auto-fix
+ruff check .         # Lint without auto-fix
+
+# Type checking (recommended, not enforced via hooks)
+ty check src/        # Run type checker
+```
+
+## Project Structure
+
+```
+src/santai_cli/
+├── cli.py           # Typer app, command registration
+├── commands/        # CLI commands (init, copy, history, ui, web)
+├── core/project.py  # Project detection, data models, file graph
+├── tui/             # Textual TUI dashboard
+│   ├── app.py       # Main TUI application
+│   ├── graph_render.py  # Force-directed graph with Braille rendering
+│   └── themes.py    # Multi-theme system
+└── web/             # FastAPI web dashboard + Jinja2 templates
+```
+
+Entry point: `santai_cli.cli:app` (Typer application)
+
+## Key Constraints
+
+- **Python 3.12+** required
+- **uv** is the package manager (not pip)
+- **Ruff v0.15.6** for linting/formatting — version pinned in `pyproject.toml` and `.pre-commit-config.yaml` (keep in sync)
+- **ty** for type checking — recommended but not enforced
+- Pre-commit hooks run `ruff format` on commit (formatting only)
+- Linting (`ruff check`) and type checking (`ty check`) should be run manually before submitting PRs
+
+## Code Quality Workflow
+
+1. **On every commit**: `ruff format` runs automatically via pre-commit hook
+2. **Before submitting a PR**: Run `ruff check --fix .` and `ty check src/` manually
+3. **Goal**: Zero errors from both `ruff check` and `ty check`
+
+## Testing
+
+No test suite currently configured.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,13 @@ dependencies = [
     "python-multipart>=0.0.9",
 ]
 
+[dependency-groups]
+dev = [
+    "ruff==0.15.6",
+    "ty>=0.0.31",
+    "pre-commit>=3.5.0",
+]
+
 [project.scripts]
 santai = "santai_cli.cli:app"
 
@@ -26,3 +33,26 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/santai_cli"]
+
+[tool.ruff]
+target-version = "py312"
+src = ["src"]
+line-length = 88
+
+[tool.ruff.lint]
+select = [
+    "E",   # pycodestyle errors
+    "W",   # pycodestyle warnings
+    "F",   # pyflakes
+    "I",   # isort
+    "UP",  # pyupgrade
+    "B",   # flake8-bugbear
+    "SIM", # flake8-simplify
+    "RUF", # ruff-specific rules
+]
+ignore = [
+    "RUF012", # mutable class attributes — false positives for Textual widget patterns (BINDINGS, etc.)
+]
+
+[tool.ruff.lint.per-file-ignores]
+"src/santai_cli/commands/init.py" = ["E501"]  # long strings in README template

--- a/src/santai_cli/commands/copy.py
+++ b/src/santai_cli/commands/copy.py
@@ -68,10 +68,7 @@ def copy(
     This allows you to fork a knowledge base and manage it independently.
     """
     # Resolve source path
-    if source == ".":
-        source_path = Path.cwd()
-    else:
-        source_path = Path(source).resolve()
+    source_path = Path.cwd() if source == "." else Path(source).resolve()
 
     # Validate source exists
     if not source_path.exists():
@@ -109,7 +106,7 @@ def copy(
         shutil.copytree(source_path, dest_path, ignore=_ignore_patterns)
     except Exception as e:
         console.print(f"[red]Error copying files: {e}[/red]")
-        raise typer.Exit(1)
+        raise typer.Exit(1) from e
 
     # Initialize fresh git repository
     console.print("Initializing fresh git repository...")

--- a/src/santai_cli/commands/history.py
+++ b/src/santai_cli/commands/history.py
@@ -83,7 +83,9 @@ def history(
 
         console.print(Rule(style="dim"))
         console.print(
-            f"[dim]{len(entries)} {'entry' if len(entries) == 1 else 'entries'} total[/dim]"
+            f"[dim]{len(entries)} "
+            f"{'entry' if len(entries) == 1 else 'entries'}"
+            " total[/dim]"
         )
         console.print()
 

--- a/src/santai_cli/commands/init.py
+++ b/src/santai_cli/commands/init.py
@@ -1,7 +1,6 @@
 """Initialize a new Santai project."""
 
 import subprocess
-import sys
 from pathlib import Path
 from typing import Annotated
 
@@ -81,7 +80,7 @@ def _is_directory_empty(path: Path) -> bool:
 def _run_command(cmd: list[str], cwd: Path) -> bool:
     """Run a command and return True if successful."""
     try:
-        result = subprocess.run(
+        subprocess.run(
             cmd,
             cwd=cwd,
             capture_output=True,

--- a/src/santai_cli/core/project.py
+++ b/src/santai_cli/core/project.py
@@ -114,11 +114,7 @@ def is_santai_project(path: Path) -> bool:
     if not path.is_dir():
         return False
 
-    for dir_name in SANTAI_DIRS:
-        if not (path / dir_name).is_dir():
-            return False
-
-    return True
+    return all((path / dir_name).is_dir() for dir_name in SANTAI_DIRS)
 
 
 def get_project(path: Path | None = None) -> SantaiProject | None:
@@ -304,7 +300,8 @@ def get_notes(project: SantaiProject) -> list[NoteEntry]:
             stat = file_path.stat()
             content = file_path.read_text(encoding="utf-8")
 
-            # Generate title from filename (remove extension, replace hyphens/underscores)
+            # Generate title from filename
+            # (remove extension, replace hyphens/underscores)
             title = file_path.stem.replace("-", " ").replace("_", " ").title()
 
             entries.append(

--- a/src/santai_cli/tui/app.py
+++ b/src/santai_cli/tui/app.py
@@ -1,7 +1,9 @@
 """Textual TUI application for Santai."""
 
+from collections.abc import Callable, Iterable
 from datetime import datetime
 from pathlib import Path
+from typing import Any
 
 from textual.app import App, ComposeResult
 from textual.binding import Binding
@@ -20,6 +22,7 @@ from textual.widgets import (
 )
 
 from santai_cli.core.project import (
+    NoteEntry,
     SantaiProject,
     get_directory_stats,
     get_file_graph,
@@ -29,7 +32,7 @@ from santai_cli.tui.graph_render import search_nodes as graph_search_nodes
 from santai_cli.tui.themes import ThemeManager, get_theme_css
 
 
-def format_size(size_bytes: int) -> str:
+def format_size(size_bytes: int | float) -> str:
     """Format bytes as human-readable size."""
     for unit in ["B", "KB", "MB", "GB"]:
         if size_bytes < 1024:
@@ -62,8 +65,8 @@ def format_time_ago(dt: datetime) -> str:
 class FilteredDirectoryTree(DirectoryTree):
     """DirectoryTree that only shows santai directories."""
 
-    def filter_paths(self, paths: list[Path]) -> list[Path]:
-        """Filter to only show resources, codebases, history, notes dirs at root level."""
+    def filter_paths(self, paths: Iterable[Path]) -> Iterable[Path]:
+        """Filter to only show santai dirs at root level."""
         return [
             p
             for p in paths
@@ -103,7 +106,12 @@ class StatsPanel(Static):
         dir_table.add_row("notes", str(stats.notes_count))
         dir_table.add_row(
             "[bold]Total[/bold]",
-            f"[bold]{stats.resources_count + stats.codebases_count + stats.history_count + stats.notes_count}[/bold]",
+            f"[bold]{
+                stats.resources_count
+                + stats.codebases_count
+                + stats.history_count
+                + stats.notes_count
+            }[/bold]",
         )
         dir_table.add_row("Size", format_size(stats.total_size_bytes))
 
@@ -128,7 +136,9 @@ class RecentFilesPanel(Static):
         self._recent_files: list = []
 
     def compose(self) -> ComposeResult:
-        yield Label("[bold]Recent Files[/bold] [dim](click to open)[/dim]", id="recent-title")
+        yield Label(
+            "[bold]Recent Files[/bold] [dim](click to open)[/dim]", id="recent-title"
+        )
         yield DataTable(id="recent-table", cursor_type="row")
 
     def on_mount(self) -> None:
@@ -164,6 +174,7 @@ class ClickableNote(Static):
 
     class Clicked(Message):
         """Message sent when a note is clicked."""
+
         def __init__(self, note: "NoteEntry") -> None:
             super().__init__()
             self.note = note
@@ -195,7 +206,6 @@ class NotesPanel(Static):
 
     def refresh_notes(self) -> None:
         """Refresh notes data."""
-        from santai_cli.core.project import NoteEntry
 
         theme = ThemeManager.get_current_theme()
         self._notes = get_notes(self.project)
@@ -260,7 +270,12 @@ class GraphPanel(Static):
         """Populate graph view."""
         self.refresh_graph()
 
-    def set_search(self, query: str, selected_id: str | None = None, highlight_ids: set[str] | None = None) -> None:
+    def set_search(
+        self,
+        query: str,
+        selected_id: str | None = None,
+        highlight_ids: set[str] | None = None,
+    ) -> None:
         """Set search state and re-render."""
         self._search_query = query
         self._selected_id = selected_id
@@ -308,14 +323,18 @@ class GraphPanel(Static):
 
         # Apply directory filter
         if self._filter_dirs is not None:
-            filtered_node_ids = {n.id for n in nodes if n.directory in self._filter_dirs}
+            filtered_node_ids = {
+                n.id for n in nodes if n.directory in self._filter_dirs
+            }
             nodes = [n for n in nodes if n.id in filtered_node_ids]
-            edges = [e for e in edges if e.source in filtered_node_ids and e.target in filtered_node_ids]
+            edges = [
+                e
+                for e in edges
+                if e.source in filtered_node_ids and e.target in filtered_node_ids
+            ]
 
         if not nodes:
-            content_widget.update(
-                "[dim]No files match the current filter.[/dim]"
-            )
+            content_widget.update("[dim]No files match the current filter.[/dim]")
             self._node_positions = {}
             self._render_width = 0
             self._render_height = 0
@@ -368,12 +387,16 @@ class GraphPanel(Static):
             stats_line += f"  [bold cyan]Filter:[/bold cyan] {filter_names}"
         else:
             stats_line = (
-                f"[bold]Nodes:[/bold] {total_nodes}  "
-                f"[bold]Edges:[/bold] {total_edges}"
+                f"[bold]Nodes:[/bold] {total_nodes}  [bold]Edges:[/bold] {total_edges}"
             )
         if self._search_query:
             match_count = len(self._highlight_ids) if self._highlight_ids else 0
-            stats_line += f"  [bold yellow]Search:[/bold yellow] \"{self._search_query}\" ({match_count} match{'es' if match_count != 1 else ''})"
+            suffix = "es" if match_count != 1 else ""
+            stats_line += (
+                f"  [bold yellow]Search:[/bold yellow]"
+                f' "{self._search_query}"'
+                f" ({match_count} match{suffix})"
+            )
         lines.append(stats_line)
         lines.append("")
 
@@ -399,14 +422,15 @@ class GraphPanel(Static):
 
         if graph_data.edges:
             lines.append(
-                "[dim]⬢ hub (5+)  ◆ connected (3+)  ● node  ◈ match  ◉ selected  c=clear[/dim]"
+                "[dim]⬢ hub (5+)  ◆ connected (3+)  ● node"
+                "  ◈ match  ◉ selected  c=clear[/dim]"
             )
 
         content_widget.update("\n".join(lines))
 
     def on_click(self, event) -> None:
         """Handle click on graph — find nearest node and open file."""
-        if not hasattr(self, '_node_positions') or not self._node_positions:
+        if not hasattr(self, "_node_positions") or not self._node_positions:
             return
 
         # Get click position relative to the graph content widget
@@ -429,7 +453,7 @@ class GraphPanel(Static):
 
         # Find the nearest node within a reasonable click radius
         best_node_id = None
-        best_dist = float('inf')
+        best_dist = float("inf")
         click_radius = 3.0  # max distance in character cells to register a click
 
         for node_id, (nx, ny) in self._node_positions.items():
@@ -450,10 +474,13 @@ class GraphPanel(Static):
 
         # Determine if it's a note
         node = self._node_map.get(best_node_id)
-        is_note = node and node.directory == "notes" and file_path.suffix in (".md", ".txt")
+        is_note = (
+            node and node.directory == "notes" and file_path.suffix in (".md", ".txt")
+        )
 
         if is_note:
             from santai_cli.core.project import NoteEntry
+
             try:
                 content = file_path.read_text(encoding="utf-8")
                 title = file_path.stem.replace("-", " ").replace("_", " ").title()
@@ -491,22 +518,20 @@ class ConfirmScreen(ModalScreen):
         Binding("n", "dismiss", "No"),
     ]
 
-    def __init__(self, message: str, on_confirm: callable) -> None:
+    def __init__(self, message: str, on_confirm: Callable[[], Any]) -> None:
         super().__init__()
         self._message = message
         self._on_confirm = on_confirm
 
     def compose(self) -> ComposeResult:
-        with Vertical(id="theme-modal"):
-            with Vertical(id="theme-modal-content"):
-                yield Label("[bold]Confirm[/bold]", id="theme-modal-title")
-                yield Static(id="confirm-body")
+        with Vertical(id="theme-modal"), Vertical(id="theme-modal-content"):
+            yield Label("[bold]Confirm[/bold]", id="theme-modal-title")
+            yield Static(id="confirm-body")
 
     def on_mount(self) -> None:
         body = self.query_one("#confirm-body", Static)
         body.update(
-            f"{self._message}\n\n"
-            f"[bold]y[/bold] = Yes  |  [bold]n[/bold] / Esc = Cancel"
+            f"{self._message}\n\n[bold]y[/bold] = Yes  |  [bold]n[/bold] / Esc = Cancel"
         )
 
     def action_confirm(self) -> None:
@@ -547,10 +572,9 @@ class MoveFileScreen(ModalScreen):
         self._project = project
 
     def compose(self) -> ComposeResult:
-        with Vertical(id="theme-modal"):
-            with Vertical(id="theme-modal-content"):
-                yield Label("[bold]Move File[/bold]", id="theme-modal-title")
-                yield Static(id="move-body")
+        with Vertical(id="theme-modal"), Vertical(id="theme-modal-content"):
+            yield Label("[bold]Move File[/bold]", id="theme-modal-title")
+            yield Static(id="move-body")
 
     def on_mount(self) -> None:
         body = self.query_one("#move-body", Static)
@@ -622,13 +646,12 @@ class NoteDetailScreen(ModalScreen):
         self._project = project
 
     def compose(self) -> ComposeResult:
-        with Vertical(id="notes-modal"):
-            with VerticalScroll(id="notes-modal-content"):
-                yield Label(
-                    f"[bold]📄 {self._note.title}[/bold]",
-                    id="notes-modal-title",
-                )
-                yield Static(id="notes-modal-body")
+        with Vertical(id="notes-modal"), VerticalScroll(id="notes-modal-content"):
+            yield Label(
+                f"[bold]📄 {self._note.title}[/bold]",
+                id="notes-modal-title",
+            )
+            yield Static(id="notes-modal-body")
 
     def on_mount(self) -> None:
         """Populate note content."""
@@ -646,7 +669,11 @@ class NoteDetailScreen(ModalScreen):
         lines.append(f"[{accent}]{'─' * 50}[/{accent}]")
         lines.append("")
         # Show full content
-        content = self._note.content[:5000] if len(self._note.content) > 5000 else self._note.content
+        content = (
+            self._note.content[:5000]
+            if len(self._note.content) > 5000
+            else self._note.content
+        )
         lines.append(content)
         if len(self._note.content) > 5000:
             lines.append("")
@@ -718,7 +745,9 @@ class NoteDetailScreen(ModalScreen):
     def _get_project(self) -> SantaiProject | None:
         """Get project from the app."""
         if hasattr(self.app, "project"):
-            return self.app.project
+            project = self.app.project  # type: ignore[attr-defined]
+            if isinstance(project, SantaiProject):
+                return project
         return None
 
 
@@ -738,21 +767,20 @@ class EditNoteScreen(ModalScreen):
         self._has_changes: bool = False
 
     def compose(self) -> ComposeResult:
-        with Vertical(id="edit-note-modal"):
-            with Vertical(id="edit-note-content"):
-                yield Label(
-                    f"[bold]✏️  Editing: {self._note.title}[/bold]",
-                    id="edit-note-title",
-                )
-                yield Static(
-                    f"[dim]{self._file_path.name}[/dim]",
-                    id="edit-note-path",
-                )
-                yield TextArea(id="edit-note-textarea")
-                yield Static(
-                    "[dim]Ctrl+S = save · Esc = close (unsaved changes will prompt)[/dim]",
-                    id="edit-note-help",
-                )
+        with Vertical(id="edit-note-modal"), Vertical(id="edit-note-content"):
+            yield Label(
+                f"[bold]✏️  Editing: {self._note.title}[/bold]",
+                id="edit-note-title",
+            )
+            yield Static(
+                f"[dim]{self._file_path.name}[/dim]",
+                id="edit-note-path",
+            )
+            yield TextArea(id="edit-note-textarea")
+            yield Static(
+                "[dim]Ctrl+S = save · Esc = close (unsaved changes will prompt)[/dim]",
+                id="edit-note-help",
+            )
 
     def on_mount(self) -> None:
         """Load file content into the editor."""
@@ -815,23 +843,22 @@ class AddNoteScreen(ModalScreen):
         self.project = project
 
     def compose(self) -> ComposeResult:
-        with Vertical(id="notes-modal"):
-            with Vertical(id="notes-modal-content"):
-                yield Label(
-                    "[bold]📝 Add Note (Esc to cancel)[/bold]",
-                    id="notes-modal-title",
-                )
-                yield Label("Title:")
-                yield Input(
-                    placeholder="my-note (will be saved as my-note.md)",
-                    id="note-title-input",
-                )
-                yield Label("Content:")
-                yield TextArea(id="note-content-input")
-                yield Static(
-                    "[dim]Tab to switch fields · Ctrl+S to save · Esc to cancel[/dim]",
-                    id="note-help",
-                )
+        with Vertical(id="notes-modal"), Vertical(id="notes-modal-content"):
+            yield Label(
+                "[bold]📝 Add Note (Esc to cancel)[/bold]",
+                id="notes-modal-title",
+            )
+            yield Label("Title:")
+            yield Input(
+                placeholder="my-note (will be saved as my-note.md)",
+                id="note-title-input",
+            )
+            yield Label("Content:")
+            yield TextArea(id="note-content-input")
+            yield Static(
+                "[dim]Tab to switch fields · Ctrl+S to save · Esc to cancel[/dim]",
+                id="note-help",
+            )
 
     def on_mount(self) -> None:
         """Focus the title input."""
@@ -902,21 +929,20 @@ class EditFileScreen(ModalScreen):
         self._has_changes: bool = False
 
     def compose(self) -> ComposeResult:
-        with Vertical(id="edit-note-modal"):
-            with Vertical(id="edit-note-content"):
-                yield Label(
-                    f"[bold]✏️  Editing: {self._file_path.name}[/bold]",
-                    id="edit-note-title",
-                )
-                yield Static(
-                    f"[dim]{self._file_path}[/dim]",
-                    id="edit-note-path",
-                )
-                yield TextArea(id="edit-file-textarea")
-                yield Static(
-                    "[dim]Ctrl+S = save · Esc = close (unsaved changes will prompt)[/dim]",
-                    id="edit-note-help",
-                )
+        with Vertical(id="edit-note-modal"), Vertical(id="edit-note-content"):
+            yield Label(
+                f"[bold]✏️  Editing: {self._file_path.name}[/bold]",
+                id="edit-note-title",
+            )
+            yield Static(
+                f"[dim]{self._file_path}[/dim]",
+                id="edit-note-path",
+            )
+            yield TextArea(id="edit-file-textarea")
+            yield Static(
+                "[dim]Ctrl+S = save · Esc = close (unsaved changes will prompt)[/dim]",
+                id="edit-note-help",
+            )
 
     def on_mount(self) -> None:
         """Load file content into the editor."""
@@ -984,13 +1010,15 @@ class FilePreviewScreen(ModalScreen):
         self._is_text_file: bool = False
 
     def compose(self) -> ComposeResult:
-        with Vertical(id="file-preview-modal"):
-            with VerticalScroll(id="file-preview-content"):
-                yield Label(
-                    f"[bold]{self.file_path.name}[/bold]",
-                    id="file-preview-title",
-                )
-                yield Static(id="file-preview-body")
+        with (
+            Vertical(id="file-preview-modal"),
+            VerticalScroll(id="file-preview-content"),
+        ):
+            yield Label(
+                f"[bold]{self.file_path.name}[/bold]",
+                id="file-preview-title",
+            )
+            yield Static(id="file-preview-body")
 
     def on_mount(self) -> None:
         """Load file content."""
@@ -1005,8 +1033,11 @@ class FilePreviewScreen(ModalScreen):
         except UnicodeDecodeError:
             self._is_text_file = False
             body.update(
-                f"[dim]Binary file: {format_size(self.file_path.stat().st_size)}[/dim]\n\n"
-                f"[dim]d = delete · m = move · Esc = close[/dim]"
+                f"[dim]Binary file: "
+                f"{format_size(self.file_path.stat().st_size)}"
+                f"[/dim]\n\n"
+                f"[dim]d = delete · m = move"
+                f" · Esc = close[/dim]"
             )
         except OSError as e:
             body.update(f"[dim]Error reading file: {e}[/dim]")
@@ -1015,7 +1046,9 @@ class FilePreviewScreen(ModalScreen):
         if self._project:
             return self._project
         if hasattr(self.app, "project"):
-            return self.app.project
+            project = self.app.project  # type: ignore[attr-defined]
+            if isinstance(project, SantaiProject):
+                return project
         return None
 
     def action_edit_file(self) -> None:
@@ -1036,6 +1069,7 @@ class FilePreviewScreen(ModalScreen):
 
     def action_delete_file(self) -> None:
         """Delete this file with confirmation."""
+
         def do_delete():
             try:
                 self.file_path.unlink()
@@ -1062,6 +1096,7 @@ class FilePreviewScreen(ModalScreen):
         else:
             self.app.notify("Cannot determine project", severity="error")
 
+
 class ThemeSelectScreen(ModalScreen):
     """Theme selection modal with live switching."""
 
@@ -1075,11 +1110,13 @@ class ThemeSelectScreen(ModalScreen):
     ]
 
     def compose(self) -> ComposeResult:
-        theme = ThemeManager.get_current_theme()
-        with Vertical(id="theme-modal"):
-            with Vertical(id="theme-modal-content"):
-                yield Label("[bold]Theme Selector (press Esc to close)[/bold]", id="theme-modal-title")
-                yield Static(id="theme-options")
+        ThemeManager.get_current_theme()
+        with Vertical(id="theme-modal"), Vertical(id="theme-modal-content"):
+            yield Label(
+                "[bold]Theme Selector (press Esc to close)[/bold]",
+                id="theme-modal-title",
+            )
+            yield Static(id="theme-options")
 
     def on_mount(self) -> None:
         """Show theme options."""
@@ -1130,7 +1167,9 @@ class ThemeSelectScreen(ModalScreen):
             # Fallback: replace all non-default sources
             for key, css_source in self.app.stylesheet.source.items():
                 if not css_source.is_defaults:
-                    self.app.stylesheet.source[key] = css_source._replace(content=new_css)
+                    self.app.stylesheet.source[key] = css_source._replace(
+                        content=new_css
+                    )
                     break
 
         # Also update the class variable for consistency
@@ -1174,17 +1213,18 @@ class GraphSearchScreen(ModalScreen):
         self._all_nodes: list = []
 
     def compose(self) -> ComposeResult:
-        with Vertical(id="graph-search-modal"):
-            with Vertical(id="graph-search-content"):
-                yield Label(
-                    "[bold]🔍 Graph Search[/bold] [dim](↑↓ select, Enter=open, Ctrl+H=highlight in graph, Esc=close)[/dim]",
-                    id="graph-search-title",
-                )
-                yield Input(
-                    placeholder="Search files...",
-                    id="graph-search-input",
-                )
-                yield Static(id="graph-search-results")
+        with Vertical(id="graph-search-modal"), Vertical(id="graph-search-content"):
+            yield Label(
+                "[bold]🔍 Graph Search[/bold]"
+                " [dim](↑↓ select, Enter=open,"
+                " Ctrl+H=highlight in graph, Esc=close)[/dim]",
+                id="graph-search-title",
+            )
+            yield Input(
+                placeholder="Search files...",
+                id="graph-search-input",
+            )
+            yield Static(id="graph-search-results")
 
     def on_mount(self) -> None:
         """Focus the search input and load nodes."""
@@ -1233,6 +1273,7 @@ class GraphSearchScreen(ModalScreen):
         is_note = selected.directory == "notes" and file_path.suffix in (".md", ".txt")
         if is_note:
             from santai_cli.core.project import NoteEntry
+
             try:
                 content = file_path.read_text(encoding="utf-8")
                 title = file_path.stem.replace("-", " ").replace("_", " ").title()
@@ -1251,9 +1292,13 @@ class GraphSearchScreen(ModalScreen):
                     modified_at=datetime.fromtimestamp(stat.st_mtime),
                     size_bytes=stat.st_size,
                 )
-                self.app.push_screen(NoteDetailScreen(note_entry, project=self._project))
+                self.app.push_screen(
+                    NoteDetailScreen(note_entry, project=self._project)
+                )
             except (OSError, UnicodeDecodeError):
-                self.app.push_screen(FilePreviewScreen(file_path, project=self._project))
+                self.app.push_screen(
+                    FilePreviewScreen(file_path, project=self._project)
+                )
         else:
             self.app.push_screen(FilePreviewScreen(file_path, project=self._project))
 
@@ -1335,7 +1380,11 @@ class GraphSearchScreen(ModalScreen):
         total = len(self._all_nodes)
         showing = len(self._results)
         lines.append("")
-        lines.append(f"[dim]{showing} of {total} files · Enter=open · Ctrl+H=highlight · Esc=cancel[/dim]")
+        lines.append(
+            f"[dim]{showing} of {total} files"
+            " · Enter=open · Ctrl+H=highlight"
+            " · Esc=cancel[/dim]"
+        )
 
         results_widget.update("\n".join(lines))
 
@@ -1358,7 +1407,9 @@ class GraphFilterScreen(ModalScreen):
 
     DIRS = ["resources", "codebases", "history", "notes"]
 
-    def __init__(self, project: SantaiProject, current_filter: set[str] | None = None) -> None:
+    def __init__(
+        self, project: SantaiProject, current_filter: set[str] | None = None
+    ) -> None:
         super().__init__()
         self._project = project
         # If no filter is active, all dirs are selected
@@ -1369,13 +1420,12 @@ class GraphFilterScreen(ModalScreen):
         self._available_dirs: set[str] = set()
 
     def compose(self) -> ComposeResult:
-        with Vertical(id="theme-modal"):
-            with Vertical(id="theme-modal-content"):
-                yield Label(
-                    "[bold]🔍 Graph Filter[/bold]",
-                    id="theme-modal-title",
-                )
-                yield Static(id="filter-body")
+        with Vertical(id="theme-modal"), Vertical(id="theme-modal-content"):
+            yield Label(
+                "[bold]🔍 Graph Filter[/bold]",
+                id="theme-modal-title",
+            )
+            yield Static(id="filter-body")
 
     def on_mount(self) -> None:
         """Detect available directories and render."""
@@ -1434,7 +1484,9 @@ class GraphFilterScreen(ModalScreen):
         lines.append("")
 
         selected_count = sum(
-            self._dir_counts.get(d, 0) for d in self._selected if d in self._available_dirs
+            self._dir_counts.get(d, 0)
+            for d in self._selected
+            if d in self._available_dirs
         )
         total_count = sum(self._dir_counts.values())
         lines.append(f"  Showing: [bold]{selected_count}[/bold] of {total_count} files")
@@ -1610,7 +1662,10 @@ class SantaiApp(App):
         SantaiApp.CSS = new_css
         self.refresh_css()
         theme = ThemeManager.get_current_theme()
-        self.notify(f"{theme.display_name}: {palette.display_name} ({ThemeManager.get_palette_info()})")
+        self.notify(
+            f"{theme.display_name}: {palette.display_name}"
+            f" ({ThemeManager.get_palette_info()})"
+        )
 
     def action_graph_search(self) -> None:
         """Open graph search modal (only in fullscreen graph mode)."""
@@ -1667,13 +1722,16 @@ class SantaiApp(App):
         """Handle click on a note — open note detail modal."""
         self.push_screen(NoteDetailScreen(event.note, project=self.project))
 
-    def action_back(self) -> None:
+    async def action_back(self) -> None:
         """Go back — exit fullscreen graph or do nothing on dashboard."""
         if self._graph_fullscreen:
             self.action_toggle_graph()
 
     def on_data_table_row_selected(self, event: DataTable.RowSelected) -> None:
-        """Handle row selection in data tables — open appropriate screen for recent files."""
+        """Handle row selection in data tables.
+
+        Opens the appropriate screen for recent files.
+        """
         # Check if this is the recent files table
         table = event.data_table
         if table.id == "recent-table":
@@ -1686,7 +1744,10 @@ class SantaiApp(App):
                         self._open_file(file_info.path)
 
     def _open_file(self, file_path: Path) -> None:
-        """Open a file in the appropriate screen — NoteDetailScreen for notes, FilePreviewScreen for others."""
+        """Open a file in the appropriate screen.
+
+        Uses NoteDetailScreen for notes, FilePreviewScreen for others.
+        """
         # Check if this file is in the notes directory
         try:
             rel = file_path.relative_to(self.project.root)
@@ -1696,6 +1757,7 @@ class SantaiApp(App):
 
         if is_note and file_path.suffix in (".md", ".txt"):
             from santai_cli.core.project import NoteEntry
+
             try:
                 content = file_path.read_text(encoding="utf-8")
                 title = file_path.stem.replace("-", " ").replace("_", " ").title()

--- a/src/santai_cli/tui/graph_render.py
+++ b/src/santai_cli/tui/graph_render.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import math
 import random
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 
 
 @dataclass
@@ -131,7 +131,9 @@ def force_directed_layout(
             for i, nd in enumerate(comp):
                 angle = 2 * math.pi * i / max(len(comp), 1)
                 nd.x = comp_cx + sub_radius * math.cos(angle) + random.uniform(-1, 1)
-                nd.y = comp_cy + sub_radius * math.sin(angle) + random.uniform(-0.5, 0.5)
+                nd.y = (
+                    comp_cy + sub_radius * math.sin(angle) + random.uniform(-0.5, 0.5)
+                )
                 nd.vx = 0.0
                 nd.vy = 0.0
 
@@ -239,7 +241,9 @@ class BrailleCanvas:
         # Color per character cell
         self._colors: dict[tuple[int, int], str] = {}
         # Override characters (for node symbols)
-        self._char_override: dict[tuple[int, int], tuple[str, str]] = {}  # (char, color)
+        self._char_override: dict[
+            tuple[int, int], tuple[str, str]
+        ] = {}  # (char, color)
         # Labels
         self._labels: list[tuple[int, int, str, str]] = []  # (cx, cy, text, color)
 
@@ -251,13 +255,15 @@ class BrailleCanvas:
                 cx, cy = px // 2, py // 4
                 self._colors[(cx, cy)] = color
 
-    def draw_line(self, x0: float, y0: float, x1: float, y1: float, color: str = "dim #555555") -> None:
+    def draw_line(
+        self, x0: float, y0: float, x1: float, y1: float, color: str = "dim #555555"
+    ) -> None:
         """Draw a line using sub-pixels (Bresenham's algorithm on the pixel grid)."""
         # Convert graph coords to pixel coords
-        px0 = int(round(x0 * 2))
-        py0 = int(round(y0 * 4))
-        px1 = int(round(x1 * 2))
-        py1 = int(round(y1 * 4))
+        px0 = round(x0 * 2)
+        py0 = round(y0 * 4)
+        px1 = round(x1 * 2)
+        py1 = round(y1 * 4)
 
         dx = abs(px1 - px0)
         dy = abs(py1 - py0)
@@ -285,15 +291,15 @@ class BrailleCanvas:
 
     def set_node(self, x: float, y: float, char: str, color: str) -> None:
         """Place a node character at graph coordinates."""
-        cx = int(round(x))
-        cy = int(round(y))
+        cx = round(x)
+        cy = round(y)
         if 0 <= cx < self.char_width and 0 <= cy < self.char_height:
             self._char_override[(cx, cy)] = (char, color)
 
     def add_label(self, x: float, y: float, text: str, color: str) -> None:
         """Add a text label near a position."""
-        cx = int(round(x))
-        cy = int(round(y))
+        cx = round(x)
+        cy = round(y)
         self._labels.append((cx, cy, text, color))
 
     def render(self) -> list[list[tuple[str, str | None]]]:
@@ -389,7 +395,7 @@ def search_nodes(
         # Fuzzy: check if all query chars appear in order
         qi = 0
         penalty = 0.0
-        for ci, ch in enumerate(label_lower):
+        for _ci, ch in enumerate(label_lower):
             if qi < len(query_lower) and ch == query_lower[qi]:
                 qi += 1
             else:
@@ -492,7 +498,9 @@ def render_graph(
             color = "bold #ffffff"
         elif node.id in hl and hl:
             char = "◈"
-            color = "bold " + dir_colors.get(node.directory, dir_colors.get("other", "#6b6560"))
+            color = "bold " + dir_colors.get(
+                node.directory, dir_colors.get("other", "#6b6560")
+            )
         elif degree >= 5:
             char = "⬢"
         elif degree >= 3:
@@ -514,7 +522,7 @@ def render_graph(
             label = node.label
             max_len = 14 if fullscreen else 10
             if len(label) > max_len:
-                label = label[:max_len - 1] + "…"
+                label = label[: max_len - 1] + "…"
 
             if is_highlighted:
                 color = "bold " + color
@@ -539,7 +547,9 @@ def render_graph(
             if col != current_color:
                 if current_text:
                     if current_color:
-                        parts.append(f"[{current_color}]{current_text}[/{current_color}]")
+                        parts.append(
+                            f"[{current_color}]{current_text}[/{current_color}]"
+                        )
                     else:
                         parts.append(current_text)
                 current_color = col
@@ -570,7 +580,9 @@ def render_graph(
     )
 
 
-def build_graph_from_project_data(graph_data) -> tuple[list[GraphNode], list[GraphEdge]]:
+def build_graph_from_project_data(
+    graph_data,
+) -> tuple[list[GraphNode], list[GraphEdge]]:
     """Convert project graph data to our internal format."""
     nodes = []
     for node in graph_data.nodes:

--- a/src/santai_cli/tui/themes.py
+++ b/src/santai_cli/tui/themes.py
@@ -1,5 +1,6 @@
 """TUI Theme System with palettes and runtime switching support."""
 
+from collections.abc import Callable
 from dataclasses import dataclass, field
 
 
@@ -347,7 +348,7 @@ def light_theme() -> Theme:
     )
 
 
-AVAILABLE_THEMES: dict[str, callable] = {
+AVAILABLE_THEMES: dict[str, Callable[[], Theme]] = {
     "claude": claude_theme,
     "catppuccin": catppuccin_theme,
     "btop": btop_theme,
@@ -367,7 +368,9 @@ class ThemeManager:
         """Set the current theme by name, optionally with a palette index."""
         if name in AVAILABLE_THEMES:
             cls._current_theme = AVAILABLE_THEMES[name]()
-            cls._current_palette_idx = min(palette_idx, len(cls._current_theme.palettes) - 1)
+            cls._current_palette_idx = min(
+                palette_idx, len(cls._current_theme.palettes) - 1
+            )
             return True
         return False
 
@@ -599,7 +602,10 @@ def _generate_css(c: ThemeColors) -> str:
         height: auto;
     }}
 
-    StatsPanel > Label, NotesPanel > Label, GraphPanel > Label, RecentFilesPanel > Label {{
+    StatsPanel > Label,
+    NotesPanel > Label,
+    GraphPanel > Label,
+    RecentFilesPanel > Label {{
         color: {c.fg};
     }}
 
@@ -632,7 +638,10 @@ def _generate_css(c: ThemeColors) -> str:
 
     /* === Modal Screens (centered overlay) === */
 
-    NoteDetailScreen, AddNoteScreen, EditNoteScreen, EditFileScreen, FilePreviewScreen, ThemeSelectScreen, ConfirmScreen, MoveFileScreen, GraphSearchScreen, GraphFilterScreen {{
+    NoteDetailScreen, AddNoteScreen, EditNoteScreen,
+    EditFileScreen, FilePreviewScreen, ThemeSelectScreen,
+    ConfirmScreen, MoveFileScreen,
+    GraphSearchScreen, GraphFilterScreen {{
         align: center middle;
         background: {c.bg} 80%;
     }}

--- a/src/santai_cli/web/app.py
+++ b/src/santai_cli/web/app.py
@@ -43,7 +43,7 @@ class MoveRequest(BaseModel):
     target_folder: str
 
 
-def format_size(size_bytes: int) -> str:
+def format_size(size_bytes: int | float) -> str:
     """Format bytes as human-readable size."""
     for unit in ["B", "KB", "MB", "GB"]:
         if size_bytes < 1024:
@@ -176,7 +176,9 @@ def create_app(project: SantaiProject) -> FastAPI:
             "recent_files": [
                 {
                     "name": f.name,
-                    "path": str(f.path.relative_to(project.root)) if f.path.is_relative_to(project.root) else str(f.path),
+                    "path": str(f.path.relative_to(project.root))
+                    if f.path.is_relative_to(project.root)
+                    else str(f.path),
                     "size": f.size_bytes,
                     "modified": f.modified_at.isoformat(),
                     "modified_ago": format_time_ago(f.modified_at),
@@ -253,7 +255,10 @@ def create_app(project: SantaiProject) -> FastAPI:
         try:
             resolved.relative_to(root_dir)
         except ValueError:
-            raise HTTPException(status_code=403, detail="Access denied: path outside root directory")
+            raise HTTPException(
+                status_code=403,
+                detail="Access denied: path outside root directory",
+            ) from None
         return resolved
 
     def get_file_info(path: Path) -> dict[str, Any]:
@@ -279,7 +284,9 @@ def create_app(project: SantaiProject) -> FastAPI:
             raise HTTPException(status_code=400, detail="Path is not a directory")
 
         items = []
-        for item in sorted(target.iterdir(), key=lambda x: (not x.is_dir(), x.name.lower())):
+        for item in sorted(
+            target.iterdir(), key=lambda x: (not x.is_dir(), x.name.lower())
+        ):
             if item.name.startswith("."):
                 continue
             try:
@@ -291,16 +298,23 @@ def create_app(project: SantaiProject) -> FastAPI:
         if path:
             parts = Path(path).parts
             for i, part in enumerate(parts):
-                breadcrumbs.append({"name": part, "path": str(Path(*parts[:i+1]))})
+                breadcrumbs.append({"name": part, "path": str(Path(*parts[: i + 1]))})
 
         return {"path": path, "items": items, "breadcrumbs": breadcrumbs}
 
     @app.post("/api/files")
-    async def upload_file(file: UploadFile, path: str = Query(default="")) -> dict[str, str]:
+    async def upload_file(
+        file: UploadFile, path: str = Query(default="")
+    ) -> dict[str, str]:
         """Upload a file to the given path."""
         target_dir = safe_path(path)
         if not target_dir.is_dir():
-            raise HTTPException(status_code=400, detail="Target path is not a directory")
+            raise HTTPException(
+                status_code=400, detail="Target path is not a directory"
+            )
+
+        if not file.filename:
+            raise HTTPException(status_code=400, detail="No filename provided")
 
         file_path = target_dir / file.filename
         if file_path.exists():
@@ -311,7 +325,10 @@ def create_app(project: SantaiProject) -> FastAPI:
             content = await file.read()
             f.write(content)
 
-        return {"message": "File uploaded successfully", "path": str(file_path.relative_to(root_dir))}
+        return {
+            "message": "File uploaded successfully",
+            "path": str(file_path.relative_to(root_dir)),
+        }
 
     @app.delete("/api/files")
     async def delete_file(path: str = Query(...)) -> dict[str, str]:
@@ -339,17 +356,24 @@ def create_app(project: SantaiProject) -> FastAPI:
         new_path = target.parent / req.new_name
         safe_path(str(new_path.relative_to(root_dir)))
         if new_path.exists():
-            raise HTTPException(status_code=409, detail="A file with that name already exists")
+            raise HTTPException(
+                status_code=409, detail="A file with that name already exists"
+            )
 
         target.rename(new_path)
-        return {"message": "Renamed successfully", "path": str(new_path.relative_to(root_dir))}
+        return {
+            "message": "Renamed successfully",
+            "path": str(new_path.relative_to(root_dir)),
+        }
 
     @app.post("/api/files/mkdir")
     async def make_directory(req: MkdirRequest) -> dict[str, str]:
         """Create a new directory."""
         parent = safe_path(req.path)
         if not parent.is_dir():
-            raise HTTPException(status_code=400, detail="Parent path is not a directory")
+            raise HTTPException(
+                status_code=400, detail="Parent path is not a directory"
+            )
 
         new_dir = parent / req.name
         safe_path(str(new_dir.relative_to(root_dir)))
@@ -357,17 +381,30 @@ def create_app(project: SantaiProject) -> FastAPI:
             raise HTTPException(status_code=409, detail="Directory already exists")
 
         new_dir.mkdir()
-        return {"message": "Directory created", "path": str(new_dir.relative_to(root_dir))}
+        return {
+            "message": "Directory created",
+            "path": str(new_dir.relative_to(root_dir)),
+        }
 
     @app.post("/api/files/move")
     async def move_file(req: MoveRequest) -> dict[str, str]:
         """Move a file or directory to a new location."""
         # Protected top-level paths that cannot be moved
-        protected_paths = {'codebases', 'history', 'notes', 'resources',
-                          'AGENTS.md', 'CLAUDE.md', 'README.md', 'rumdl.toml'}
+        protected_paths = {
+            "codebases",
+            "history",
+            "notes",
+            "resources",
+            "AGENTS.md",
+            "CLAUDE.md",
+            "README.md",
+            "rumdl.toml",
+        }
 
         if req.source_path in protected_paths:
-            raise HTTPException(status_code=403, detail="Cannot move protected files or folders")
+            raise HTTPException(
+                status_code=403, detail="Cannot move protected files or folders"
+            )
 
         source = safe_path(req.source_path)
         target_dir = safe_path(req.target_folder)
@@ -379,21 +416,31 @@ def create_app(project: SantaiProject) -> FastAPI:
 
         new_path = target_dir / source.name
         if new_path.exists():
-            raise HTTPException(status_code=409, detail="A file with that name already exists in the target folder")
+            raise HTTPException(
+                status_code=409,
+                detail="A file with that name already exists in the target folder",
+            )
 
         # Prevent moving a folder into itself
         if source.is_dir():
             try:
                 target_dir.relative_to(source)
-                raise HTTPException(status_code=400, detail="Cannot move a folder into itself")
+                raise HTTPException(
+                    status_code=400, detail="Cannot move a folder into itself"
+                )
             except ValueError:
                 pass  # Not a subdirectory, OK to proceed
 
         shutil.move(str(source), str(new_path))
-        return {"message": "Moved successfully", "path": str(new_path.relative_to(root_dir))}
+        return {
+            "message": "Moved successfully",
+            "path": str(new_path.relative_to(root_dir)),
+        }
 
     @app.get("/api/files/tree")
-    async def api_files_tree(path: str = Query(default=""), depth: int = Query(default=10)) -> dict[str, Any]:
+    async def api_files_tree(
+        path: str = Query(default=""), depth: int = Query(default=10)
+    ) -> dict[str, Any]:
         """Get recursive tree structure of files and directories."""
         target = safe_path(path)
         if not target.exists():
@@ -406,7 +453,9 @@ def create_app(project: SantaiProject) -> FastAPI:
                 return []
             items = []
             try:
-                for item in sorted(dir_path.iterdir(), key=lambda x: (not x.is_dir(), x.name.lower())):
+                for item in sorted(
+                    dir_path.iterdir(), key=lambda x: (not x.is_dir(), x.name.lower())
+                ):
                     if item.name.startswith("."):
                         continue
                     node = {
@@ -435,7 +484,9 @@ def create_app(project: SantaiProject) -> FastAPI:
         if not target.exists():
             raise HTTPException(status_code=404, detail="File not found")
         if target.is_dir():
-            raise HTTPException(status_code=400, detail="Cannot read directory contents")
+            raise HTTPException(
+                status_code=400, detail="Cannot read directory contents"
+            )
 
         size = target.stat().st_size
         if size > 1024 * 1024:
@@ -448,17 +499,53 @@ def create_app(project: SantaiProject) -> FastAPI:
                 "message": "File too large to preview",
             }
 
-        text_extensions = {'.txt', '.md', '.py', '.js', '.ts', '.html', '.css', '.json', '.yaml', '.yml',
-                          '.xml', '.csv', '.log', '.sh', '.bash', '.zsh', '.env', '.gitignore', '.toml',
-                          '.ini', '.cfg', '.conf', '.jsx', '.tsx', '.vue', '.svelte', '.rs', '.go', '.rb',
-                          '.php', '.java', '.c', '.cpp', '.h', '.hpp', '.sql', '.graphql', '.prisma'}
+        text_extensions = {
+            ".txt",
+            ".md",
+            ".py",
+            ".js",
+            ".ts",
+            ".html",
+            ".css",
+            ".json",
+            ".yaml",
+            ".yml",
+            ".xml",
+            ".csv",
+            ".log",
+            ".sh",
+            ".bash",
+            ".zsh",
+            ".env",
+            ".gitignore",
+            ".toml",
+            ".ini",
+            ".cfg",
+            ".conf",
+            ".jsx",
+            ".tsx",
+            ".vue",
+            ".svelte",
+            ".rs",
+            ".go",
+            ".rb",
+            ".php",
+            ".java",
+            ".c",
+            ".cpp",
+            ".h",
+            ".hpp",
+            ".sql",
+            ".graphql",
+            ".prisma",
+        }
 
         ext = target.suffix.lower()
-        is_text = ext in text_extensions or ext == ''
+        is_text = ext in text_extensions or ext == ""
 
         if is_text:
             try:
-                content = target.read_text(encoding='utf-8')
+                content = target.read_text(encoding="utf-8")
                 return {
                     "name": target.name,
                     "path": path,
@@ -472,7 +559,16 @@ def create_app(project: SantaiProject) -> FastAPI:
             except UnicodeDecodeError:
                 is_text = False
 
-        image_extensions = {'.png', '.jpg', '.jpeg', '.gif', '.webp', '.svg', '.ico', '.bmp'}
+        image_extensions = {
+            ".png",
+            ".jpg",
+            ".jpeg",
+            ".gif",
+            ".webp",
+            ".svg",
+            ".ico",
+            ".bmp",
+        }
         if ext in image_extensions:
             return {
                 "name": target.name,
@@ -494,7 +590,9 @@ def create_app(project: SantaiProject) -> FastAPI:
         }
 
     @app.post("/api/files/save")
-    async def save_file_content(req: FileContentRequest, path: str = Query(...)) -> dict[str, str]:
+    async def save_file_content(
+        req: FileContentRequest, path: str = Query(...)
+    ) -> dict[str, str]:
         """Save file content."""
         target = safe_path(path)
         if not target.exists():
@@ -503,10 +601,12 @@ def create_app(project: SantaiProject) -> FastAPI:
             raise HTTPException(status_code=400, detail="Cannot write to a directory")
 
         try:
-            target.write_text(req.content, encoding='utf-8')
+            target.write_text(req.content, encoding="utf-8")
             return {"message": "File saved successfully"}
         except Exception as e:
-            raise HTTPException(status_code=500, detail=f"Failed to save file: {str(e)}")
+            raise HTTPException(
+                status_code=500, detail=f"Failed to save file: {e!s}"
+            ) from e
 
     @app.get("/api/files/download")
     async def download_file(path: str = Query(...)) -> FileResponse:

--- a/uv.lock
+++ b/uv.lock
@@ -34,6 +34,15 @@ wheels = [
 ]
 
 [[package]]
+name = "cfgv"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/b5/721b8799b04bf9afe054a3899c6cf4e880fcf8563cc71c15610242490a0c/cfgv-3.5.0.tar.gz", hash = "sha256:d5b1034354820651caa73ede66a6294d6e95c1b00acc5e9b098e917404669132", size = 7334, upload-time = "2025-11-19T20:55:51.612Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl", hash = "sha256:a8dc6b26ad22ff227d2634a65cb388215ce6cc96bbcc5cfde7641ae87e8dacc0", size = 7445, upload-time = "2025-11-19T20:55:50.744Z" },
+]
+
+[[package]]
 name = "click"
 version = "8.3.2"
 source = { registry = "https://pypi.org/simple" }
@@ -55,6 +64,15 @@ wheels = [
 ]
 
 [[package]]
+name = "distlib"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/8e/709914eb2b5749865801041647dc7f4e6d00b549cfe88b65ca192995f07c/distlib-0.4.0.tar.gz", hash = "sha256:feec40075be03a04501a973d81f633735b4b69f98b05450592310c0f401a4e0d", size = 614605, upload-time = "2025-07-17T16:52:00.465Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/6b/e0547afaf41bf2c42e52430072fa5658766e3d65bd4b03a563d1b6336f57/distlib-0.4.0-py2.py3-none-any.whl", hash = "sha256:9659f7d87e46584a30b5780e43ac7a2143098441670ff0a49d5f9034c54a6c16", size = 469047, upload-time = "2025-07-17T16:51:58.613Z" },
+]
+
+[[package]]
 name = "fastapi"
 version = "0.135.3"
 source = { registry = "https://pypi.org/simple" }
@@ -68,6 +86,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f7/e6/7adb4c5fa231e82c35b8f5741a9f2d055f520c29af5546fd70d3e8e1cd2e/fastapi-0.135.3.tar.gz", hash = "sha256:bd6d7caf1a2bdd8d676843cdcd2287729572a1ef524fc4d65c17ae002a1be654", size = 396524, upload-time = "2026-04-01T16:23:58.188Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/84/a4/5caa2de7f917a04ada20018eccf60d6cc6145b0199d55ca3711b0fc08312/fastapi-0.135.3-py3-none-any.whl", hash = "sha256:9b0f590c813acd13d0ab43dd8494138eb58e484bfac405db1f3187cfc5810d98", size = 117734, upload-time = "2026-04-01T16:23:59.328Z" },
+]
+
+[[package]]
+name = "filelock"
+version = "3.28.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/17/6e8890271880903e3538660a21d63a6c1fea969ac71d0d6b608b78727fa9/filelock-3.28.0.tar.gz", hash = "sha256:4ed1010aae813c4ee8d9c660e4792475ee60c4a0ba76073ceaf862bd317e3ca6", size = 56474, upload-time = "2026-04-14T22:54:33.625Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/21/2f728888c45033d34a417bfcd248ea2564c9e08ab1bfd301377cf05d5586/filelock-3.28.0-py3-none-any.whl", hash = "sha256:de9af6712788e7171df1b28b15eba2446c69721433fa427a9bee07b17820a9db", size = 39189, upload-time = "2026-04-14T22:54:32.037Z" },
 ]
 
 [[package]]
@@ -106,6 +133,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/4d/31/14df99e1c43bd132eec921c2e7e11cda7852f65619bc0fc5bdc2d0cb126c/httptools-0.7.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:f084813239e1eb403ddacd06a30de3d3e09a9b76e7894dcda2b22f8a726e9c60", size = 452631, upload-time = "2025-10-10T03:54:58.219Z" },
     { url = "https://files.pythonhosted.org/packages/22/d2/b7e131f7be8d854d48cb6d048113c30f9a46dca0c9a8b08fcb3fcd588cdc/httptools-0.7.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7347714368fb2b335e9063bc2b96f2f87a9ceffcd9758ac295f8bbcd3ffbc0ca", size = 452910, upload-time = "2025-10-10T03:54:59.366Z" },
     { url = "https://files.pythonhosted.org/packages/53/cf/878f3b91e4e6e011eff6d1fa9ca39f7eb17d19c9d7971b04873734112f30/httptools-0.7.1-cp314-cp314-win_amd64.whl", hash = "sha256:cfabda2a5bb85aa2a904ce06d974a3f30fb36cc63d7feaddec05d2050acede96", size = 88205, upload-time = "2025-10-10T03:55:00.389Z" },
+]
+
+[[package]]
+name = "identify"
+version = "2.6.18"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/c4/7fb4db12296cdb11893d61c92048fe617ee853f8523b9b296ac03b43757e/identify-2.6.18.tar.gz", hash = "sha256:873ac56a5e3fd63e7438a7ecbc4d91aca692eb3fefa4534db2b7913f3fc352fd", size = 99580, upload-time = "2026-03-15T18:39:50.319Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/33/92ef41c6fad0233e41d3d84ba8e8ad18d1780f1e5d99b3c683e6d7f98b63/identify-2.6.18-py2.py3-none-any.whl", hash = "sha256:8db9d3c8ea9079db92cafb0ebf97abdc09d52e97f4dcf773a2e694048b7cd737", size = 99394, upload-time = "2026-03-15T18:39:48.915Z" },
 ]
 
 [[package]]
@@ -243,12 +279,37 @@ wheels = [
 ]
 
 [[package]]
+name = "nodeenv"
+version = "1.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
+]
+
+[[package]]
 name = "platformdirs"
 version = "4.9.6"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9f/4a/0883b8e3802965322523f0b200ecf33d31f10991d0401162f4b23c698b42/platformdirs-4.9.6.tar.gz", hash = "sha256:3bfa75b0ad0db84096ae777218481852c0ebc6c727b3168c1b9e0118e458cf0a", size = 29400, upload-time = "2026-04-09T00:04:10.812Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/75/a6/a0a304dc33b49145b21f4808d763822111e67d1c3a32b524a1baf947b6e1/platformdirs-4.9.6-py3-none-any.whl", hash = "sha256:e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917", size = 21348, upload-time = "2026-04-09T00:04:09.463Z" },
+]
+
+[[package]]
+name = "pre-commit"
+version = "4.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cfgv" },
+    { name = "identify" },
+    { name = "nodeenv" },
+    { name = "pyyaml" },
+    { name = "virtualenv" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/40/f1/6d86a29246dfd2e9b6237f0b5823717f60cad94d47ddc26afa916d21f525/pre_commit-4.5.1.tar.gz", hash = "sha256:eb545fcff725875197837263e977ea257a402056661f09dae08e4b149b030a61", size = 198232, upload-time = "2025-12-16T21:14:33.552Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/19/fd3ef348460c80af7bb4669ea7926651d1f95c23ff2df18b9d24bab4f3fa/pre_commit-4.5.1-py2.py3-none-any.whl", hash = "sha256:3b3afd891e97337708c1674210f8eba659b52a38ea5f822ff142d10786221f77", size = 226437, upload-time = "2025-12-16T21:14:32.409Z" },
 ]
 
 [[package]]
@@ -347,12 +408,34 @@ wheels = [
 ]
 
 [[package]]
+name = "python-discovery"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "platformdirs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/de/ef/3bae0e537cfe91e8431efcba4434463d2c5a65f5a89edd47c6cf2f03c55f/python_discovery-1.2.2.tar.gz", hash = "sha256:876e9c57139eb757cb5878cbdd9ae5379e5d96266c99ef731119e04fffe533bb", size = 58872, upload-time = "2026-04-07T17:28:49.249Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d8/db/795879cc3ddfe338599bddea6388cc5100b088db0a4caf6e6c1af1c27e04/python_discovery-1.2.2-py3-none-any.whl", hash = "sha256:e1ae95d9af875e78f15e19aed0c6137ab1bb49c200f21f5061786490c9585c7a", size = 31894, upload-time = "2026-04-07T17:28:48.09Z" },
+]
+
+[[package]]
 name = "python-dotenv"
 version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.26"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/71/b145a380824a960ebd60e1014256dbb7d2253f2316ff2d73dfd8928ec2c3/python_multipart-0.0.26.tar.gz", hash = "sha256:08fadc45918cd615e26846437f50c5d6d23304da32c341f289a617127b081f17", size = 43501, upload-time = "2026-04-10T14:09:59.473Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/22/f1925cdda983ab66fc8ec6ec8014b959262747e58bdca26a4e3d1da29d56/python_multipart-0.0.26-py3-none-any.whl", hash = "sha256:c0b169f8c4484c13b0dcf2ef0ec3a4adb255c4b7d18d8e420477d2b1dd03f185", size = 28847, upload-time = "2026-04-10T14:09:58.131Z" },
 ]
 
 [[package]]
@@ -415,26 +498,67 @@ wheels = [
 ]
 
 [[package]]
+name = "ruff"
+version = "0.15.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/51/df/f8629c19c5318601d3121e230f74cbee7a3732339c52b21daa2b82ef9c7d/ruff-0.15.6.tar.gz", hash = "sha256:8394c7bb153a4e3811a4ecdacd4a8e6a4fa8097028119160dffecdcdf9b56ae4", size = 4597916, upload-time = "2026-03-12T23:05:47.51Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/2f/4e03a7e5ce99b517e98d3b4951f411de2b0fa8348d39cf446671adcce9a2/ruff-0.15.6-py3-none-linux_armv6l.whl", hash = "sha256:7c98c3b16407b2cf3d0f2b80c80187384bc92c6774d85fefa913ecd941256fff", size = 10508953, upload-time = "2026-03-12T23:05:17.246Z" },
+    { url = "https://files.pythonhosted.org/packages/70/60/55bcdc3e9f80bcf39edf0cd272da6fa511a3d94d5a0dd9e0adf76ceebdb4/ruff-0.15.6-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ee7dcfaad8b282a284df4aa6ddc2741b3f4a18b0555d626805555a820ea181c3", size = 10942257, upload-time = "2026-03-12T23:05:23.076Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/f9/005c29bd1726c0f492bfa215e95154cf480574140cb5f867c797c18c790b/ruff-0.15.6-py3-none-macosx_11_0_arm64.whl", hash = "sha256:3bd9967851a25f038fc8b9ae88a7fbd1b609f30349231dffaa37b6804923c4bb", size = 10322683, upload-time = "2026-03-12T23:05:33.738Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/74/2f861f5fd7cbb2146bddb5501450300ce41562da36d21868c69b7a828169/ruff-0.15.6-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:13f4594b04e42cd24a41da653886b04d2ff87adbf57497ed4f728b0e8a4866f8", size = 10660986, upload-time = "2026-03-12T23:05:53.245Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/a1/309f2364a424eccb763cdafc49df843c282609f47fe53aa83f38272389e0/ruff-0.15.6-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e2ed8aea2f3fe57886d3f00ea5b8aae5bf68d5e195f487f037a955ff9fbaac9e", size = 10332177, upload-time = "2026-03-12T23:05:56.145Z" },
+    { url = "https://files.pythonhosted.org/packages/30/41/7ebf1d32658b4bab20f8ac80972fb19cd4e2c6b78552be263a680edc55ac/ruff-0.15.6-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:70789d3e7830b848b548aae96766431c0dc01a6c78c13381f423bf7076c66d15", size = 11170783, upload-time = "2026-03-12T23:06:01.742Z" },
+    { url = "https://files.pythonhosted.org/packages/76/be/6d488f6adca047df82cd62c304638bcb00821c36bd4881cfca221561fdfc/ruff-0.15.6-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:542aaf1de3154cea088ced5a819ce872611256ffe2498e750bbae5247a8114e9", size = 12044201, upload-time = "2026-03-12T23:05:28.697Z" },
+    { url = "https://files.pythonhosted.org/packages/71/68/e6f125df4af7e6d0b498f8d373274794bc5156b324e8ab4bf5c1b4fc0ec7/ruff-0.15.6-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1c22e6f02c16cfac3888aa636e9eba857254d15bbacc9906c9689fdecb1953ab", size = 11421561, upload-time = "2026-03-12T23:05:31.236Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/9f/f85ef5fd01a52e0b472b26dc1b4bd228b8f6f0435975442ffa4741278703/ruff-0.15.6-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:98893c4c0aadc8e448cfa315bd0cc343a5323d740fe5f28ef8a3f9e21b381f7e", size = 11310928, upload-time = "2026-03-12T23:05:45.288Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/26/b75f8c421f5654304b89471ed384ae8c7f42b4dff58fa6ce1626d7f2b59a/ruff-0.15.6-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:70d263770d234912374493e8cc1e7385c5d49376e41dfa51c5c3453169dc581c", size = 11235186, upload-time = "2026-03-12T23:05:50.677Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/d4/d5a6d065962ff7a68a86c9b4f5500f7d101a0792078de636526c0edd40da/ruff-0.15.6-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:55a1ad63c5a6e54b1f21b7514dfadc0c7fb40093fa22e95143cf3f64ebdcd512", size = 10635231, upload-time = "2026-03-12T23:05:37.044Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/56/7c3acf3d50910375349016cf33de24be021532042afbed87942858992491/ruff-0.15.6-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:8dc473ba093c5ec238bb1e7429ee676dca24643c471e11fbaa8a857925b061c0", size = 10340357, upload-time = "2026-03-12T23:06:04.748Z" },
+    { url = "https://files.pythonhosted.org/packages/06/54/6faa39e9c1033ff6a3b6e76b5df536931cd30caf64988e112bbf91ef5ce5/ruff-0.15.6-py3-none-musllinux_1_2_i686.whl", hash = "sha256:85b042377c2a5561131767974617006f99f7e13c63c111b998f29fc1e58a4cfb", size = 10860583, upload-time = "2026-03-12T23:05:58.978Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1e/509a201b843b4dfb0b32acdedf68d951d3377988cae43949ba4c4133a96a/ruff-0.15.6-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:cef49e30bc5a86a6a92098a7fbf6e467a234d90b63305d6f3ec01225a9d092e0", size = 11410976, upload-time = "2026-03-12T23:05:39.955Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/25/3fc9114abf979a41673ce877c08016f8e660ad6cf508c3957f537d2e9fa9/ruff-0.15.6-py3-none-win32.whl", hash = "sha256:bbf67d39832404812a2d23020dda68fee7f18ce15654e96fb1d3ad21a5fe436c", size = 10616872, upload-time = "2026-03-12T23:05:42.451Z" },
+    { url = "https://files.pythonhosted.org/packages/89/7a/09ece68445ceac348df06e08bf75db72d0e8427765b96c9c0ffabc1be1d9/ruff-0.15.6-py3-none-win_amd64.whl", hash = "sha256:aee25bc84c2f1007ecb5037dff75cef00414fdf17c23f07dc13e577883dca406", size = 11787271, upload-time = "2026-03-12T23:05:20.168Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/d0/578c47dd68152ddddddf31cd7fc67dc30b7cdf639a86275fda821b0d9d98/ruff-0.15.6-py3-none-win_arm64.whl", hash = "sha256:c34de3dd0b0ba203be50ae70f5910b17188556630e2178fd7d79fc030eb0d837", size = 11060497, upload-time = "2026-03-12T23:05:25.968Z" },
+]
+
+[[package]]
 name = "santai-cli"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },
     { name = "jinja2" },
+    { name = "python-multipart" },
     { name = "rich" },
     { name = "textual" },
     { name = "typer" },
     { name = "uvicorn", extra = ["standard"] },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pre-commit" },
+    { name = "ruff" },
+    { name = "ty" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "fastapi", specifier = ">=0.110.0" },
     { name = "jinja2", specifier = ">=3.1.0" },
+    { name = "python-multipart", specifier = ">=0.0.9" },
     { name = "rich", specifier = ">=13.0.0" },
     { name = "textual", specifier = ">=0.50.0" },
     { name = "typer", specifier = ">=0.12.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.27.0" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pre-commit", specifier = ">=3.5.0" },
+    { name = "ruff", specifier = "==0.15.6" },
+    { name = "ty", specifier = ">=0.0.31" },
 ]
 
 [[package]]
@@ -474,6 +598,30 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/cf/2f/d44f0f12b3ddb1f0b88f7775652e99c6b5a43fd733badf4ce064bdbfef4a/textual-8.2.3.tar.gz", hash = "sha256:beea7b86b03b03558a2224f0cc35252e60ef8b0c4353b117b2f40972902d976a", size = 1848738, upload-time = "2026-04-05T09:12:45.338Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0e/28/a81d6ce9f4804818bd1231a9a6e4d56ea84ebbe8385c49591444f0234fa2/textual-8.2.3-py3-none-any.whl", hash = "sha256:5008ac581bebf1f6fa0520404261844a231e5715fdbddd10ca73916a3af48ca2", size = 724231, upload-time = "2026-04-05T09:12:48.747Z" },
+]
+
+[[package]]
+name = "ty"
+version = "0.0.31"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/31/cc/5ea5d3a72216c8c2bf77d83066dd4f3553532d0aacc03d4a8397dd9845e1/ty-0.0.31.tar.gz", hash = "sha256:4a4094292d9671caf3b510c7edf36991acd9c962bb5d97205374ffed9f541c45", size = 5516619, upload-time = "2026-04-15T15:47:59.87Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/10/ea805cbbd75d5d50792551a2b383de8521eeab0c44f38c73e12819ced65e/ty-0.0.31-py3-none-linux_armv6l.whl", hash = "sha256:761651dc17ad7bc0abfc1b04b3f0e84df263ed435d34f29760b3da739ab02d35", size = 10834749, upload-time = "2026-04-15T15:48:14.877Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/4c/fabf951850401d24d36b21bced088a366c6827e1c37dab4523afff84c4b2/ty-0.0.31-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:c529922395a07231c27488f0290651e05d27d149f7e0aa807678f1f7e9c58a5e", size = 10626012, upload-time = "2026-04-15T15:48:22.554Z" },
+    { url = "https://files.pythonhosted.org/packages/04/b0/4a5aff88d2544f19514a59c8f693d63144aa7307fe2ee5df608333ab5460/ty-0.0.31-py3-none-macosx_11_0_arm64.whl", hash = "sha256:5f345df2b87d747859e72c2cbc9be607ea1bbc8bc93dd32fa3d03ea091cb4fee", size = 10075790, upload-time = "2026-04-15T15:47:46.959Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/73/9d4dcad12cd4e85274014f2c0510ef93f590b2a1e5148de3a9f276098dad/ty-0.0.31-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d4b207eddcfbafd376132689d3435b14efcb531289cb59cd961c6a611133bd54", size = 10590286, upload-time = "2026-04-15T15:48:06.222Z" },
+    { url = "https://files.pythonhosted.org/packages/47/45/fe40adde18692359ded174ae7ddbfac056e876eb0f43b65be74fde7f6072/ty-0.0.31-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:663778b220f357067488ce68bfc52335ccbd161549776f70dcbde6bbde82f77a", size = 10623824, upload-time = "2026-04-15T15:48:12.965Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/e8/0ffa2e09b548e6daa9ebc368d68b767dc2405ca4cbeadb7ede0e2cb21059/ty-0.0.31-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3506cfe87dfade0fb2960dd4fffd4fd8089003587b3445c0a1a295c9d83764fb", size = 11156864, upload-time = "2026-04-15T15:48:08.473Z" },
+    { url = "https://files.pythonhosted.org/packages/08/e9/fd44c2075115d569593ee9473d7e2a38b750fd7e783421c95eb528c15df5/ty-0.0.31-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8b3f3d8492f08e81916026354c1d1599e9ddfa1241804141a74d5662fc710085", size = 11696401, upload-time = "2026-04-15T15:48:17.355Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/50/35aad8eadf964d23e2a4faa5b38a206aa85c78833c8ce335dddd2c34ba63/ty-0.0.31-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a97de32ee6a619393a4c495e056a1c547de7877510f3152e61345c71d774d2d0", size = 11374903, upload-time = "2026-04-15T15:47:55.893Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/37/01eccd25d23f5aaa7f7ff1a87b5b215469f6b202cf689a1812b71c1e7f6b/ty-0.0.31-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c906354ce441e342646582bc9b8f48a676f79f3d061e25de15ff870e015ca14e", size = 11206624, upload-time = "2026-04-15T15:47:51.778Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/70/baad2914cb097453f127a221f8addb2b41926098059cd773c75e6a662fc4/ty-0.0.31-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:275bb7c82afcbf89fe2dbef1b2692f2bc98451f1ee2c8eb809ddd91317822388", size = 10575089, upload-time = "2026-04-15T15:47:49.448Z" },
+    { url = "https://files.pythonhosted.org/packages/83/12/bae3a7bba2e785eb72ce00f9da70eedcb8c5e8299efecbd16e6e436abd82/ty-0.0.31-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:405da247027c6efd1e264886b6ac4a86ab3a4f09200b02e33630efe85f119e53", size = 10642315, upload-time = "2026-04-15T15:48:19.661Z" },
+    { url = "https://files.pythonhosted.org/packages/93/9e/cad04d5d839bc60355cea98c7e09d724ea65f47184def0fae8b90dc54591/ty-0.0.31-py3-none-musllinux_1_2_i686.whl", hash = "sha256:54d9835608eed196853d6643f645c50ce83bcc7fe546cdb3e210c1bcf7c58c09", size = 10834473, upload-time = "2026-04-15T15:48:02.091Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/ba/84112d280182d37690d3d2b4018b2667e42bc281585e607015635310016a/ty-0.0.31-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:5ee11be9b07e8c0c6b455ff075a0abe4f194de9476f57624db98eec9df618355", size = 11315785, upload-time = "2026-04-15T15:48:10.754Z" },
+    { url = "https://files.pythonhosted.org/packages/50/9f/ac42dc223d7e0950e97a1854567a8b3e7fe09ad7375adbf91bfb43290482/ty-0.0.31-py3-none-win32.whl", hash = "sha256:7286587aacf3eef0956062d6492b893b02f82b0f22c5e230008e13ff0d216a8b", size = 10187657, upload-time = "2026-04-15T15:48:04.264Z" },
+    { url = "https://files.pythonhosted.org/packages/75/3e/57ba7ea7ecb2f4751644ba91756e2be70e33ef5952c0c41a256a0e4c2437/ty-0.0.31-py3-none-win_amd64.whl", hash = "sha256:81134e25d2a2562ab372f24de8f9bd05034d27d30377a5d7540f259791c6234c", size = 11205258, upload-time = "2026-04-15T15:47:53.759Z" },
+    { url = "https://files.pythonhosted.org/packages/88/39/bca669095ccf0a400af941fdf741578d4c2d6719f1b7f10e6dbec10aa862/ty-0.0.31-py3-none-win_arm64.whl", hash = "sha256:e9cb15fad26545c6a608f40f227af3a5513cb376998ca6feddd47ca7d93ffafa", size = 10590392, upload-time = "2026-04-15T15:47:57.968Z" },
 ]
 
 [[package]]
@@ -575,6 +723,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/37/945b4ca0ac27e3dc4952642d4c900edd030b3da6c9634875af6e13ae80e5/uvloop-0.22.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b91328c72635f6f9e0282e4a57da7470c7350ab1c9f48546c0f2866205349d21", size = 4467065, upload-time = "2025-10-16T22:16:58.206Z" },
     { url = "https://files.pythonhosted.org/packages/97/cc/48d232f33d60e2e2e0b42f4e73455b146b76ebe216487e862700457fbf3c/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:daf620c2995d193449393d6c62131b3fbd40a63bf7b307a1527856ace637fe88", size = 4328384, upload-time = "2025-10-16T22:16:59.36Z" },
     { url = "https://files.pythonhosted.org/packages/e4/16/c1fd27e9549f3c4baf1dc9c20c456cd2f822dbf8de9f463824b0c0357e06/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6cde23eeda1a25c75b2e07d39970f3374105d5eafbaab2a4482be82f272d5a5e", size = 4296730, upload-time = "2025-10-16T22:17:00.744Z" },
+]
+
+[[package]]
+name = "virtualenv"
+version = "21.2.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "distlib" },
+    { name = "filelock" },
+    { name = "platformdirs" },
+    { name = "python-discovery" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0c/98/3a7e644e19cb26133488caff231be390579860bbbb3da35913c49a1d0a46/virtualenv-21.2.4.tar.gz", hash = "sha256:b294ef68192638004d72524ce7ef303e9d0cf5a44c95ce2e54a7500a6381cada", size = 5850742, upload-time = "2026-04-14T22:15:31.438Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/8d/edd0bd910ff803c308ee9a6b7778621af0d10252219ad9f19ef4d4982a61/virtualenv-21.2.4-py3-none-any.whl", hash = "sha256:29d21e941795206138d0f22f4e45ff7050e5da6c6472299fb7103318763861ac", size = 5831232, upload-time = "2026-04-14T22:15:29.342Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds code quality tooling to the project, resolving #10.

- **Ruff v0.15.6** configured for linting and formatting with sensible rule selection (`E`, `W`, `F`, `I`, `UP`, `B`, `SIM`, `RUF`)
- **ty** added as a recommended type checker (not enforced)
- **Pre-commit hook** runs `ruff format` on every commit (formatting only — linting and type checking are manual)
- All existing lint errors and type errors fixed across the codebase

### Enforcement tiers

| Tool | Pre-commit hook? | Usage |
|------|-----------------|-------|
| `ruff format` | Yes — auto-formats on every commit | Automatic |
| `ruff check` | No | Recommended: `ruff check --fix .` |
| `ty check` | No | Recommended: `ty check src/` |

### Key fixes applied
- Added missing `NoteEntry` import (was causing `F821` undefined name errors)
- Fixed `callable` → `Callable` type annotations
- Fixed Liskov Substitution violations (`filter_paths`, `action_back` signatures)
- Added proper `raise ... from` in exception handlers
- Fixed `int | float` type narrowing in `format_size()`
- Added null guard for `UploadFile.filename`
- Resolved all E501 line-length violations
- Applied `ruff format` across all source files

### New files
- `.pre-commit-config.yaml` — ruff-format hook
- `AGENTS.md` — development workflow documentation

Supersedes #11.