### PR TITLE
feat: add login, logout, and whoami commands

### DIFF
--- a/src/santai_cli/cli.py
+++ b/src/santai_cli/cli.py
@@ -10,7 +10,7 @@ from rich.panel import Panel
 from rich.table import Table
 from rich.text import Text
 
-from santai_cli.commands import chat, copy, history, init, merge, ui, web
+from santai_cli.commands import auth, chat, copy, history, init, merge, ui, web
 
 
 class _VerboseHelpGroup(typer.core.TyperGroup):
@@ -59,6 +59,9 @@ app.command(name="merge")(merge.merge)
 app.command(name="history")(history.history)
 app.command(name="ui")(ui.ui)
 app.command(name="web")(web.web)
+app.command(name="login")(auth.login)
+app.command(name="logout")(auth.logout)
+app.command(name="whoami")(auth.whoami)
 
 
 # ---------------------------------------------------------------------------

--- a/src/santai_cli/commands/auth.py
+++ b/src/santai_cli/commands/auth.py
@@ -1,0 +1,171 @@
+"""Authentication commands for Santai Hub."""
+
+from __future__ import annotations
+
+import json
+import socket
+import threading
+import webbrowser
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+from typing import Annotated
+from urllib.parse import parse_qs, urlparse
+
+import typer
+from rich.console import Console
+
+console = Console()
+
+CREDENTIALS_DIR = Path.home() / ".config" / "santai"
+CREDENTIALS_FILE = CREDENTIALS_DIR / "credentials.json"
+DEFAULT_HUB_URL = "http://localhost:3000"
+
+
+def _get_hub_url() -> str:
+    import os
+
+    return os.environ.get("SANTAI_HUB_URL", DEFAULT_HUB_URL)
+
+
+def _save_credentials(token: str, username: str, hub_url: str) -> None:
+    CREDENTIALS_DIR.mkdir(parents=True, exist_ok=True)
+    CREDENTIALS_FILE.write_text(
+        json.dumps({"token": token, "username": username, "hub_url": hub_url}),
+        encoding="utf-8",
+    )
+    CREDENTIALS_FILE.chmod(0o600)
+
+
+def load_credentials() -> dict[str, str] | None:
+    if not CREDENTIALS_FILE.is_file():
+        return None
+    try:
+        data = json.loads(CREDENTIALS_FILE.read_text(encoding="utf-8"))
+        if "token" in data:
+            return data
+    except (json.JSONDecodeError, OSError):
+        pass
+    return None
+
+
+def _clear_credentials() -> None:
+    if CREDENTIALS_FILE.is_file():
+        CREDENTIALS_FILE.unlink()
+
+
+def _find_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def login(
+    hub_url: Annotated[
+        str | None,
+        typer.Option("--hub-url", help="Santai Hub URL"),
+    ] = None,
+) -> None:
+    """Authenticate with Santai Hub via the browser."""
+    hub = hub_url or _get_hub_url()
+    port = _find_free_port()
+
+    result: dict[str, str] = {}
+    error: list[str] = []
+    server_ready = threading.Event()
+    got_callback = threading.Event()
+
+    class CallbackHandler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:
+            parsed = urlparse(self.path)
+            if parsed.path != "/callback":
+                self.send_response(404)
+                self.end_headers()
+                return
+
+            params = parse_qs(parsed.query)
+            token = params.get("token", [None])[0]
+            username = params.get("username", [None])[0]
+
+            if not token:
+                error.append("No token received")
+                self.send_response(400)
+                self.send_header("Content-Type", "text/html")
+                self.end_headers()
+                self.wfile.write(
+                    b"<html><body><h2>Authentication failed.</h2>"
+                    b"<p>No token received. You can close this tab.</p></body></html>"
+                )
+                got_callback.set()
+                return
+
+            result["token"] = token
+            result["username"] = username or ""
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html")
+            self.end_headers()
+            self.wfile.write(
+                b"<html><body><h2>Authenticated!</h2>"
+                b"<p>You can close this tab and return to your terminal.</p></body></html>"
+            )
+            got_callback.set()
+
+        def log_message(self, format: str, *args: object) -> None:
+            pass
+
+    server = HTTPServer(("127.0.0.1", port), CallbackHandler)
+
+    def run_server() -> None:
+        server_ready.set()
+        server.handle_request()
+
+    thread = threading.Thread(target=run_server, daemon=True)
+    thread.start()
+    server_ready.wait()
+
+    auth_url = f"{hub}/auth/cli?callback_port={port}"
+    console.print(f"Opening browser to authenticate...")
+    console.print(f"  [dim]{auth_url}[/dim]\n")
+    webbrowser.open(auth_url)
+    console.print("Waiting for authentication (press Ctrl+C to cancel)...")
+
+    try:
+        got_callback.wait(timeout=120)
+    except KeyboardInterrupt:
+        console.print("\n[yellow]Login cancelled.[/yellow]")
+        server.server_close()
+        raise typer.Exit(1)
+
+    server.server_close()
+
+    if error:
+        console.print(f"[red]Login failed: {error[0]}[/red]")
+        raise typer.Exit(1)
+
+    if not result.get("token"):
+        console.print("[red]Login timed out. Please try again.[/red]")
+        raise typer.Exit(1)
+
+    _save_credentials(result["token"], result.get("username", ""), hub)
+    console.print(f"[green]Logged in as {result.get('username', 'unknown')}[/green]")
+
+
+def logout() -> None:
+    """Log out of Santai Hub."""
+    creds = load_credentials()
+    if not creds:
+        console.print("Not currently logged in.")
+        return
+    _clear_credentials()
+    console.print("[green]Logged out successfully.[/green]")
+
+
+def whoami() -> None:
+    """Show the currently authenticated user."""
+    creds = load_credentials()
+    if not creds:
+        console.print("Not logged in. Run [bold]santai login[/bold] to authenticate.")
+        raise typer.Exit(1)
+
+    hub = creds.get("hub_url", DEFAULT_HUB_URL)
+    console.print(f"Logged in as [bold]{creds.get('username', 'unknown')}[/bold]")
+    console.print(f"  Hub: [dim]{hub}[/dim]")

