### PR TITLE
feat: add AI chatbot with Anthropic and OpenAI streaming support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# Santai CLI - AI Chatbot Configuration
+# Copy this file to .env and fill in your API keys.
+# At least one provider key is required for `santai chat` to work.
+
+# --- Anthropic ---
+ANTHROPIC_API_KEY=your-anthropic-api-key-here
+ANTHROPIC_MODEL=claude-sonnet-4-20250514
+
+# --- OpenAI ---
+OPENAI_API_KEY=your-openai-api-key-here
+OPENAI_MODEL=gpt-4o

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ wheels/
 
 # Claude Code local settings
 .claude/
+
+# Environment secrets
+.env

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,10 +29,14 @@ ty check src/        # Run type checker
 ```
 src/santai_cli/
 ├── cli.py           # Typer app, command registration
-├── commands/        # CLI commands (init, copy, history, ui, web)
-├── core/project.py  # Project detection, data models, file graph
+├── agents/          # Markdown agent profiles for AI chat system prompts
+├── commands/        # CLI commands (init, copy, chat, history, ui, web)
+├── core/
+│   ├── project.py   # Project detection, data models, file graph
+│   ├── config.py    # Environment/config loading, API key validation
+│   └── chat.py      # Shared chat engine (streaming, provider abstraction)
 ├── tui/             # Textual TUI dashboard
-│   ├── app.py       # Main TUI application
+│   ├── app.py       # Main TUI application (includes ChatScreen modal)
 │   ├── graph_render.py  # Force-directed graph with Braille rendering
 │   └── themes.py    # Multi-theme system
 └── web/             # FastAPI web dashboard + Jinja2 templates
@@ -58,3 +62,32 @@ Entry point: `santai_cli.cli:app` (Typer application)
 ## Testing
 
 No test suite currently configured.
+
+## AI Chat Configuration
+
+The `santai chat` command (and the chat panels in TUI/Web) require API keys configured in a `.env` file at the project root:
+
+```bash
+# At least one provider key is required
+ANTHROPIC_API_KEY=sk-ant-...
+OPENAI_API_KEY=sk-...
+
+# Optional: override default models
+ANTHROPIC_MODEL=claude-sonnet-4-20250514
+OPENAI_MODEL=gpt-4o
+```
+
+See `.env.example` for the full template. The `.env` file is gitignored.
+
+### Chat Architecture
+
+- **`core/config.py`** — Loads `.env`, validates API keys, exposes available models/providers
+- **`core/chat.py`** — Provider-agnostic chat engine with `ChatSession` (message history) and async streaming via `stream_response()`
+- **`commands/chat.py`** — CLI REPL with Rich Live streaming, `/agent`, `/model`, `/clear` commands
+- **`tui/app.py` (`ChatScreen`)** — Modal chat screen in TUI, opened with `x` key
+- **`web/app.py`** — SSE streaming endpoints: `POST /api/chat`, `GET /api/chat/models`, `GET /api/chat/agents`
+- **`web/templates/index.html`** — Chat panel in web dashboard with streaming display
+
+### Agent Profiles
+
+The `agents/` directory contains markdown files that serve as system prompts. Each file has YAML frontmatter with a `description:` field. Use `santai chat --agent code-review` to load an agent, or select one interactively in the TUI/Web chat panels.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,9 @@ dependencies = [
     "jinja2>=3.1.0",
     "rich>=13.0.0",
     "python-multipart>=0.0.9",
+    "anthropic>=0.42.0",
+    "openai>=1.60.0",
+    "python-dotenv>=1.0.0",
 ]
 
 [dependency-groups]

--- a/src/santai_cli/cli.py
+++ b/src/santai_cli/cli.py
@@ -2,7 +2,7 @@
 
 import typer
 
-from santai_cli.commands import copy, history, init, ui, web
+from santai_cli.commands import chat, copy, history, init, ui, web
 
 app = typer.Typer(
     name="santai",
@@ -12,6 +12,7 @@ app = typer.Typer(
 
 app.command(name="init")(init.init)
 app.command(name="copy")(copy.copy)
+app.command(name="chat")(chat.chat)
 app.command(name="history")(history.history)
 app.command(name="ui")(ui.ui)
 app.command(name="web")(web.web)

--- a/src/santai_cli/commands/chat.py
+++ b/src/santai_cli/commands/chat.py
@@ -1,0 +1,400 @@
+"""Chat command for Santai CLI.
+
+Provides an interactive REPL-style chat with AI models (Anthropic, OpenAI)
+using Rich for terminal formatting and streaming response display.
+"""
+
+import asyncio
+from dataclasses import dataclass
+from typing import Annotated
+
+import typer
+from rich.console import Console
+from rich.live import Live
+from rich.markdown import Markdown
+from rich.panel import Panel
+from rich.prompt import Prompt
+from rich.text import Text
+
+from santai_cli.core.chat import ChatSession, stream_response
+from santai_cli.core.config import (
+    ChatConfig,
+    get_agent_profiles,
+    load_agent_prompt,
+    load_config,
+)
+from santai_cli.core.project import get_project
+
+console = Console()
+
+
+@dataclass
+class _ChatState:
+    """Mutable state for the chat REPL loop."""
+
+    session: ChatSession
+    config: ChatConfig
+    provider: str
+    model: str
+    agent: str | None
+
+
+def chat(
+    agent: Annotated[
+        str | None,
+        typer.Option(
+            "--agent",
+            "-a",
+            help="Agent profile name to use as system prompt (e.g. 'code-review').",
+        ),
+    ] = None,
+    model: Annotated[
+        str | None,
+        typer.Option(
+            "--model",
+            "-m",
+            help=(
+                "Model to use (e.g. 'claude-sonnet-4-20250514', 'gpt-4o')."
+                " Skips interactive selection."
+            ),
+        ),
+    ] = None,
+) -> None:
+    """Start an interactive AI chat session.
+
+    Chat with AI models from your terminal. Requires API keys to be
+    configured in a .env file at your project root (see .env.example).
+
+    Use --agent to load an agent profile as the system prompt.
+
+    REPL commands:
+      /quit     Exit the chat
+      /clear    Clear conversation history
+      /agent    List or switch agent profiles
+      /model    Re-select the model
+      /help     Show available commands
+    """
+    project = get_project()
+    project_root = project.root if project else None
+
+    # Load configuration
+    config = load_config(project_root)
+
+    if not config.has_any_provider:
+        console.print(
+            Panel(
+                "[bold red]No API keys configured.[/]\n\n"
+                "Create a [cyan].env[/] file in your project root"
+                " with at least one key:\n\n"
+                "  [dim]ANTHROPIC_API_KEY=sk-ant-...[/]\n"
+                "  [dim]OPENAI_API_KEY=sk-...[/]\n\n"
+                "See [cyan].env.example[/] for the full template.",
+                title="Configuration Required",
+                border_style="red",
+            )
+        )
+        raise typer.Exit(1)
+
+    # Load agent system prompt if specified
+    system_prompt = None
+    active_agent = agent
+    if active_agent:
+        system_prompt = load_agent_prompt(active_agent)
+        if system_prompt is None:
+            console.print(f"[red]Agent profile '{active_agent}' not found.[/]")
+            _print_available_agents()
+            raise typer.Exit(1)
+
+    # Select model (interactive or from flag)
+    provider, selected_model = _select_model(config, model)
+    if provider is None or selected_model is None:
+        raise typer.Exit(1)
+
+    # Initialize session
+    session = ChatSession(system_prompt=system_prompt)
+
+    # Print welcome
+    _print_welcome(config, provider, selected_model, active_agent)
+
+    # Enter REPL loop
+    try:
+        _repl_loop(session, config, provider, selected_model, active_agent)
+    except KeyboardInterrupt:
+        console.print("\n[dim]Chat ended.[/]")
+
+
+def _select_model(
+    config: ChatConfig, model_flag: str | None
+) -> tuple[str | None, str | None]:
+    """Select a provider and model, either from flag or interactively.
+
+    Returns (provider, model) tuple, or (None, None) on cancellation.
+    """
+    if model_flag:
+        # Try to auto-detect provider from model name
+        return _resolve_model_provider(config, model_flag)
+
+    # Interactive selection
+    choices = config.get_model_choices()
+    if not choices:
+        console.print("[red]No models available.[/]")
+        return None, None
+
+    if len(choices) == 1:
+        label, provider, model_name = choices[0]
+        console.print(f"[dim]Auto-selected: {label}[/]")
+        return provider, model_name
+
+    console.print("\n[bold]Select a model:[/]\n")
+    for i, (label, _, _) in enumerate(choices, 1):
+        console.print(f"  [cyan]{i}[/]) {label}")
+    console.print()
+
+    while True:
+        selection = Prompt.ask(
+            "Enter number",
+            default="1",
+        )
+        try:
+            idx = int(selection) - 1
+            if 0 <= idx < len(choices):
+                _, provider, model_name = choices[idx]
+                return provider, model_name
+        except ValueError:
+            pass
+        console.print(f"[red]Please enter a number between 1 and {len(choices)}.[/]")
+
+
+def _resolve_model_provider(
+    config: ChatConfig, model_name: str
+) -> tuple[str | None, str | None]:
+    """Resolve which provider a model belongs to."""
+    # Check if it matches a known model in any configured provider
+    for provider_name, provider_config in config.providers.items():
+        if model_name in provider_config.available_models:
+            return provider_name, model_name
+
+    # Heuristic: claude -> anthropic, gpt/o3 -> openai
+    model_lower = model_name.lower()
+    if "claude" in model_lower and "anthropic" in config.providers:
+        return "anthropic", model_name
+    if (
+        any(prefix in model_lower for prefix in ("gpt", "o3", "o1"))
+        and "openai" in config.providers
+    ):
+        return "openai", model_name
+
+    # If only one provider is configured, use it
+    if len(config.providers) == 1:
+        provider_name = next(iter(config.providers))
+        return provider_name, model_name
+
+    console.print(
+        f"[red]Cannot determine provider for model '{model_name}'.[/]\n"
+        "[dim]Use interactive selection or specify a recognized model name.[/]"
+    )
+    return None, None
+
+
+def _print_welcome(
+    config: ChatConfig,
+    provider: str,
+    model: str,
+    agent: str | None,
+) -> None:
+    """Print the welcome banner when chat starts."""
+    provider_display = config.providers[provider].name
+    info_lines = [
+        f"[bold]Provider:[/] {provider_display}",
+        f"[bold]Model:[/]    {model}",
+    ]
+    if agent:
+        info_lines.append(f"[bold]Agent:[/]    {agent}")
+
+    info_lines.append("")
+    info_lines.append("[dim]Type /help for commands, /quit to exit.[/]")
+
+    console.print(
+        Panel(
+            "\n".join(info_lines),
+            title="[bold cyan]Santai Chat[/]",
+            border_style="cyan",
+        )
+    )
+    console.print()
+
+
+def _print_available_agents() -> None:
+    """Print a list of available agent profiles."""
+    profiles = get_agent_profiles()
+    if not profiles:
+        console.print("[dim]No agent profiles found.[/]")
+        return
+
+    console.print("\n[bold]Available agents:[/]\n")
+    for name, description in profiles:
+        desc_text = f" — {description}" if description else ""
+        console.print(f"  [cyan]{name}[/]{desc_text}")
+    console.print()
+
+
+def _repl_loop(
+    session: ChatSession,
+    config: ChatConfig,
+    provider: str,
+    model: str,
+    agent: str | None,
+) -> None:
+    """Main REPL loop for the chat."""
+    state = _ChatState(
+        session=session,
+        config=config,
+        provider=provider,
+        model=model,
+        agent=agent,
+    )
+
+    while True:
+        try:
+            user_input = Prompt.ask("[bold green]You[/]")
+        except (KeyboardInterrupt, EOFError):
+            console.print("\n[dim]Chat ended.[/]")
+            return
+
+        user_input = user_input.strip()
+        if not user_input:
+            continue
+
+        # Handle REPL commands
+        if user_input.startswith("/"):
+            if _handle_command(user_input, state) == "quit":
+                return
+            continue
+
+        # Add user message and get streaming response
+        state.session.add_user_message(user_input)
+
+        console.print()
+        full_response = _stream_assistant_response(state)
+
+        if full_response is not None:
+            state.session.add_assistant_message(full_response)
+        else:
+            # Remove the user message if the response failed
+            state.session.messages.pop()
+
+        console.print()
+
+
+def _handle_command(command: str, state: _ChatState) -> str:
+    """Handle a REPL slash command. Mutates state in place.
+
+    Returns 'quit' to exit the REPL, or 'continue' to keep going.
+    """
+    parts = command.strip().split(maxsplit=1)
+    cmd = parts[0].lower()
+    arg = parts[1] if len(parts) > 1 else None
+
+    if cmd in ("/quit", "/exit", "/q"):
+        console.print("[dim]Goodbye![/]")
+        return "quit"
+
+    elif cmd == "/clear":
+        state.session.clear()
+        console.print("[dim]Conversation cleared.[/]\n")
+
+    elif cmd == "/help":
+        console.print(
+            Panel(
+                "[cyan]/quit[/]          Exit the chat\n"
+                "[cyan]/clear[/]         Clear conversation history\n"
+                "[cyan]/agent[/]         List agents, or /agent <name> to switch\n"
+                "[cyan]/model[/]         Re-select the model\n"
+                "[cyan]/help[/]          Show this help message",
+                title="Commands",
+                border_style="dim",
+            )
+        )
+
+    elif cmd == "/agent":
+        if arg:
+            new_prompt = load_agent_prompt(arg)
+            if new_prompt is None:
+                console.print(f"[red]Agent '{arg}' not found.[/]")
+                _print_available_agents()
+            else:
+                state.session = ChatSession(system_prompt=new_prompt)
+                state.agent = arg
+                console.print(f"[dim]Switched to agent: {arg}. History cleared.[/]\n")
+        else:
+            _print_available_agents()
+
+    elif cmd == "/model":
+        new_provider, new_model = _select_model(state.config, None)
+        if new_provider and new_model:
+            state.provider = new_provider
+            state.model = new_model
+            provider_name = state.config.providers[new_provider].name
+            console.print(f"[dim]Switched to {provider_name}: {new_model}[/]\n")
+
+    else:
+        console.print(f"[red]Unknown command: {cmd}[/]. Type /help for options.\n")
+
+    return "continue"
+
+
+def _stream_assistant_response(state: _ChatState) -> str | None:
+    """Stream the assistant response to the terminal with Rich formatting.
+
+    Returns the full response text, or None on error.
+    """
+    provider_config = state.config.providers[state.provider]
+    full_text = ""
+
+    try:
+        label = Text.assemble(("Assistant", "bold cyan"))
+        console.print(label)
+
+        # Use Live display with markdown rendering for streaming
+        with Live(
+            Markdown(" "),
+            console=console,
+            refresh_per_second=12,
+            vertical_overflow="visible",
+        ) as live:
+
+            async def _run_stream() -> str:
+                nonlocal full_text
+                async for chunk in stream_response(
+                    state.session,
+                    state.provider,
+                    provider_config,
+                    state.model,
+                ):
+                    full_text += chunk
+                    live.update(Markdown(full_text))
+                return full_text
+
+            full_text = asyncio.run(_run_stream())
+
+        return full_text
+
+    except KeyboardInterrupt:
+        console.print("\n[dim]Response interrupted.[/]")
+        return full_text if full_text else None
+
+    except Exception as e:
+        error_msg = str(e)
+        # Provide friendlier messages for common errors
+        if "401" in error_msg or "authentication" in error_msg.lower():
+            console.print("[red]Authentication failed.[/] Check your API key in .env")
+        elif "429" in error_msg or "rate" in error_msg.lower():
+            console.print("[red]Rate limited.[/] Wait a moment and try again.")
+        elif "model" in error_msg.lower() and "not found" in error_msg.lower():
+            console.print(
+                f"[red]Model '{state.model}' not found.[/]"
+                " Use /model to select another."
+            )
+        else:
+            console.print(f"[red]Error:[/] {error_msg}")
+        return None

--- a/src/santai_cli/commands/init.py
+++ b/src/santai_cli/commands/init.py
@@ -65,6 +65,25 @@ RUMDL_TOML_CONTENT = """\
 include = ["**/*.md"]
 """
 
+ENV_EXAMPLE_CONTENT = """\
+# Santai CLI - AI Chatbot Configuration
+# Copy this file to .env and fill in your API keys.
+# At least one provider key is required for `santai chat` to work.
+
+# --- Anthropic ---
+ANTHROPIC_API_KEY=your-anthropic-api-key-here
+ANTHROPIC_MODEL=claude-sonnet-4-20250514
+
+# --- OpenAI ---
+OPENAI_API_KEY=your-openai-api-key-here
+OPENAI_MODEL=gpt-4o
+"""
+
+GITIGNORE_CONTENT = """\
+# Environment secrets
+.env
+"""
+
 
 def _is_directory_empty(path: Path) -> bool:
     """Check if directory is completely empty (no files, no .git)."""
@@ -178,6 +197,14 @@ def init(
     console.print("Creating rumdl.toml...")
     (target_path / "rumdl.toml").write_text(RUMDL_TOML_CONTENT, encoding="utf-8")
 
+    # Write .env.example
+    console.print("Creating .env.example...")
+    (target_path / ".env.example").write_text(ENV_EXAMPLE_CONTENT, encoding="utf-8")
+
+    # Write .gitignore
+    console.print("Creating .gitignore...")
+    (target_path / ".gitignore").write_text(GITIGNORE_CONTENT, encoding="utf-8")
+
     # Install prek hooks
     console.print("Installing prek hooks...")
     if not _run_command(["prek", "install"], cwd=target_path):
@@ -196,6 +223,8 @@ def init(
     console.print("Project structure:")
     console.print(f"  {project_name}/")
     console.print("  ├── .git/")
+    console.print("  ├── .gitignore")
+    console.print("  ├── .env.example")
     console.print("  ├── .pre-commit-config.yaml")
     console.print("  ├── rumdl.toml")
     console.print("  ├── AGENTS.md")
@@ -210,4 +239,5 @@ def init(
     console.print(f"  cd {project_name}" if name != "." else "")
     console.print("  santai ui      # Launch TUI dashboard")
     console.print("  santai web     # Launch web dashboard")
+    console.print("  santai chat    # Chat with AI models")
     console.print("  santai history # View project history")

--- a/src/santai_cli/core/chat.py
+++ b/src/santai_cli/core/chat.py
@@ -1,0 +1,179 @@
+"""Shared chat engine for Santai CLI.
+
+Provides a provider-agnostic chat interface with streaming support
+for both Anthropic and OpenAI models. Used by the CLI, TUI, and
+Web interfaces.
+"""
+
+import asyncio
+from collections.abc import AsyncGenerator
+from dataclasses import dataclass, field
+
+import anthropic
+import openai
+
+from santai_cli.core.config import ProviderConfig
+
+
+@dataclass
+class ChatMessage:
+    """A single message in a chat conversation."""
+
+    role: str  # "system", "user", or "assistant"
+    content: str
+
+
+@dataclass
+class ChatSession:
+    """Manages conversation history for a chat session."""
+
+    system_prompt: str | None = None
+    messages: list[ChatMessage] = field(default_factory=list)
+
+    def add_user_message(self, content: str) -> None:
+        """Add a user message to the conversation."""
+        self.messages.append(ChatMessage(role="user", content=content))
+
+    def add_assistant_message(self, content: str) -> None:
+        """Add an assistant response to the conversation."""
+        self.messages.append(ChatMessage(role="assistant", content=content))
+
+    def clear(self) -> None:
+        """Clear conversation history (keeps system prompt)."""
+        self.messages.clear()
+
+    def to_anthropic_messages(self) -> list[dict[str, str]]:
+        """Convert messages to Anthropic API format.
+
+        Anthropic handles system prompts separately, so this only
+        returns user/assistant messages.
+        """
+        return [
+            {"role": m.role, "content": m.content}
+            for m in self.messages
+            if m.role in ("user", "assistant")
+        ]
+
+    def to_openai_messages(self) -> list[dict[str, str]]:
+        """Convert messages to OpenAI API format.
+
+        OpenAI expects system prompts inline as messages.
+        """
+        msgs: list[dict[str, str]] = []
+        if self.system_prompt:
+            msgs.append({"role": "system", "content": self.system_prompt})
+        msgs.extend(
+            {"role": m.role, "content": m.content}
+            for m in self.messages
+            if m.role in ("user", "assistant")
+        )
+        return msgs
+
+
+async def stream_response(
+    session: ChatSession,
+    provider: str,
+    provider_config: ProviderConfig,
+    model: str | None = None,
+) -> AsyncGenerator[str, None]:
+    """Stream a response from the specified provider.
+
+    Yields text chunks as they arrive from the model.
+
+    Args:
+        session: The current chat session with message history.
+        provider: Provider name ('anthropic' or 'openai').
+        provider_config: Configuration for the provider (API key, etc.).
+        model: Model to use. Falls back to provider_config.model if None.
+
+    Yields:
+        Text chunks of the response.
+    """
+    target_model = model or provider_config.model
+
+    if provider == "anthropic":
+        async for chunk in _stream_anthropic(
+            session, provider_config.api_key, target_model
+        ):
+            yield chunk
+    elif provider == "openai":
+        async for chunk in _stream_openai(
+            session, provider_config.api_key, target_model
+        ):
+            yield chunk
+    else:
+        raise ValueError(f"Unknown provider: {provider}")
+
+
+async def get_response(
+    session: ChatSession,
+    provider: str,
+    provider_config: ProviderConfig,
+    model: str | None = None,
+) -> str:
+    """Get a complete (non-streaming) response from the specified provider.
+
+    Args:
+        session: The current chat session with message history.
+        provider: Provider name ('anthropic' or 'openai').
+        provider_config: Configuration for the provider.
+        model: Model to use. Falls back to provider_config.model if None.
+
+    Returns:
+        The full response text.
+    """
+    chunks: list[str] = []
+    async for chunk in stream_response(session, provider, provider_config, model):
+        chunks.append(chunk)
+    return "".join(chunks)
+
+
+def get_response_sync(
+    session: ChatSession,
+    provider: str,
+    provider_config: ProviderConfig,
+    model: str | None = None,
+) -> str:
+    """Synchronous wrapper around get_response for non-async contexts."""
+    return asyncio.run(get_response(session, provider, provider_config, model))
+
+
+async def _stream_anthropic(
+    session: ChatSession,
+    api_key: str,
+    model: str,
+) -> AsyncGenerator[str, None]:
+    """Stream a response from the Anthropic API."""
+    client = anthropic.AsyncAnthropic(api_key=api_key)
+
+    kwargs: dict = {
+        "model": model,
+        "max_tokens": 4096,
+        "messages": session.to_anthropic_messages(),
+    }
+    if session.system_prompt:
+        kwargs["system"] = session.system_prompt
+
+    async with client.messages.stream(**kwargs) as stream:
+        async for text in stream.text_stream:
+            yield text
+
+
+async def _stream_openai(
+    session: ChatSession,
+    api_key: str,
+    model: str,
+) -> AsyncGenerator[str, None]:
+    """Stream a response from the OpenAI API."""
+    client = openai.AsyncOpenAI(api_key=api_key)
+
+    stream = await client.chat.completions.create(
+        model=model,
+        messages=session.to_openai_messages(),
+        max_tokens=4096,
+        stream=True,
+    )
+
+    async for chunk in stream:
+        if chunk.choices and chunk.choices[0].delta.content:
+            yield chunk.choices[0].delta.content

--- a/src/santai_cli/core/config.py
+++ b/src/santai_cli/core/config.py
@@ -1,0 +1,214 @@
+"""Configuration management for Santai CLI.
+
+Loads environment variables from .env files and provides
+API key validation and model configuration for AI chat providers.
+"""
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+# Default models per provider
+DEFAULT_MODELS: dict[str, str] = {
+    "anthropic": "claude-sonnet-4-20250514",
+    "openai": "gpt-4o",
+}
+
+# Popular models available per provider (for interactive selection)
+AVAILABLE_MODELS: dict[str, list[str]] = {
+    "anthropic": [
+        "claude-sonnet-4-20250514",
+        "claude-opus-4-20250514",
+        "claude-haiku-4-20250514",
+    ],
+    "openai": [
+        "gpt-4o",
+        "gpt-4o-mini",
+        "o3-mini",
+        "gpt-4.1",
+        "gpt-4.1-mini",
+        "gpt-4.1-nano",
+    ],
+}
+
+
+@dataclass
+class ProviderConfig:
+    """Configuration for a single AI provider."""
+
+    name: str
+    api_key: str
+    model: str
+    available_models: list[str] = field(default_factory=list)
+
+
+@dataclass
+class ChatConfig:
+    """Full chat configuration with all available providers."""
+
+    providers: dict[str, ProviderConfig] = field(default_factory=dict)
+
+    @property
+    def has_any_provider(self) -> bool:
+        """Check if at least one provider is configured."""
+        return len(self.providers) > 0
+
+    def get_model_choices(self) -> list[tuple[str, str, str]]:
+        """Return a list of (display_label, provider, model) for interactive selection.
+
+        Each configured provider contributes its available models to the list.
+        """
+        choices: list[tuple[str, str, str]] = []
+        for provider_name, config in self.providers.items():
+            for model in config.available_models:
+                # Mark the configured/default model
+                marker = " *" if model == config.model else ""
+                label = f"{provider_name}: {model}{marker}"
+                choices.append((label, provider_name, model))
+        return choices
+
+
+def load_config(project_root: Path | None = None) -> ChatConfig:
+    """Load chat configuration from environment.
+
+    Looks for a .env file in the project root (if provided) and falls
+    back to environment variables. Returns a ChatConfig with all
+    providers that have valid API keys set.
+
+    Args:
+        project_root: Optional path to the santai project root.
+                      If provided, loads .env from this directory.
+
+    Returns:
+        ChatConfig with discovered providers.
+    """
+    # Load .env from project root if available
+    if project_root:
+        env_path = project_root / ".env"
+        if env_path.is_file():
+            load_dotenv(env_path)
+    else:
+        # Try loading from cwd
+        load_dotenv()
+
+    config = ChatConfig()
+
+    # Check Anthropic
+    anthropic_key = os.environ.get("ANTHROPIC_API_KEY", "").strip()
+    if anthropic_key and not anthropic_key.startswith("your-"):
+        anthropic_model = os.environ.get(
+            "ANTHROPIC_MODEL", DEFAULT_MODELS["anthropic"]
+        ).strip()
+        config.providers["anthropic"] = ProviderConfig(
+            name="Anthropic",
+            api_key=anthropic_key,
+            model=anthropic_model,
+            available_models=AVAILABLE_MODELS["anthropic"],
+        )
+
+    # Check OpenAI
+    openai_key = os.environ.get("OPENAI_API_KEY", "").strip()
+    if openai_key and not openai_key.startswith("your-"):
+        openai_model = os.environ.get("OPENAI_MODEL", DEFAULT_MODELS["openai"]).strip()
+        config.providers["openai"] = ProviderConfig(
+            name="OpenAI",
+            api_key=openai_key,
+            model=openai_model,
+            available_models=AVAILABLE_MODELS["openai"],
+        )
+
+    return config
+
+
+def get_agent_profiles(agents_dir: Path | None = None) -> list[tuple[str, str]]:
+    """Get available agent profiles from the agents directory.
+
+    Returns a list of (name, description) tuples. The name is the
+    filename stem (e.g. 'code-review') and description is extracted
+    from the YAML frontmatter if present.
+
+    Args:
+        agents_dir: Path to the agents directory. If None, uses the
+                    bundled agents directory from the package.
+
+    Returns:
+        List of (name, description) tuples sorted by name.
+    """
+    if agents_dir is None:
+        agents_dir = Path(__file__).parent.parent / "agents"
+
+    if not agents_dir.is_dir():
+        return []
+
+    profiles: list[tuple[str, str]] = []
+    for md_file in sorted(agents_dir.glob("*.md")):
+        # Skip README and HOW_TO_USE
+        if md_file.stem.upper() in ("README", "HOW_TO_USE"):
+            continue
+
+        description = _extract_description(md_file)
+        profiles.append((md_file.stem, description))
+
+    return profiles
+
+
+def load_agent_prompt(agent_name: str, agents_dir: Path | None = None) -> str | None:
+    """Load the system prompt for a named agent.
+
+    Reads the agent markdown file and strips YAML frontmatter,
+    returning only the body content as the system prompt.
+
+    Args:
+        agent_name: Agent name (e.g. 'code-review').
+        agents_dir: Path to agents directory. Uses bundled default if None.
+
+    Returns:
+        The agent's system prompt text, or None if agent not found.
+    """
+    if agents_dir is None:
+        agents_dir = Path(__file__).parent.parent / "agents"
+
+    agent_file = agents_dir / f"{agent_name}.md"
+    if not agent_file.is_file():
+        return None
+
+    content = agent_file.read_text(encoding="utf-8")
+    return _strip_frontmatter(content)
+
+
+def _extract_description(md_file: Path) -> str:
+    """Extract the description from YAML frontmatter of an agent file."""
+    try:
+        content = md_file.read_text(encoding="utf-8")
+    except OSError:
+        return ""
+
+    if not content.startswith("---"):
+        return ""
+
+    # Find closing ---
+    end = content.find("---", 3)
+    if end == -1:
+        return ""
+
+    frontmatter = content[3:end]
+    for line in frontmatter.splitlines():
+        line = line.strip()
+        if line.startswith("description:"):
+            return line[len("description:") :].strip()
+
+    return ""
+
+
+def _strip_frontmatter(content: str) -> str:
+    """Strip YAML frontmatter from markdown content."""
+    if not content.startswith("---"):
+        return content.strip()
+
+    end = content.find("---", 3)
+    if end == -1:
+        return content.strip()
+
+    return content[end + 3 :].strip()

--- a/src/santai_cli/tui/app.py
+++ b/src/santai_cli/tui/app.py
@@ -17,6 +17,7 @@ from textual.widgets import (
     Header,
     Input,
     Label,
+    RichLog,
     Static,
     TextArea,
 )
@@ -1544,6 +1545,296 @@ class GraphFilterScreen(ModalScreen):
         self.dismiss()
 
 
+# === Chat Screen ===
+
+
+class ChatScreen(ModalScreen):
+    """Modal screen for AI chat within the TUI dashboard."""
+
+    BINDINGS = [
+        Binding("escape", "dismiss", "Close"),
+    ]
+
+    DEFAULT_CSS = """
+    ChatScreen {
+        align: center middle;
+    }
+    #chat-modal {
+        width: 90%;
+        height: 90%;
+        border: thick $primary;
+        background: $surface;
+    }
+    #chat-modal-header {
+        dock: top;
+        height: 3;
+        padding: 0 2;
+        background: $primary;
+        color: $text;
+    }
+    #chat-log {
+        height: 1fr;
+        padding: 1 2;
+        scrollbar-size-vertical: 1;
+    }
+    #chat-input-bar {
+        dock: bottom;
+        height: 3;
+        padding: 0 1;
+    }
+    #chat-input {
+        width: 1fr;
+    }
+    #chat-status {
+        dock: bottom;
+        height: 1;
+        padding: 0 2;
+        color: $text-muted;
+    }
+    """
+
+    def __init__(self, project: SantaiProject) -> None:
+        super().__init__()
+        self.project = project
+        self._provider: str | None = None
+        self._model: str | None = None
+        self._agent: str | None = None
+        self._session: Any = None
+        self._config: Any = None
+        self._streaming = False
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="chat-modal"):
+            yield Label(
+                "[bold]Santai Chat[/bold] — press Escape to close",
+                id="chat-modal-header",
+            )
+            yield RichLog(id="chat-log", wrap=True, highlight=True, markup=True)
+            yield Label("", id="chat-status")
+            with Horizontal(id="chat-input-bar"):
+                yield Input(
+                    placeholder="Type a message... (/help for commands)",
+                    id="chat-input",
+                )
+
+    def on_mount(self) -> None:
+        """Initialize chat configuration."""
+        from santai_cli.core.config import load_config
+
+        log = self.query_one("#chat-log", RichLog)
+        status = self.query_one("#chat-status", Label)
+
+        self._config = load_config(self.project.root)
+
+        if not self._config.has_any_provider:
+            log.write(
+                "[bold red]No API keys configured.[/]\n\n"
+                "Create a .env file in your project root with at least one key:\n"
+                "  ANTHROPIC_API_KEY=sk-ant-...\n"
+                "  OPENAI_API_KEY=sk-...\n\n"
+                "See .env.example for the full template."
+            )
+            status.update("No providers configured")
+            return
+
+        # Auto-select first available model
+        choices = self._config.get_model_choices()
+        if choices:
+            _, self._provider, self._model = choices[0]
+            provider_name = self._config.providers[self._provider].name
+            status.update(
+                f"Provider: {provider_name} | Model: {self._model} | /help for commands"
+            )
+
+            # Show model selection prompt
+            log.write("[bold cyan]Welcome to Santai Chat![/]\n")
+            log.write(f"[dim]Using {provider_name}: {self._model}[/]")
+            if len(choices) > 1:
+                log.write("[dim]Type /model to switch models.[/]")
+            log.write("[dim]Type /help for all commands.[/]\n")
+
+        # Initialize session
+        from santai_cli.core.chat import ChatSession
+
+        self._session = ChatSession()
+
+        # Focus the input
+        self.query_one("#chat-input", Input).focus()
+
+    async def on_input_submitted(self, event: Input.Submitted) -> None:
+        """Handle user input submission."""
+        if event.input.id != "chat-input":
+            return
+
+        user_text = event.value.strip()
+        if not user_text:
+            return
+
+        event.input.value = ""
+        log = self.query_one("#chat-log", RichLog)
+
+        if self._session is None or self._config is None:
+            log.write("[red]Chat not initialized. Check your .env configuration.[/]")
+            return
+
+        # Handle slash commands
+        if user_text.startswith("/"):
+            self._handle_chat_command(user_text)
+            return
+
+        if self._provider is None or self._model is None:
+            log.write("[red]No model selected. Type /model to select one.[/]")
+            return
+
+        if self._streaming:
+            log.write("[dim]Please wait for the current response to finish.[/]")
+            return
+
+        # Show user message
+        log.write(f"\n[bold green]You:[/] {user_text}")
+
+        # Get streaming response
+        self._session.add_user_message(user_text)
+        self._streaming = True
+        status = self.query_one("#chat-status", Label)
+        status.update("Generating response...")
+
+        try:
+            from santai_cli.core.chat import stream_response
+
+            provider_config = self._config.providers[self._provider]
+            full_text = ""
+
+            log.write("[bold cyan]Assistant:[/]")
+
+            async for chunk in stream_response(
+                self._session, self._provider, provider_config, self._model
+            ):
+                full_text += chunk
+                # RichLog doesn't support in-place updates easily,
+                # so we write chunks as they arrive
+                log.write(chunk, scroll_end=True)
+
+            log.write("")  # Blank line after response
+            self._session.add_assistant_message(full_text)
+
+            provider_name = self._config.providers[self._provider].name
+            status.update(
+                f"Provider: {provider_name} | Model: {self._model} | /help for commands"
+            )
+
+        except Exception as e:
+            error_msg = str(e)
+            if "401" in error_msg or "authentication" in error_msg.lower():
+                log.write("[red]Authentication failed. Check your API key.[/]")
+            elif "429" in error_msg or "rate" in error_msg.lower():
+                log.write("[red]Rate limited. Wait a moment and try again.[/]")
+            else:
+                log.write(f"[red]Error: {error_msg}[/]")
+            # Remove the failed user message
+            self._session.messages.pop()
+            status.update("Error occurred")
+        finally:
+            self._streaming = False
+
+    def _handle_chat_command(self, command: str) -> None:
+        """Handle slash commands in the chat input."""
+        from santai_cli.core.chat import ChatSession
+        from santai_cli.core.config import load_agent_prompt
+
+        log = self.query_one("#chat-log", RichLog)
+        status = self.query_one("#chat-status", Label)
+
+        parts = command.strip().split(maxsplit=1)
+        cmd = parts[0].lower()
+        arg = parts[1] if len(parts) > 1 else None
+
+        if cmd in ("/quit", "/exit", "/q"):
+            self.dismiss()
+
+        elif cmd == "/clear":
+            if self._session:
+                self._session.clear()
+            log.clear()
+            log.write("[dim]Conversation cleared.[/]\n")
+
+        elif cmd == "/help":
+            log.write(
+                "\n[bold]Commands:[/]\n"
+                "  [cyan]/quit[/]          Close the chat\n"
+                "  [cyan]/clear[/]         Clear conversation history\n"
+                "  [cyan]/agent[/]         List agents, or /agent <name> to switch\n"
+                "  [cyan]/model[/]         Switch model (shows numbered list)\n"
+                "  [cyan]/help[/]          Show this help\n"
+            )
+
+        elif cmd == "/agent":
+            if arg:
+                prompt = load_agent_prompt(arg)
+                if prompt is None:
+                    log.write(f"[red]Agent '{arg}' not found.[/]")
+                    self._show_agents(log)
+                else:
+                    self._session = ChatSession(system_prompt=prompt)
+                    self._agent = arg
+                    log.clear()
+                    log.write(f"[dim]Switched to agent: {arg}. History cleared.[/]\n")
+                    status.update(
+                        f"Agent: {arg} | Model: {self._model} | /help for commands"
+                    )
+            else:
+                self._show_agents(log)
+
+        elif cmd == "/model":
+            if self._config is None:
+                return
+            choices = self._config.get_model_choices()
+            if not choices:
+                log.write("[red]No models available.[/]")
+                return
+
+            log.write("\n[bold]Available models:[/]")
+            for i, (label, _, _) in enumerate(choices, 1):
+                log.write(f"  [cyan]{i}[/]) {label}")
+
+            if arg:
+                # Allow direct selection by number
+                try:
+                    idx = int(arg) - 1
+                    if 0 <= idx < len(choices):
+                        _, self._provider, self._model = choices[idx]
+                        provider_name = self._config.providers[self._provider].name
+                        log.write(
+                            f"\n[dim]Switched to {provider_name}: {self._model}[/]\n"
+                        )
+                        status.update(
+                            f"Provider: {provider_name} | Model: {self._model}"
+                        )
+                        return
+                except ValueError:
+                    pass
+
+            log.write("[dim]Type /model <number> to switch.[/]\n")
+
+        else:
+            log.write(f"[red]Unknown command: {cmd}[/]. Type /help for options.")
+
+    def _show_agents(self, log: RichLog) -> None:
+        """Display available agent profiles."""
+        from santai_cli.core.config import get_agent_profiles
+
+        profiles = get_agent_profiles()
+        if not profiles:
+            log.write("[dim]No agent profiles found.[/]")
+            return
+
+        log.write("\n[bold]Available agents:[/]")
+        for name, description in profiles:
+            desc_text = f" — {description}" if description else ""
+            log.write(f"  [cyan]{name}[/]{desc_text}")
+        log.write("[dim]Type /agent <name> to switch.[/]\n")
+
+
 # === Main App ===
 
 
@@ -1563,6 +1854,7 @@ class SantaiApp(App):
         Binding("n", "add_note", "Add Note"),
         Binding("p", "cycle_palette", "Palette"),
         Binding("c", "clear_graph_search", "Clear Search", show=True),
+        Binding("x", "open_chat", "Chat", show=True),
         Binding("escape", "back", "Back", show=True),
     ]
 
@@ -1717,6 +2009,10 @@ class SantaiApp(App):
     def action_add_note(self) -> None:
         """Open add note modal."""
         self.push_screen(AddNoteScreen(self.project))
+
+    def action_open_chat(self) -> None:
+        """Open the AI chat modal."""
+        self.push_screen(ChatScreen(self.project))
 
     def on_clickable_note_clicked(self, event: ClickableNote.Clicked) -> None:
         """Handle click on a note — open note detail modal."""

--- a/src/santai_cli/web/app.py
+++ b/src/santai_cli/web/app.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Any
 
 from fastapi import FastAPI, HTTPException, Query, Request, UploadFile
-from fastapi.responses import FileResponse, HTMLResponse
+from fastapi.responses import FileResponse, HTMLResponse, StreamingResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 from pydantic import BaseModel
@@ -41,6 +41,13 @@ class FileContentRequest(BaseModel):
 class MoveRequest(BaseModel):
     source_path: str
     target_folder: str
+
+
+class ChatRequest(BaseModel):
+    messages: list[dict[str, str]]
+    provider: str
+    model: str
+    agent: str | None = None
 
 
 def format_size(size_bytes: int | float) -> str:
@@ -618,5 +625,97 @@ def create_app(project: SantaiProject) -> FastAPI:
             raise HTTPException(status_code=400, detail="Cannot download a directory")
 
         return FileResponse(target, filename=target.name)
+
+    # === Chat API Endpoints ===
+
+    @app.get("/api/chat/models")
+    async def chat_models() -> dict[str, Any]:
+        """Return available AI models based on configured API keys."""
+        from santai_cli.core.config import load_config
+
+        config = load_config(project.root)
+        models: list[dict[str, str | bool]] = []
+        for provider_name, provider_config in config.providers.items():
+            for model_name in provider_config.available_models:
+                is_default = model_name == provider_config.model
+                models.append(
+                    {
+                        "provider": provider_name,
+                        "provider_display": provider_config.name,
+                        "model": model_name,
+                        "default": is_default,
+                    }
+                )
+        return {"models": models, "configured": config.has_any_provider}
+
+    @app.get("/api/chat/agents")
+    async def chat_agents() -> dict[str, Any]:
+        """Return available agent profiles."""
+        from santai_cli.core.config import get_agent_profiles
+
+        profiles = get_agent_profiles()
+        agents = [{"name": name, "description": desc} for name, desc in profiles]
+        return {"agents": agents}
+
+    @app.post("/api/chat")
+    async def chat_send(req: ChatRequest) -> StreamingResponse:
+        """Stream an AI chat response via Server-Sent Events (SSE).
+
+        Accepts the full conversation history and streams the
+        assistant's response back as SSE data events.
+        """
+        import json
+
+        from santai_cli.core.chat import ChatSession, stream_response
+        from santai_cli.core.config import load_agent_prompt, load_config
+
+        config = load_config(project.root)
+
+        if req.provider not in config.providers:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"Provider '{req.provider}' not configured. Check your .env file."
+                ),
+            )
+
+        provider_config = config.providers[req.provider]
+
+        # Build session from message history
+        system_prompt = None
+        if req.agent:
+            system_prompt = load_agent_prompt(req.agent)
+
+        session = ChatSession(system_prompt=system_prompt)
+        for msg in req.messages:
+            if msg.get("role") == "user":
+                session.add_user_message(msg.get("content", ""))
+            elif msg.get("role") == "assistant":
+                session.add_assistant_message(msg.get("content", ""))
+
+        async def event_generator():
+            """Generate SSE events from the streaming response."""
+            try:
+                async for chunk in stream_response(
+                    session, req.provider, provider_config, req.model
+                ):
+                    # SSE format: data: <json>\n\n
+                    data = json.dumps({"type": "chunk", "content": chunk})
+                    yield f"data: {data}\n\n"
+                # Send done event
+                yield f"data: {json.dumps({'type': 'done'})}\n\n"
+            except Exception as e:
+                error_data = json.dumps({"type": "error", "content": str(e)})
+                yield f"data: {error_data}\n\n"
+
+        return StreamingResponse(
+            event_generator(),
+            media_type="text/event-stream",
+            headers={
+                "Cache-Control": "no-cache",
+                "Connection": "keep-alive",
+                "X-Accel-Buffering": "no",
+            },
+        )
 
     return app

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -1494,7 +1494,7 @@
         .dashboard {
             display: grid;
             grid-template-columns: 1fr 1fr;
-            grid-template-rows: 1fr 1fr;
+            grid-template-rows: 1fr auto auto;
             gap: 12px;
             height: 100%;
             padding: 20px;
@@ -2360,6 +2360,169 @@
             overflow-y: auto;
             padding: 20px;
         }
+
+        /* Chat Panel */
+        .dashboard-panel.chat-panel {
+            grid-column: 1 / -1;
+            max-height: 500px;
+        }
+
+        .chat-header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            margin-bottom: 12px;
+            padding-bottom: 8px;
+            border-bottom: 1px solid rgba(0, 0, 0, 0.06);
+        }
+
+        .chat-header h3 {
+            margin: 0;
+            border: none;
+            padding: 0;
+        }
+
+        .chat-header-controls {
+            display: flex;
+            gap: 8px;
+            align-items: center;
+        }
+
+        .chat-header-controls select {
+            padding: 4px 8px;
+            border-radius: 8px;
+            border: 1px solid rgba(0, 0, 0, 0.1);
+            background: rgba(255, 255, 255, 0.6);
+            font-size: 12px;
+            color: var(--text-primary);
+            cursor: pointer;
+        }
+
+        .chat-messages {
+            flex: 1;
+            overflow-y: auto;
+            padding: 8px;
+            display: flex;
+            flex-direction: column;
+            gap: 12px;
+            min-height: 200px;
+        }
+
+        .chat-msg {
+            padding: 10px 14px;
+            border-radius: 12px;
+            max-width: 80%;
+            font-size: 13px;
+            line-height: 1.5;
+            word-wrap: break-word;
+        }
+
+        .chat-msg.user {
+            align-self: flex-end;
+            background: var(--accent, rgba(0, 122, 255, 0.15));
+            color: var(--text-primary);
+            border-bottom-right-radius: 4px;
+        }
+
+        .chat-msg.assistant {
+            align-self: flex-start;
+            background: rgba(0, 0, 0, 0.04);
+            color: var(--text-primary);
+            border-bottom-left-radius: 4px;
+        }
+
+        .chat-msg.assistant p {
+            margin: 0 0 8px 0;
+        }
+
+        .chat-msg.assistant p:last-child {
+            margin-bottom: 0;
+        }
+
+        .chat-msg.assistant pre {
+            background: rgba(0, 0, 0, 0.06);
+            padding: 8px 12px;
+            border-radius: 8px;
+            overflow-x: auto;
+            font-size: 12px;
+        }
+
+        .chat-msg.assistant code {
+            font-family: "SF Mono", "Fira Code", monospace;
+            font-size: 12px;
+        }
+
+        .chat-msg.system {
+            align-self: center;
+            color: var(--text-secondary);
+            font-size: 12px;
+            font-style: italic;
+        }
+
+        .chat-input-row {
+            display: flex;
+            gap: 8px;
+            padding-top: 8px;
+            border-top: 1px solid rgba(0, 0, 0, 0.06);
+        }
+
+        .chat-input-row input {
+            flex: 1;
+            padding: 10px 14px;
+            border-radius: 12px;
+            border: 1px solid rgba(0, 0, 0, 0.1);
+            background: rgba(255, 255, 255, 0.6);
+            font-size: 13px;
+            color: var(--text-primary);
+            outline: none;
+            transition: border-color 0.2s;
+        }
+
+        .chat-input-row input:focus {
+            border-color: var(--accent, rgba(0, 122, 255, 0.5));
+        }
+
+        .chat-input-row button {
+            padding: 10px 18px;
+            border-radius: 12px;
+            border: none;
+            background: var(--accent, rgba(0, 122, 255, 0.8));
+            color: white;
+            font-size: 13px;
+            font-weight: 600;
+            cursor: pointer;
+            transition: opacity 0.2s;
+        }
+
+        .chat-input-row button:hover {
+            opacity: 0.85;
+        }
+
+        .chat-input-row button:disabled {
+            opacity: 0.4;
+            cursor: not-allowed;
+        }
+
+        .chat-no-config {
+            text-align: center;
+            padding: 24px;
+            color: var(--text-secondary);
+            font-size: 13px;
+        }
+
+        /* Simple theme overrides for chat */
+        body.simple-theme .chat-msg.user {
+            background: rgba(0, 122, 255, 0.1);
+        }
+
+        body.simple-theme .chat-msg.assistant {
+            background: rgba(0, 0, 0, 0.03);
+        }
+
+        body.simple-theme .chat-input-row input {
+            background: white;
+            border-color: #ddd;
+        }
     </style>
 </head>
 <body>
@@ -2502,7 +2665,30 @@
                 </div>
             </div>
 
-            <!-- File Browser View (shown when navigating) -->
+            <!-- Chat Panel -->
+            <div class="dashboard-panel chat-panel" id="chat-panel">
+                <div class="chat-header">
+                    <h3>AI Chat</h3>
+                    <div class="chat-header-controls">
+                        <select id="chat-agent-select" onchange="onChatAgentChange()">
+                            <option value="">No Agent</option>
+                        </select>
+                        <select id="chat-model-select">
+                            <option value="">Loading models...</option>
+                        </select>
+                        <button onclick="clearChat()" style="padding: 4px 10px; border-radius: 8px; border: 1px solid rgba(0,0,0,0.1); background: rgba(255,255,255,0.6); font-size: 12px; cursor: pointer;">Clear</button>
+                    </div>
+                </div>
+                <div class="chat-messages" id="chat-messages">
+                    <div class="chat-msg system">Loading configuration...</div>
+                </div>
+                <div class="chat-input-row">
+                    <input type="text" id="chat-input" placeholder="Type a message..." onkeydown="if(event.key==='Enter')sendChatMessage()" disabled>
+                    <button id="chat-send-btn" onclick="sendChatMessage()" disabled>Send</button>
+                </div>
+            </div>
+
+            </div>
             <div class="content" id="content" style="display: none;">
                 <div class="browser-header">
                     <button class="dashboard-btn" onclick="showDashboard()">Dashboard</button>
@@ -4003,7 +4189,8 @@
             await Promise.all([
                 loadRecentFiles(),
                 loadNotesPreview(),
-                initGraph()
+                initGraph(),
+                initChat()
             ]);
         }
 
@@ -4587,6 +4774,204 @@
             }
         });
 
+        // === Chat Functions ===
+
+        let chatMessages = []; // {role, content} array
+        let chatConfigured = false;
+        let chatStreaming = false;
+
+        async function initChat() {
+            const messagesEl = document.getElementById('chat-messages');
+            const inputEl = document.getElementById('chat-input');
+            const sendBtn = document.getElementById('chat-send-btn');
+            const modelSelect = document.getElementById('chat-model-select');
+            const agentSelect = document.getElementById('chat-agent-select');
+
+            try {
+                // Load models and agents in parallel
+                const [modelsRes, agentsRes] = await Promise.all([
+                    fetch('/api/chat/models'),
+                    fetch('/api/chat/agents')
+                ]);
+
+                const modelsData = await modelsRes.json();
+                const agentsData = await agentsRes.json();
+
+                // Populate model select
+                modelSelect.innerHTML = '';
+                if (modelsData.models.length === 0) {
+                    modelSelect.innerHTML = '<option value="">No models available</option>';
+                    messagesEl.innerHTML = '<div class="chat-no-config">No API keys configured. Add a <code>.env</code> file with your API keys to enable chat.<br>See <code>.env.example</code> for the template.</div>';
+                    return;
+                }
+
+                modelsData.models.forEach(m => {
+                    const opt = document.createElement('option');
+                    opt.value = JSON.stringify({provider: m.provider, model: m.model});
+                    opt.textContent = `${m.provider_display}: ${m.model}`;
+                    if (m.default) opt.selected = true;
+                    modelSelect.appendChild(opt);
+                });
+
+                // Populate agent select
+                agentSelect.innerHTML = '<option value="">No Agent</option>';
+                agentsData.agents.forEach(a => {
+                    const opt = document.createElement('option');
+                    opt.value = a.name;
+                    opt.textContent = a.name;
+                    if (a.description) opt.title = a.description;
+                    agentSelect.appendChild(opt);
+                });
+
+                // Enable chat
+                chatConfigured = true;
+                inputEl.disabled = false;
+                sendBtn.disabled = false;
+                messagesEl.innerHTML = '<div class="chat-msg system">Ready to chat. Select a model and type a message.</div>';
+
+            } catch (e) {
+                messagesEl.innerHTML = '<div class="chat-msg system">Failed to load chat configuration.</div>';
+                console.error('Chat init error:', e);
+            }
+        }
+
+        function onChatAgentChange() {
+            const agent = document.getElementById('chat-agent-select').value;
+            if (agent) {
+                clearChat();
+                appendChatMessage('system', `Agent switched to: ${agent}`);
+            }
+        }
+
+        function clearChat() {
+            chatMessages = [];
+            const messagesEl = document.getElementById('chat-messages');
+            messagesEl.innerHTML = '<div class="chat-msg system">Chat cleared.</div>';
+        }
+
+        function appendChatMessage(role, content) {
+            const messagesEl = document.getElementById('chat-messages');
+            const msgDiv = document.createElement('div');
+            msgDiv.className = `chat-msg ${role}`;
+
+            if (role === 'assistant' && typeof marked !== 'undefined') {
+                msgDiv.innerHTML = marked.parse(content);
+            } else {
+                msgDiv.textContent = content;
+            }
+
+            messagesEl.appendChild(msgDiv);
+            messagesEl.scrollTop = messagesEl.scrollHeight;
+            return msgDiv;
+        }
+
+        async function sendChatMessage() {
+            if (!chatConfigured || chatStreaming) return;
+
+            const inputEl = document.getElementById('chat-input');
+            const sendBtn = document.getElementById('chat-send-btn');
+            const userText = inputEl.value.trim();
+            if (!userText) return;
+
+            // Get selected model
+            const modelSelect = document.getElementById('chat-model-select');
+            const modelValue = modelSelect.value;
+            if (!modelValue) return;
+
+            let selected;
+            try {
+                selected = JSON.parse(modelValue);
+            } catch {
+                return;
+            }
+
+            // Get selected agent
+            const agent = document.getElementById('chat-agent-select').value || null;
+
+            // Clear input and show user message
+            inputEl.value = '';
+            appendChatMessage('user', userText);
+            chatMessages.push({role: 'user', content: userText});
+
+            // Disable input during streaming
+            chatStreaming = true;
+            inputEl.disabled = true;
+            sendBtn.disabled = true;
+            sendBtn.textContent = '...';
+
+            // Create the assistant message element for streaming
+            const assistantDiv = appendChatMessage('assistant', '');
+            let fullResponse = '';
+
+            try {
+                const response = await fetch('/api/chat', {
+                    method: 'POST',
+                    headers: {'Content-Type': 'application/json'},
+                    body: JSON.stringify({
+                        messages: chatMessages,
+                        provider: selected.provider,
+                        model: selected.model,
+                        agent: agent
+                    })
+                });
+
+                if (!response.ok) {
+                    const err = await response.json();
+                    throw new Error(err.detail || 'Chat request failed');
+                }
+
+                // Read SSE stream
+                const reader = response.body.getReader();
+                const decoder = new TextDecoder();
+                let buffer = '';
+
+                while (true) {
+                    const {done, value} = await reader.read();
+                    if (done) break;
+
+                    buffer += decoder.decode(value, {stream: true});
+                    const lines = buffer.split('\n');
+                    buffer = lines.pop() || '';
+
+                    for (const line of lines) {
+                        if (line.startsWith('data: ')) {
+                            try {
+                                const data = JSON.parse(line.slice(6));
+                                if (data.type === 'chunk') {
+                                    fullResponse += data.content;
+                                    if (typeof marked !== 'undefined') {
+                                        assistantDiv.innerHTML = marked.parse(fullResponse);
+                                    } else {
+                                        assistantDiv.textContent = fullResponse;
+                                    }
+                                    const messagesEl = document.getElementById('chat-messages');
+                                    messagesEl.scrollTop = messagesEl.scrollHeight;
+                                } else if (data.type === 'error') {
+                                    assistantDiv.innerHTML = `<span style="color: red;">Error: ${data.content}</span>`;
+                                }
+                            } catch {
+                                // Ignore malformed data lines
+                            }
+                        }
+                    }
+                }
+
+                if (fullResponse) {
+                    chatMessages.push({role: 'assistant', content: fullResponse});
+                }
+
+            } catch (e) {
+                assistantDiv.innerHTML = `<span style="color: red;">Error: ${e.message}</span>`;
+                console.error('Chat error:', e);
+            } finally {
+                chatStreaming = false;
+                inputEl.disabled = false;
+                sendBtn.disabled = false;
+                sendBtn.textContent = 'Send';
+                inputEl.focus();
+            }
+        }
+
         // Initial load
         loadTree();
     </script>
@@ -4616,6 +5001,7 @@
                 loadRecentFiles();
                 loadNotesPreview();
                 initGraph();
+                initChat();
                 startAutoRefresh();
 
                 // Check for preview URL parameter

--- a/uv.lock
+++ b/uv.lock
@@ -21,6 +21,25 @@ wheels = [
 ]
 
 [[package]]
+name = "anthropic"
+version = "0.96.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "docstring-parser" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b9/7e/672f533dee813028d2c699bfd2a7f52c9118d7353680d9aa44b9e23f717f/anthropic-0.96.0.tar.gz", hash = "sha256:9de947b737f39452f68aa520f1c2239d44119c9b73b0fb6d4e6ca80f00279ee6", size = 658210, upload-time = "2026-04-16T14:28:02.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/5a/72f33204064b6e87601a71a6baf8d855769f8a0c1eaae8d06a1094872371/anthropic-0.96.0-py3-none-any.whl", hash = "sha256:9a6e335a354602a521cd9e777e92bfd46ba6e115bf9bbfe6135311e8fb2015b2", size = 635930, upload-time = "2026-04-16T14:28:01.436Z" },
+]
+
+[[package]]
 name = "anyio"
 version = "4.13.0"
 source = { registry = "https://pypi.org/simple" }
@@ -31,6 +50,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.2.25"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/2d/7bf41579a8986e348fa033a31cdd0e4121114f6bce2457e8876010b092dd/certifi-2026.2.25.tar.gz", hash = "sha256:e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7", size = 155029, upload-time = "2026-02-25T02:54:17.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl", hash = "sha256:027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa", size = 153684, upload-time = "2026-02-25T02:54:15.766Z" },
 ]
 
 [[package]]
@@ -73,6 +101,24 @@ wheels = [
 ]
 
 [[package]]
+name = "distro"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
+name = "docstring-parser"
+version = "0.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341, upload-time = "2026-04-14T04:09:19.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484, upload-time = "2026-04-14T04:09:18.638Z" },
+]
+
+[[package]]
 name = "fastapi"
 version = "0.135.3"
 source = { registry = "https://pypi.org/simple" }
@@ -107,6 +153,19 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
 name = "httptools"
 version = "0.7.1"
 source = { registry = "https://pypi.org/simple" }
@@ -133,6 +192,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/4d/31/14df99e1c43bd132eec921c2e7e11cda7852f65619bc0fc5bdc2d0cb126c/httptools-0.7.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:f084813239e1eb403ddacd06a30de3d3e09a9b76e7894dcda2b22f8a726e9c60", size = 452631, upload-time = "2025-10-10T03:54:58.219Z" },
     { url = "https://files.pythonhosted.org/packages/22/d2/b7e131f7be8d854d48cb6d048113c30f9a46dca0c9a8b08fcb3fcd588cdc/httptools-0.7.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7347714368fb2b335e9063bc2b96f2f87a9ceffcd9758ac295f8bbcd3ffbc0ca", size = 452910, upload-time = "2025-10-10T03:54:59.366Z" },
     { url = "https://files.pythonhosted.org/packages/53/cf/878f3b91e4e6e011eff6d1fa9ca39f7eb17d19c9d7971b04873734112f30/httptools-0.7.1-cp314-cp314-win_amd64.whl", hash = "sha256:cfabda2a5bb85aa2a904ce06d974a3f30fb36cc63d7feaddec05d2050acede96", size = 88205, upload-time = "2025-10-10T03:55:00.389Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
 ]
 
 [[package]]
@@ -163,6 +237,78 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "jiter"
+version = "0.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/c1/0cddc6eb17d4c53a99840953f95dd3accdc5cfc7a337b0e9b26476276be9/jiter-0.14.0.tar.gz", hash = "sha256:e8a39e66dac7153cf3f964a12aad515afa8d74938ec5cc0018adcdae5367c79e", size = 165725, upload-time = "2026-04-10T14:28:42.01Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/68/7390a418f10897da93b158f2d5a8bd0bcd73a0f9ec3bb36917085bb759ef/jiter-0.14.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:2fb2ce3a7bc331256dfb14cefc34832366bb28a9aca81deaf43bbf2a5659e607", size = 316295, upload-time = "2026-04-10T14:26:24.887Z" },
+    { url = "https://files.pythonhosted.org/packages/60/a0/5854ac00ff63551c52c6c89534ec6aba4b93474e7924d64e860b1c94165b/jiter-0.14.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5252a7ca23785cef5d02d4ece6077a1b556a410c591b379f82091c3001e14844", size = 315898, upload-time = "2026-04-10T14:26:26.601Z" },
+    { url = "https://files.pythonhosted.org/packages/41/a1/4f44832650a16b18e8391f1bf1d6ca4909bc738351826bcc198bba4357f4/jiter-0.14.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c409578cbd77c338975670ada777add4efd53379667edf0aceea730cabede6fb", size = 343730, upload-time = "2026-04-10T14:26:28.326Z" },
+    { url = "https://files.pythonhosted.org/packages/48/64/a329e9d469f86307203594b1707e11ae51c3348d03bfd514a5f997870012/jiter-0.14.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7ede4331a1899d604463369c730dbb961ffdc5312bc7f16c41c2896415b1304a", size = 370102, upload-time = "2026-04-10T14:26:30.089Z" },
+    { url = "https://files.pythonhosted.org/packages/94/c1/5e3dfc59635aa4d4c7bd20a820ac1d09b8ed851568356802cf1c08edb3cf/jiter-0.14.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:92cd8b6025981a041f5310430310b55b25ca593972c16407af8837d3d7d2ca01", size = 461335, upload-time = "2026-04-10T14:26:31.911Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/1b/dd157009dbc058f7b00108f545ccb72a2d56461395c4fc7b9cfdccb00af4/jiter-0.14.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:351bf6eda4e3a7ceb876377840c702e9a3e4ecc4624dbfb2d6463c67ae52637d", size = 378536, upload-time = "2026-04-10T14:26:33.595Z" },
+    { url = "https://files.pythonhosted.org/packages/91/78/256013667b7c10b8834f8e6e54cd3e562d4c6e34227a1596addccc05e38c/jiter-0.14.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c1dcfbeb93d9ecd9ca128bbf8910120367777973fa193fb9a39c31237d8df165", size = 353859, upload-time = "2026-04-10T14:26:35.098Z" },
+    { url = "https://files.pythonhosted.org/packages/de/d9/137d65ade9093a409fe80955ce60b12bb753722c986467aeda47faf450ad/jiter-0.14.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:ae039aaef8de3f8157ecc1fdd4d85043ac4f57538c245a0afaecb8321ec951c3", size = 357626, upload-time = "2026-04-10T14:26:36.685Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/48/76750835b87029342727c1a268bea8878ab988caf81ee4e7b880900eeb5a/jiter-0.14.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7d9d51eb96c82a9652933bd769fe6de66877d6eb2b2440e281f2938c51b5643e", size = 393172, upload-time = "2026-04-10T14:26:38.097Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/60/456c4e81d5c8045279aefe60e9e483be08793828800a4e64add8fdde7f2a/jiter-0.14.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:d824ca4148b705970bf4e120924a212fdfca9859a73e42bd7889a63a4ea6bb98", size = 520300, upload-time = "2026-04-10T14:26:39.532Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/9f/2020e0984c235f678dced38fe4eec3058cf528e6af36ebf969b410305941/jiter-0.14.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:ff3a6465b3a0f54b1a430f45c3c0ba7d61ceb45cbc3e33f9e1a7f638d690baf3", size = 553059, upload-time = "2026-04-10T14:26:40.991Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/32/e2d298e1a22a4bbe6062136d1c7192db7dba003a6975e51d9a9eecabc4c2/jiter-0.14.0-cp312-cp312-win32.whl", hash = "sha256:5dec7c0a3e98d2a3f8a2e67382d0d7c3ac60c69103a4b271da889b4e8bb1e129", size = 206030, upload-time = "2026-04-10T14:26:42.517Z" },
+    { url = "https://files.pythonhosted.org/packages/36/ac/96369141b3d8a4a8e4590e983085efe1c436f35c0cda940dd76d942e3e40/jiter-0.14.0-cp312-cp312-win_amd64.whl", hash = "sha256:fc7e37b4b8bc7e80a63ad6cfa5fc11fab27dbfea4cc4ae644b1ab3f273dc348f", size = 201603, upload-time = "2026-04-10T14:26:44.328Z" },
+    { url = "https://files.pythonhosted.org/packages/01/c3/75d847f264647017d7e3052bbcc8b1e24b95fa139c320c5f5066fa7a0bdd/jiter-0.14.0-cp312-cp312-win_arm64.whl", hash = "sha256:ee4a72f12847ef29b072aee9ad5474041ab2924106bdca9fcf5d7d965853e057", size = 191525, upload-time = "2026-04-10T14:26:46Z" },
+    { url = "https://files.pythonhosted.org/packages/97/2a/09f70020898507a89279659a1afe3364d57fc1b2c89949081975d135f6f5/jiter-0.14.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:af72f204cf4d44258e5b4c1745130ac45ddab0e71a06333b01de660ab4187a94", size = 315502, upload-time = "2026-04-10T14:26:47.697Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/be/080c96a45cd74f9fce5db4fd68510b88087fb37ffe2541ff73c12db92535/jiter-0.14.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4b77da71f6e819be5fbcec11a453fde5b1d0267ef6ed487e2a392fd8e14e4e3a", size = 314870, upload-time = "2026-04-10T14:26:49.149Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/5e/2d0fee155826a968a832cc32438de5e2a193292c8721ca70d0b53e58245b/jiter-0.14.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:77f4ea612fe8b84b8b04e51d0e78029ecf3466348e25973f953de6e6a59aa4c1", size = 343406, upload-time = "2026-04-10T14:26:50.762Z" },
+    { url = "https://files.pythonhosted.org/packages/70/af/bf9ee0d3a4f8dc0d679fc1337f874fe60cdbf841ebbb304b374e1c9aaceb/jiter-0.14.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:62fe2451f8fcc0240261e6a4df18ecbcd58327857e61e625b2393ea3b468aac9", size = 369415, upload-time = "2026-04-10T14:26:52.188Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/83/8e8561eadba31f4d3948a5b712fb0447ec71c3560b57a855449e7b8ddc98/jiter-0.14.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6112f26f5afc75bcb475787d29da3aa92f9d09c7858f632f4be6ffe607be82e9", size = 461456, upload-time = "2026-04-10T14:26:53.611Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/c9/c5299e826a5fe6108d172b344033f61c69b1bb979dd8d9ddd4278a160971/jiter-0.14.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:215a6cb8fb7dc702aa35d475cc00ddc7f970e5c0b1417fb4b4ac5d82fa2a29db", size = 378488, upload-time = "2026-04-10T14:26:55.211Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/37/c16d9d15c0a471b8644b1abe3c82668092a707d9bedcf076f24ff2e380cd/jiter-0.14.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fc4ab96a30fb3cb2c7e0cd33f7616c8860da5f5674438988a54ac717caccdbaa", size = 353242, upload-time = "2026-04-10T14:26:56.705Z" },
+    { url = "https://files.pythonhosted.org/packages/58/ea/8050cb0dc654e728e1bfacbc0c640772f2181af5dedd13ae70145743a439/jiter-0.14.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:3a99c1387b1f2928f799a9de899193484d66206a50e98233b6b088a7f0c1edb2", size = 356823, upload-time = "2026-04-10T14:26:58.281Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/3b/cf71506d270e5f84d97326bf220e47aed9b95e9a4a060758fb07772170ab/jiter-0.14.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ab18d11074485438695f8d34a1b6da61db9754248f96d51341956607a8f39985", size = 392564, upload-time = "2026-04-10T14:27:00.018Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/cc/8c6c74a3efb5bd671bfd14f51e8a73375464ca914b1551bc3b40e26ac2c9/jiter-0.14.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:801028dcfc26ac0895e4964cbc0fd62c73be9fd4a7d7b1aaf6e5790033a719b7", size = 520322, upload-time = "2026-04-10T14:27:01.664Z" },
+    { url = "https://files.pythonhosted.org/packages/41/24/68d7b883ec959884ddf00d019b2e0e82ba81b167e1253684fa90519ce33c/jiter-0.14.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:ad425b087aafb4a1c7e1e98a279200743b9aaf30c3e0ba723aec93f061bd9bc8", size = 552619, upload-time = "2026-04-10T14:27:03.316Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/89/b1a0985223bbf3150ff9e8f46f98fc9360c1de94f48abe271bbe1b465682/jiter-0.14.0-cp313-cp313-win32.whl", hash = "sha256:882bcb9b334318e233950b8be366fe5f92c86b66a7e449e76975dfd6d776a01f", size = 205699, upload-time = "2026-04-10T14:27:04.662Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/19/3f339a5a7f14a11730e67f6be34f9d5105751d547b615ef593fa122a5ded/jiter-0.14.0-cp313-cp313-win_amd64.whl", hash = "sha256:9b8c571a5dba09b98bd3462b5a53f27209a5cbbe85670391692ede71974e979f", size = 201323, upload-time = "2026-04-10T14:27:06.139Z" },
+    { url = "https://files.pythonhosted.org/packages/50/56/752dd89c84be0e022a8ea3720bcfa0a8431db79a962578544812ce061739/jiter-0.14.0-cp313-cp313-win_arm64.whl", hash = "sha256:34f19dcc35cb1abe7c369b3756babf8c7f04595c0807a848df8f26ef8298ef92", size = 191099, upload-time = "2026-04-10T14:27:07.564Z" },
+    { url = "https://files.pythonhosted.org/packages/91/28/292916f354f25a1fe8cf2c918d1415c699a4a659ae00be0430e1c5d9ffea/jiter-0.14.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e89bcd7d426a75bb4952c696b267075790d854a07aad4c9894551a82c5b574ab", size = 320880, upload-time = "2026-04-10T14:27:09.326Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/c7/b002a7d8b8957ac3d469bd59c18ef4b1595a5216ae0de639a287b9816023/jiter-0.14.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7b25beaa0d4447ea8c7ae0c18c688905d34840d7d0b937f2f7bdd52162c98a40", size = 346563, upload-time = "2026-04-10T14:27:11.287Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/3b/f8d07580d8706021d255a6356b8fab13ee4c869412995550ce6ed4ddf97d/jiter-0.14.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:651a8758dd413c51e3b7f6557cdc6921faf70b14106f45f969f091f5cda990ea", size = 357928, upload-time = "2026-04-10T14:27:12.729Z" },
+    { url = "https://files.pythonhosted.org/packages/47/5b/ac1a974da29e35507230383110ffec59998b290a8732585d04e19a9eb5ba/jiter-0.14.0-cp313-cp313t-win_amd64.whl", hash = "sha256:e1a7eead856a5038a8d291f1447176ab0b525c77a279a058121b5fccee257f6f", size = 203519, upload-time = "2026-04-10T14:27:14.125Z" },
+    { url = "https://files.pythonhosted.org/packages/96/6d/9fc8433d667d2454271378a79747d8c76c10b51b482b454e6190e511f244/jiter-0.14.0-cp313-cp313t-win_arm64.whl", hash = "sha256:2e692633a12cda97e352fdcd1c4acc971b1c28707e1e33aeef782b0cbf051975", size = 190113, upload-time = "2026-04-10T14:27:16.638Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/1e/354ed92461b165bd581f9ef5150971a572c873ec3b68a916d5aa91da3cc2/jiter-0.14.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:6f396837fc7577871ca8c12edaf239ed9ccef3bbe39904ae9b8b63ce0a48b140", size = 315277, upload-time = "2026-04-10T14:27:18.109Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/95/8c7c7028aa8636ac21b7a55faef3e34215e6ed0cbf5ae58258427f621aa3/jiter-0.14.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a4d50ea3d8ba4176f79754333bd35f1bbcd28e91adc13eb9b7ca91bc52a6cef9", size = 315923, upload-time = "2026-04-10T14:27:19.603Z" },
+    { url = "https://files.pythonhosted.org/packages/47/40/e2a852a44c4a089f2681a16611b7ce113224a80fd8504c46d78491b47220/jiter-0.14.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce17f8a050447d1b4153bda4fb7d26e6a9e74eb4f4a41913f30934c5075bf615", size = 344943, upload-time = "2026-04-10T14:27:21.262Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/1f/670f92adee1e9895eac41e8a4d623b6da68c4d46249d8b556b60b63f949e/jiter-0.14.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f4f1c4b125e1652aefbc2e2c1617b60a160ab789d180e3d423c41439e5f32850", size = 369725, upload-time = "2026-04-10T14:27:22.766Z" },
+    { url = "https://files.pythonhosted.org/packages/01/2f/541c9ba567d05de1c4874a0f8f8c5e3fd78e2b874266623da9a775cf46e0/jiter-0.14.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:be808176a6a3a14321d18c603f2d40741858a7c4fc982f83232842689fe86dd9", size = 461210, upload-time = "2026-04-10T14:27:24.315Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/a9/c31cbec09627e0d5de7aeaec7690dba03e090caa808fefd8133137cf45bc/jiter-0.14.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:26679d58ba816f88c3849306dd58cb863a90a1cf352cdd4ef67e30ccf8a77994", size = 380002, upload-time = "2026-04-10T14:27:26.155Z" },
+    { url = "https://files.pythonhosted.org/packages/50/02/3c05c1666c41904a2f607475a73e7a4763d1cbde2d18229c4f85b22dc253/jiter-0.14.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:80381f5a19af8fa9aef743f080e34f6b25ebd89656475f8cf0470ec6157052aa", size = 354678, upload-time = "2026-04-10T14:27:27.701Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/97/e15b33545c2b13518f560d695f974b9891b311641bdcf178d63177e8801e/jiter-0.14.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:004df5fdb8ecbd6d99f3227df18ba1a259254c4359736a2e6f036c944e02d7c5", size = 358920, upload-time = "2026-04-10T14:27:29.256Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/d2/8b1461def6b96ba44530df20d07ef7a1c7da22f3f9bf1727e2d611077bf1/jiter-0.14.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:cff5708f7ed0fa098f2b53446c6fa74c48469118e5cd7497b4f1cd569ab06928", size = 394512, upload-time = "2026-04-10T14:27:31.344Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/88/837566dd6ed6e452e8d3205355afd484ce44b2533edfa4ed73a298ea893e/jiter-0.14.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:2492e5f06c36a976d25c7cc347a60e26d5470178d44cde1b9b75e60b4e519f28", size = 521120, upload-time = "2026-04-10T14:27:33.299Z" },
+    { url = "https://files.pythonhosted.org/packages/89/6b/b00b45c4d1b4c031777fe161d620b755b5b02cdade1e316dcb46e4471d63/jiter-0.14.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:7609cfbe3a03d37bfdbf5052012d5a879e72b83168a363deae7b3a26564d57de", size = 553668, upload-time = "2026-04-10T14:27:34.868Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/d8/6fe5b42011d19397433d345716eac16728ac241862a2aac9c91923c7509a/jiter-0.14.0-cp314-cp314-win32.whl", hash = "sha256:7282342d32e357543565286b6450378c3cd402eea333fc1ebe146f1fabb306fc", size = 207001, upload-time = "2026-04-10T14:27:36.455Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/43/5c2e08da1efad5e410f0eaaabeadd954812612c33fbbd8fd5328b489139d/jiter-0.14.0-cp314-cp314-win_amd64.whl", hash = "sha256:bd77945f38866a448e73b0b7637366afa814d4617790ecd88a18ca74377e6c02", size = 202187, upload-time = "2026-04-10T14:27:38Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/1f/6e39ac0b4cdfa23e606af5b245df5f9adaa76f35e0c5096790da430ca506/jiter-0.14.0-cp314-cp314-win_arm64.whl", hash = "sha256:f2d4c61da0821ee42e0cdf5489da60a6d074306313a377c2b35af464955a3611", size = 192257, upload-time = "2026-04-10T14:27:39.504Z" },
+    { url = "https://files.pythonhosted.org/packages/05/57/7dbc0ffbbb5176a27e3518716608aa464aee2e2887dc938f0b900a120449/jiter-0.14.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1bf7ff85517dd2f20a5750081d2b75083c1b269cf75afc7511bdf1f9548beb3b", size = 323441, upload-time = "2026-04-10T14:27:41.039Z" },
+    { url = "https://files.pythonhosted.org/packages/83/6e/7b3314398d8983f06b557aa21b670511ec72d3b79a68ee5e4d9bff972286/jiter-0.14.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c8ef8791c3e78d6c6b157c6d360fbb5c715bebb8113bc6a9303c5caff012754a", size = 348109, upload-time = "2026-04-10T14:27:42.552Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/4f/8dc674bcd7db6dba566de73c08c763c337058baff1dbeb34567045b27cdc/jiter-0.14.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e74663b8b10da1fe0f4e4703fd7980d24ad17174b6bb35d8498d6e3ebce2ae6a", size = 368328, upload-time = "2026-04-10T14:27:44.574Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/5f/188e09a1f20906f98bbdec44ed820e19f4e8eb8aff88b9d1a5a497587ff3/jiter-0.14.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1aca29ba52913f78362ec9c2da62f22cdc4c3083313403f90c15460979b84d9b", size = 463301, upload-time = "2026-04-10T14:27:46.717Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/f0/19046ef965ed8f349e8554775bb12ff4352f443fbe12b95d31f575891256/jiter-0.14.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8b39b7d87a952b79949af5fef44d2544e58c21a28da7f1bae3ef166455c61746", size = 378891, upload-time = "2026-04-10T14:27:48.32Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/c3/da43bd8431ee175695777ee78cf0e93eacbb47393ff493f18c45231b427d/jiter-0.14.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:78d918a68b26e9fab068c2b5453577ef04943ab2807b9a6275df2a812599a310", size = 360749, upload-time = "2026-04-10T14:27:49.88Z" },
+    { url = "https://files.pythonhosted.org/packages/72/26/e054771be889707c6161dbdec9c23d33a9ec70945395d70f07cfea1e9a6f/jiter-0.14.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:b08997c35aee1201c1a5361466a8fb9162d03ae7bf6568df70b6c859f1e654a4", size = 358526, upload-time = "2026-04-10T14:27:51.504Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/0f/7bea65ea2a6d91f2bf989ff11a18136644392bf2b0497a1fa50934c30a9c/jiter-0.14.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:260bf7ca20704d58d41f669e5e9fe7fe2fa72901a6b324e79056f5d52e9c9be2", size = 393926, upload-time = "2026-04-10T14:27:53.368Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a1/b1ff7d70deef61ac0b7c6c2f12d2ace950cdeecb4fdc94500a0926802857/jiter-0.14.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:37826e3df29e60f30a382f9294348d0238ef127f4b5d7f5f8da78b5b9e050560", size = 521052, upload-time = "2026-04-10T14:27:55.058Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/7b/3b0649983cbaf15eda26a414b5b1982e910c67bd6f7b1b490f3cfc76896a/jiter-0.14.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:645be49c46f2900937ba0eaf871ad5183c96858c0af74b6becc7f4e367e36e06", size = 553716, upload-time = "2026-04-10T14:27:57.269Z" },
+    { url = "https://files.pythonhosted.org/packages/97/f8/33d78c83bd93ae0c0af05293a6660f88a1977caef39a6d72a84afab94ce0/jiter-0.14.0-cp314-cp314t-win32.whl", hash = "sha256:2f7877ed45118de283786178eceaf877110abacd04fde31efff3940ae9672674", size = 207957, upload-time = "2026-04-10T14:27:59.285Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/ac/2b760516c03e2227826d1f7025d89bf6bf6357a28fe75c2a2800873c50bf/jiter-0.14.0-cp314-cp314t-win_amd64.whl", hash = "sha256:14c0cb10337c49f5eafe8e7364daca5e29a020ea03580b8f8e6c597fed4e1588", size = 204690, upload-time = "2026-04-10T14:28:00.962Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/2e/a44c20c58aeed0355f2d326969a181696aeb551a25195f47563908a815be/jiter-0.14.0-cp314-cp314t-win_arm64.whl", hash = "sha256:5419d4aa2024961da9fe12a9cfe7484996735dca99e8e090b5c88595ef1951ff", size = 191338, upload-time = "2026-04-10T14:28:02.853Z" },
+    { url = "https://files.pythonhosted.org/packages/21/42/9042c3f3019de4adcb8c16591c325ec7255beea9fcd33a42a43f3b0b1000/jiter-0.14.0-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:fbd9e482663ca9d005d051330e4d2d8150bb208a209409c10f7e7dfdf7c49da9", size = 308810, upload-time = "2026-04-10T14:28:34.673Z" },
+    { url = "https://files.pythonhosted.org/packages/60/cf/a7e19b308bd86bb04776803b1f01a5f9a287a4c55205f4708827ee487fbf/jiter-0.14.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:33a20d838b91ef376b3a56896d5b04e725c7df5bc4864cc6569cf046a8d73b6d", size = 308443, upload-time = "2026-04-10T14:28:36.658Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/44/e26ede3f0caeff93f222559cb0cc4ca68579f07d009d7b6010c5b586f9b1/jiter-0.14.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:432c4db5255d86a259efde91e55cb4c8d18c0521d844c9e2e7efcce3899fb016", size = 343039, upload-time = "2026-04-10T14:28:38.356Z" },
+    { url = "https://files.pythonhosted.org/packages/da/e9/1f9ada30cef7b05e74bb06f52127e7a724976c225f46adb65c37b1dadfb6/jiter-0.14.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:67f00d94b281174144d6532a04b66a12cb866cbdc47c3af3bfe2973677f9861a", size = 349613, upload-time = "2026-04-10T14:28:40.066Z" },
 ]
 
 [[package]]
@@ -285,6 +431,25 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
+]
+
+[[package]]
+name = "openai"
+version = "2.32.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ed/59/bdcc6b759b8c42dd73afaf5bf8f902c04b37987a5514dbc1c64dba390fef/openai-2.32.0.tar.gz", hash = "sha256:c54b27a9e4cb8d51f0dd94972ffd1a04437efeb259a9e60d8922b8bd26fe55e0", size = 693286, upload-time = "2026-04-15T22:28:19.434Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/c1/d6e64ccd0536bf616556f0cad2b6d94a8125f508d25cfd814b1d2db4e2f1/openai-2.32.0-py3-none-any.whl", hash = "sha256:4dcc9badeb4bf54ad0d187453742f290226d30150890b7890711bda4f32f192f", size = 1162570, upload-time = "2026-04-15T22:28:17.714Z" },
 ]
 
 [[package]]
@@ -527,8 +692,11 @@ name = "santai-cli"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "anthropic" },
     { name = "fastapi" },
     { name = "jinja2" },
+    { name = "openai" },
+    { name = "python-dotenv" },
     { name = "python-multipart" },
     { name = "rich" },
     { name = "textual" },
@@ -545,8 +713,11 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "anthropic", specifier = ">=0.42.0" },
     { name = "fastapi", specifier = ">=0.110.0" },
     { name = "jinja2", specifier = ">=3.1.0" },
+    { name = "openai", specifier = ">=1.60.0" },
+    { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "python-multipart", specifier = ">=0.0.9" },
     { name = "rich", specifier = ">=13.0.0" },
     { name = "textual", specifier = ">=0.50.0" },
@@ -568,6 +739,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
+name = "sniffio"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
 ]
 
 [[package]]
@@ -598,6 +778,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/cf/2f/d44f0f12b3ddb1f0b88f7775652e99c6b5a43fd733badf4ce064bdbfef4a/textual-8.2.3.tar.gz", hash = "sha256:beea7b86b03b03558a2224f0cc35252e60ef8b0c4353b117b2f40972902d976a", size = 1848738, upload-time = "2026-04-05T09:12:45.338Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0e/28/a81d6ce9f4804818bd1231a9a6e4d56ea84ebbe8385c49591444f0234fa2/textual-8.2.3-py3-none-any.whl", hash = "sha256:5008ac581bebf1f6fa0520404261844a231e5715fdbddd10ca73916a3af48ca2", size = 724231, upload-time = "2026-04-05T09:12:48.747Z" },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.67.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Add a full-stack AI chat feature supporting **Anthropic** and **OpenAI** providers with async streaming responses
- Integrate chat across all three interfaces: **CLI REPL** (`santai chat`), **TUI modal** (`x` keybinding), and **Web dashboard** (chat panel with SSE streaming)
- Add provider-agnostic chat engine with config management, agent profiles, and model selection

## What's New

### Core Engine (`core/chat.py`, `core/config.py`)
- `ChatSession` manages conversation history with provider-specific message formatting
- `stream_response()` async generator abstracts over Anthropic/OpenAI streaming APIs
- Config loader reads `.env` files for API keys, validates providers, and exposes available models

### CLI (`commands/chat.py`)
- Interactive REPL with Rich Live markdown rendering for streamed responses
- Slash commands: `/agent`, `/model`, `/clear`, `/quit`, `/help`
- Interactive model picker with provider auto-detection from model name

### TUI (`tui/app.py` — `ChatScreen`)
- Modal chat screen with `RichLog` streaming display
- Provider/model/agent selection via Select widgets
- Accessible via `x` keybinding from the main dashboard

### Web (`web/app.py`, `web/templates/index.html`)
- `POST /api/chat` — SSE streaming endpoint for chat messages
- `GET /api/chat/models` / `GET /api/chat/agents` — Discovery endpoints
- Chat panel in web dashboard with real-time streaming, model/agent selectors, and markdown rendering

### Scaffold & Config
- `santai init` now generates `.env.example` and `.gitignore`
- New dependencies: `anthropic`, `openai`, `python-dotenv`
- Updated `AGENTS.md` with chat architecture documentation

## Configuration

Requires a `.env` file at the project root with at least one provider key:

```bash
ANTHROPIC_API_KEY=sk-ant-...
OPENAI_API_KEY=sk-...
```

See `.env.example` for the full template.