### PR TITLE
feat: add push and pull commands for cloud sync

### DIFF
--- a/src/santai_cli/cli.py
+++ b/src/santai_cli/cli.py
@@ -10,7 +10,7 @@ from rich.panel import Panel
 from rich.table import Table
 from rich.text import Text
 
-from santai_cli.commands import auth, chat, copy, history, init, merge, ui, web
+from santai_cli.commands import auth, chat, copy, history, init, merge, pull, push, ui, web
 
 
 class _VerboseHelpGroup(typer.core.TyperGroup):
@@ -59,6 +59,8 @@ app.command(name="merge")(merge.merge)
 app.command(name="history")(history.history)
 app.command(name="ui")(ui.ui)
 app.command(name="web")(web.web)
+app.command(name="push")(push.push)
+app.command(name="pull")(pull.pull)
 app.command(name="login")(auth.login)
 app.command(name="logout")(auth.logout)
 app.command(name="whoami")(auth.whoami)

--- a/src/santai_cli/commands/pull.py
+++ b/src/santai_cli/commands/pull.py
@@ -1,0 +1,121 @@
+"""Pull a Santai project from the cloud."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import zipfile
+from pathlib import Path
+from typing import Annotated
+
+import typer
+from rich.console import Console
+
+from santai_cli.commands.auth import DEFAULT_HUB_URL, load_credentials
+
+console = Console()
+
+
+def _get_backend_url(hub_url: str) -> str:
+    return hub_url.replace(":3000", ":3001") if ":3000" in hub_url else hub_url
+
+
+def _format_size(size_bytes: int) -> str:
+    if size_bytes < 1024:
+        return f"{size_bytes} B"
+    if size_bytes < 1024 * 1024:
+        return f"{size_bytes / 1024:.1f} KB"
+    return f"{size_bytes / (1024 * 1024):.1f} MB"
+
+
+def pull(
+    name: Annotated[
+        str,
+        typer.Argument(help="Project name to pull"),
+    ],
+    dest: Annotated[
+        str | None,
+        typer.Option("--dest", "-d", help="Destination directory"),
+    ] = None,
+) -> None:
+    """Pull a Santai project from the cloud."""
+    import urllib.error
+    import urllib.request
+
+    creds = load_credentials()
+    if not creds:
+        console.print("Not logged in. Run [bold]santai login[/bold] first.")
+        raise typer.Exit(1)
+
+    dest_path = Path(dest or name).resolve()
+
+    if dest_path.exists():
+        console.print(f"[red]Error: '{dest_path}' already exists.[/red]")
+        raise typer.Exit(1)
+
+    hub = creds.get("hub_url", DEFAULT_HUB_URL)
+    backend = _get_backend_url(hub)
+
+    console.print(f"Looking up [bold]{name}[/bold]...")
+
+    req = urllib.request.Request(
+        f"{backend}/santai-repos/download/{name}",
+        headers={"Authorization": f"Bearer {creds['token']}"},
+    )
+
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            data = json.loads(resp.read())
+    except urllib.error.HTTPError as e:
+        if e.code == 401:
+            console.print(
+                "[yellow]Session expired. Run [bold]santai login[/bold] to re-authenticate.[/yellow]"
+            )
+            raise typer.Exit(1)
+        if e.code == 404:
+            console.print(f"[red]Project '{name}' not found.[/red]")
+            raise typer.Exit(1)
+        console.print(f"[red]Pull failed (HTTP {e.code})[/red]")
+        raise typer.Exit(1)
+    except (urllib.error.URLError, TimeoutError):
+        console.print("[red]Could not reach the hub. Check your connection.[/red]")
+        raise typer.Exit(1)
+
+    download_url = data.get("downloadUrl")
+    if not download_url:
+        console.print("[red]No download URL received.[/red]")
+        raise typer.Exit(1)
+
+    size = data.get("size", 0)
+    console.print(f"  Found ({_format_size(size)}). Downloading...")
+
+    with tempfile.NamedTemporaryFile(suffix=".zip", delete=False) as tmp:
+        tmp_path = Path(tmp.name)
+
+    try:
+        dl_req = urllib.request.Request(download_url)
+        with urllib.request.urlopen(dl_req, timeout=120) as resp:
+            tmp_path.write_bytes(resp.read())
+
+        console.print("Extracting...")
+
+        dest_path.mkdir(parents=True, exist_ok=True)
+
+        with zipfile.ZipFile(tmp_path, "r") as zf:
+            zf.extractall(dest_path)
+
+        console.print(
+            f"[green]Pulled [bold]{name}[/bold] to {dest_path}[/green]"
+        )
+    except (urllib.error.URLError, TimeoutError):
+        console.print("[red]Download failed. The URL may have expired — try again.[/red]")
+        if dest_path.exists() and not any(dest_path.iterdir()):
+            dest_path.rmdir()
+        raise typer.Exit(1)
+    except zipfile.BadZipFile:
+        console.print("[red]Downloaded file is not a valid zip.[/red]")
+        if dest_path.exists() and not any(dest_path.iterdir()):
+            dest_path.rmdir()
+        raise typer.Exit(1)
+    finally:
+        tmp_path.unlink(missing_ok=True)

--- a/src/santai_cli/commands/push.py
+++ b/src/santai_cli/commands/push.py
@@ -1,0 +1,163 @@
+"""Push a Santai project to the cloud."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import zipfile
+from pathlib import Path
+from typing import Annotated
+from urllib.parse import quote
+
+import typer
+from rich.console import Console
+
+from santai_cli.commands.auth import DEFAULT_HUB_URL, load_credentials
+from santai_cli.core.project import is_santai_project
+
+console = Console()
+
+IGNORED_DIRECTORIES = {
+    ".git",
+    ".ruff_cache",
+    ".rumdl_cache",
+    "__pycache__",
+    ".venv",
+    "node_modules",
+}
+
+MAX_UPLOAD_BYTES = 50 * 1024 * 1024
+
+
+def _should_include(path: Path) -> bool:
+    return not any(part in IGNORED_DIRECTORIES for part in path.parts)
+
+
+def _get_backend_url(hub_url: str) -> str:
+    return hub_url.replace(":3000", ":3001") if ":3000" in hub_url else hub_url
+
+
+def _format_size(size_bytes: int) -> str:
+    if size_bytes < 1024:
+        return f"{size_bytes} B"
+    if size_bytes < 1024 * 1024:
+        return f"{size_bytes / 1024:.1f} KB"
+    return f"{size_bytes / (1024 * 1024):.1f} MB"
+
+
+def push(
+    name: Annotated[
+        str | None,
+        typer.Argument(help="Project name (defaults to directory name)"),
+    ] = None,
+) -> None:
+    """Push the current Santai project to the cloud."""
+    import urllib.error
+    import urllib.request
+
+    project_dir = Path.cwd()
+
+    if not is_santai_project(project_dir):
+        console.print("[red]Error: Not a Santai project.[/red]")
+        console.print(
+            "[yellow]A Santai project must have resources/, codebases/, history/, "
+            "and notes/ directories.[/yellow]"
+        )
+        raise typer.Exit(1)
+
+    creds = load_credentials()
+    if not creds:
+        console.print("Not logged in. Run [bold]santai login[/bold] first.")
+        raise typer.Exit(1)
+
+    project_name = name or project_dir.name
+    hub = creds.get("hub_url", DEFAULT_HUB_URL)
+    backend = _get_backend_url(hub)
+
+    console.print(f"Packaging [bold]{project_name}[/bold]...")
+
+    with tempfile.NamedTemporaryFile(suffix=".zip", delete=False) as tmp:
+        tmp_path = Path(tmp.name)
+
+    try:
+        with zipfile.ZipFile(tmp_path, "w", zipfile.ZIP_DEFLATED) as zf:
+            for file_path in sorted(project_dir.rglob("*")):
+                if not file_path.is_file():
+                    continue
+                rel = file_path.relative_to(project_dir)
+                if not _should_include(rel):
+                    continue
+                zf.write(file_path, rel)
+
+        zip_size = tmp_path.stat().st_size
+
+        if zip_size > MAX_UPLOAD_BYTES:
+            console.print(
+                f"[red]Error: Archive is {_format_size(zip_size)}, "
+                f"exceeds the 50 MB limit.[/red]"
+            )
+            raise typer.Exit(1)
+
+        console.print(f"  Archive size: {_format_size(zip_size)}")
+        console.print("Uploading...")
+
+        zip_bytes = tmp_path.read_bytes()
+
+        boundary = "----SantaiUploadBoundary"
+        body_parts: list[bytes] = []
+
+        body_parts.append(f"--{boundary}\r\n".encode())
+        body_parts.append(
+            f'Content-Disposition: form-data; name="repoZip"; filename="{quote(project_name)}.zip"\r\n'.encode()
+        )
+        body_parts.append(b"Content-Type: application/zip\r\n\r\n")
+        body_parts.append(zip_bytes)
+        body_parts.append(b"\r\n")
+
+        body_parts.append(f"--{boundary}\r\n".encode())
+        body_parts.append(
+            b'Content-Disposition: form-data; name="repoName"\r\n\r\n'
+        )
+        body_parts.append(project_name.encode())
+        body_parts.append(b"\r\n")
+
+        body_parts.append(f"--{boundary}--\r\n".encode())
+
+        body = b"".join(body_parts)
+
+        req = urllib.request.Request(
+            f"{backend}/santai-repos/upload",
+            data=body,
+            method="POST",
+            headers={
+                "Authorization": f"Bearer {creds['token']}",
+                "Content-Type": f"multipart/form-data; boundary={boundary}",
+            },
+        )
+
+        try:
+            with urllib.request.urlopen(req, timeout=120) as resp:
+                data = json.loads(resp.read())
+                console.print(
+                    f"[green]Pushed [bold]{project_name}[/bold] "
+                    f"({_format_size(data.get('size', zip_size))})[/green]"
+                )
+        except urllib.error.HTTPError as e:
+            if e.code == 401:
+                console.print(
+                    "[yellow]Session expired. Run [bold]santai login[/bold] to re-authenticate.[/yellow]"
+                )
+                raise typer.Exit(1)
+            body_text = e.read().decode(errors="replace")
+            try:
+                err_data = json.loads(body_text)
+                msg = err_data.get("error", body_text)
+            except json.JSONDecodeError:
+                msg = body_text
+            console.print(f"[red]Push failed (HTTP {e.code}): {msg}[/red]")
+            raise typer.Exit(1)
+        except (urllib.error.URLError, TimeoutError):
+            console.print("[red]Could not reach the hub. Check your connection.[/red]")
+            raise typer.Exit(1)
+    finally:
+        tmp_path.unlink(missing_ok=True)