--- a/src/santai_cli/commands/auth.py
+++ b/src/santai_cli/commands/auth.py
@@ -165,11 +165,39 @@ def logout() -> None:
 
 def whoami() -> None:
     """Show the currently authenticated user."""
+    import urllib.request
+    import urllib.error
+
     creds = load_credentials()
     if not creds:
         console.print("Not logged in. Run [bold]santai login[/bold] to authenticate.")
         raise typer.Exit(1)
 
     hub = creds.get("hub_url", DEFAULT_HUB_URL)
-    console.print(f"Logged in as [bold]{creds.get('username', 'unknown')}[/bold]")
-    console.print(f"  Hub: [dim]{hub}[/dim]")
+    backend = hub.replace(":3000", ":3001") if ":3000" in hub else hub
+
+    try:
+        req = urllib.request.Request(
+            f"{backend}/api/auth/get-session",
+            headers={"Authorization": f"Bearer {creds['token']}"},
+        )
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            data = json.loads(resp.read())
+            user = data.get("user", {})
+            session = data.get("session", {})
+            console.print(f"Logged in as [bold]{user.get('username', creds.get('username', 'unknown'))}[/bold]")
+            console.print(f"  Name:  {user.get('name', 'N/A')}")
+            console.print(f"  Email: {user.get('email', 'N/A')}")
+            console.print(f"  Hub:   [dim]{hub}[/dim]")
+            if session.get("expiresAt"):
+                console.print(f"  Expires: [dim]{session['expiresAt']}[/dim]")
+    except urllib.error.HTTPError as e:
+        if e.code == 401:
+            console.print("[yellow]Session expired. Run [bold]santai login[/bold] to re-authenticate.[/yellow]")
+            _clear_credentials()
+            raise typer.Exit(1)
+        console.print(f"[red]Failed to verify session: HTTP {e.code}[/red]")
+        raise typer.Exit(1)
+    except (urllib.error.URLError, TimeoutError):
+        console.print(f"Logged in as [bold]{creds.get('username', 'unknown')}[/bold]  [dim](offline — could not reach hub)[/dim]")
+        console.print(f"  Hub: [dim]{hub}[/dim]")

--- a/src/santai_cli/commands/auth.py
+++ b/src/santai_cli/commands/auth.py
@@ -64,10 +64,14 @@ def login(
         str | None,
         typer.Option("--hub-url", help="Santai Hub URL"),
     ] = None,
+    port: Annotated[
+        int | None,
+        typer.Option("--port", "-p", help="Fixed port for callback server (useful for SSH tunneling)"),
+    ] = None,
 ) -> None:
     """Authenticate with Santai Hub via the browser."""
     hub = hub_url or _get_hub_url()
-    port = _find_free_port()
+    port = port or _find_free_port()
 
     result: dict[str, str] = {}
     error: list[str] = []


### PR DESCRIPTION
## Summary

- `santai login` — opens the Hub in a browser, starts a local callback server, stores the bearer token in `~/.config/santai/credentials.json`
- `santai logout` — clears stored credentials
- `santai whoami` — verifies token against the server, shows username/email/expiry, auto-clears on expired sessions, falls back to local data when offline
- `--port` flag on login for SSH tunneling scenarios
- `--hub-url` flag and `SANTAI_HUB_URL` env var for custom hub URLs
- `load_credentials()` exported for use by future hub API commands

## How it works

1. `santai login` finds a free port (or uses `--port`), starts an HTTP server on localhost
2. Opens `{hub}/auth/cli?callback_port=PORT` in the browser
3. User authenticates on the Hub website
4. Hub redirects to `http://localhost:PORT/callback?token=TOKEN&username=USERNAME`
5. CLI captures the token, stores it in `~/.config/santai/credentials.json` (mode 0600)
6. Future commands can use `load_credentials()` to attach the bearer token to API calls

## Test plan

- [x] `santai login` opens browser and completes auth flow
- [x] `santai whoami` shows user info from server
- [x] `santai logout` clears credentials
- [x] `santai whoami` after logout shows "Not logged in"
- [x] Bearer token works on protected hub endpoints

Depends on: santai-inc/santai-hub#62

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)