### PR DESCRIPTION
## Summary
- Add `santai push` command to upload the current project as a zip archive to S3 via the hub's `/santai-repos/upload` endpoint
- Add `santai pull` command to download and extract a project from S3 via presigned URLs from `/santai-repos/download/:name`
- Register both commands in the CLI

## Details
- Push creates a zip (excluding `.git`, `__pycache__`, `.venv`, `.ruff_cache`, `.rumdl_cache`, `node_modules`), validates size < 50MB, and uploads via multipart form with bearer token auth
- Pull fetches a presigned S3 download URL, downloads the zip, and extracts to a local directory
- Uses only stdlib (`zipfile`, `urllib.request`, `tempfile`) — no new dependencies
- Requires the hub's bearer auth plugin and santai-repos module (both merged to hub main)

## Test plan
- [ ] `santai push` from a santai project directory uploads successfully
- [ ] `santai push myname` uses custom name instead of directory name
- [ ] `santai push` outside a santai project shows error
- [ ] `santai push` without login shows "not logged in" error
- [ ] `santai pull <name>` downloads and extracts to `./<name>/`
- [ ] `santai pull <name> --dest /path` extracts to custom destination
- [ ] `santai pull <name>` when destination exists shows error
- [ ] `santai pull nonexistent` shows "not found" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)