### PR TITLE
feat: repository awareness for chat sessions

### DIFF
--- a/src/santai_cli/commands/chat.py
+++ b/src/santai_cli/commands/chat.py
@@ -23,7 +23,8 @@ from santai_cli.core.config import (
     load_agent_prompt,
     load_config,
 )
-from santai_cli.core.project import get_project
+from santai_cli.core.project import SantaiProject, get_project
+from santai_cli.core.repo_context import build_repo_context, inject_repo_context
 
 console = Console()
 
@@ -37,6 +38,7 @@ class _ChatState:
     provider: str
     model: str
     agent: str | None
+    project: SantaiProject | None = None
 
 
 def chat(
@@ -105,6 +107,12 @@ def chat(
             _print_available_agents()
             raise typer.Exit(1)
 
+    # Inject repository context if in a Santai project
+    if project:
+        repo_context = build_repo_context(project)
+        system_prompt = inject_repo_context(system_prompt, repo_context)
+        console.print(f"[dim]Repository context loaded: {project.root.name}[/]")
+
     # Select model (interactive or from flag)
     provider, selected_model = _select_model(config, model)
     if provider is None or selected_model is None:
@@ -118,7 +126,7 @@ def chat(
 
     # Enter REPL loop
     try:
-        _repl_loop(session, config, provider, selected_model, active_agent)
+        _repl_loop(session, config, provider, selected_model, active_agent, project)
     except KeyboardInterrupt:
         console.print("\n[dim]Chat ended.[/]")
 
@@ -244,6 +252,7 @@ def _repl_loop(
     provider: str,
     model: str,
     agent: str | None,
+    project: SantaiProject | None = None,
 ) -> None:
     """Main REPL loop for the chat."""
     state = _ChatState(
@@ -252,6 +261,7 @@ def _repl_loop(
         provider=provider,
         model=model,
         agent=agent,
+        project=project,
     )
 
     while True:
@@ -323,6 +333,9 @@ def _handle_command(command: str, state: _ChatState) -> str:
                 console.print(f"[red]Agent '{arg}' not found.[/]")
                 _print_available_agents()
             else:
+                if state.project:
+                    repo_context = build_repo_context(state.project)
+                    new_prompt = inject_repo_context(new_prompt, repo_context)
                 state.session = ChatSession(system_prompt=new_prompt)
                 state.agent = arg
                 console.print(f"[dim]Switched to agent: {arg}. History cleared.[/]\n")

--- a/src/santai_cli/core/repo_context.py
+++ b/src/santai_cli/core/repo_context.py
@@ -1,0 +1,273 @@
+"""Repository context builder for chat sessions.
+
+Provides functions to generate a comprehensive context about the project
+that can be injected into chat system prompts, giving AI models awareness
+of all files and content in the repository.
+"""
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from santai_cli.core.project import (
+    SantaiProject,
+    get_history_entries,
+    get_notes,
+)
+
+
+@dataclass
+class RepoContext:
+    """Complete repository context for a Santai project."""
+
+    project: SantaiProject
+    file_tree: str
+    wiki_content: str
+    notes_content: str
+    history_content: str
+    resources_summary: str
+
+
+def _build_file_tree(root: Path, max_depth: int = 4) -> str:
+    """Build a tree representation of the project directory.
+
+    Args:
+        root: The root directory to tree.
+        max_depth: Maximum depth to traverse.
+
+    Returns:
+        A string representation of the directory tree.
+    """
+    lines = [f"{root.name}/"]
+
+    def _walk(path: Path, prefix: str = "", depth: int = 0) -> list[str]:
+        if depth >= max_depth:
+            return []
+
+        try:
+            entries = sorted(path.iterdir(), key=lambda x: (not x.is_dir(), x.name))
+        except PermissionError:
+            return []
+
+        result = []
+        entries = [e for e in entries if not e.name.startswith(".")]
+
+        for i, entry in enumerate(entries):
+            is_last = i == len(entries) - 1
+            current_prefix = "└── " if is_last else "├── "
+            result.append(f"{prefix}{current_prefix}{entry.name}")
+
+            if entry.is_dir():
+                extension = "    " if is_last else "│   "
+                result.extend(_walk(entry, prefix + extension, depth + 1))
+
+        return result
+
+    lines.extend(_walk(root))
+    return "\n".join(lines)
+
+
+def _format_wiki_content(project: SantaiProject, max_entries: int = 10) -> str:
+    """Format wiki entries for context.
+
+    Args:
+        project: The Santai project.
+        max_entries: Maximum number of wiki entries to include.
+
+    Returns:
+        Formatted wiki content string.
+    """
+    wiki_path = project.wiki_path
+    if not wiki_path.is_dir():
+        return ""
+
+    entries = []
+    for file_path in sorted(wiki_path.glob("*.md"))[:max_entries]:
+        try:
+            content = file_path.read_text(encoding="utf-8")
+            title = file_path.stem.replace("-", " ").replace("_", " ").title()
+            preview = content[:500] + "..." if len(content) > 500 else content
+            entries.append(f"## {title}\n{preview}\n")
+        except (OSError, UnicodeDecodeError):
+            continue
+
+    if not entries:
+        return ""
+
+    return f"## Wiki Content\n\n{'=' * 40}\n\n" + "\n\n".join(entries)
+
+
+def _format_notes_content(project: SantaiProject, max_entries: int = 10) -> str:
+    """Format note entries for context.
+
+    Args:
+        project: The Santai project.
+        max_entries: Maximum number of notes to include.
+
+    Returns:
+        Formatted notes content string.
+    """
+    notes = get_notes(project)
+    if not notes:
+        return ""
+
+    entries = []
+    for note in notes[:max_entries]:
+        preview = note.preview if note.preview else note.content[:300]
+        entries.append(f"## {note.title}\n{preview}\n")
+
+    return f"## Notes\n\n{'=' * 40}\n\n" + "\n\n".join(entries)
+
+
+def _format_history_content(project: SantaiProject, max_entries: int = 10) -> str:
+    """Format history entries for context.
+
+    Args:
+        project: The Santai project.
+        max_entries: Maximum number of history entries to include.
+
+    Returns:
+        Formatted history content string.
+    """
+    history = get_history_entries(project)
+    if not history:
+        return ""
+
+    entries = []
+    for entry in history[:max_entries]:
+        content = entry.content
+        preview = content[:500] + "..." if len(content) > 500 else content
+        entries.append(f"## {entry.title} ({entry.date})\n{preview}\n")
+
+    return f"## History\n\n{'=' * 40}\n\n" + "\n\n".join(entries)
+
+
+def _get_resources_summary(project: SantaiProject) -> str:
+    """Get a summary of resources in the project.
+
+    Args:
+        project: The Santai project.
+
+    Returns:
+        Summary string of resources.
+    """
+    resources_path = project.resources_path
+    codebases_path = project.codebases_path
+
+    summary_parts = []
+
+    if resources_path.is_dir():
+        files = [f for f in resources_path.rglob("*") if f.is_file()]
+        if files:
+            summary_parts.append(f"Resources ({len(files)} files):")
+            for f in sorted(files)[:20]:
+                rel = f.relative_to(resources_path)
+                summary_parts.append(f"  - {rel}")
+
+    if codebases_path.is_dir():
+        repos = [d for d in codebases_path.iterdir() if d.is_dir()]
+        if repos:
+            summary_parts.append(f"\nCodebases ({len(repos)} repositories):")
+            for repo in sorted(repos)[:10]:
+                summary_parts.append(f"  - {repo.name}/")
+
+    if not summary_parts:
+        return ""
+
+    return f"## Resources Summary\n\n{'=' * 40}\n\n" + "\n".join(summary_parts)
+
+
+def build_repo_context(project: SantaiProject) -> RepoContext:
+    """Build a comprehensive context for a Santai project.
+
+    This function scans the project directory and generates structured
+    context including:
+    - File tree structure
+    - Wiki content (most recent entries)
+    - Notes content (most recent entries)
+    - History content (most recent entries)
+    - Resources summary
+
+    Args:
+        project: The Santai project to build context for.
+
+    Returns:
+        A RepoContext object containing all project context.
+    """
+    return RepoContext(
+        project=project,
+        file_tree=_build_file_tree(project.root),
+        wiki_content=_format_wiki_content(project),
+        notes_content=_format_notes_content(project),
+        history_content=_format_history_content(project),
+        resources_summary=_get_resources_summary(project),
+    )
+
+
+def build_repo_context_prompt(context: RepoContext) -> str:
+    """Build a system prompt segment with repository context.
+
+    This generates a formatted prompt that provides the AI model with
+    awareness of the entire repository structure and key content.
+
+    Args:
+        context: The pre-built repository context.
+
+    Returns:
+        A formatted string suitable for inclusion in a system prompt.
+    """
+    sections = [
+        "## Repository Context",
+        "",
+        (
+            "You have access to this Santai project. "
+            "Below is its structure and key content:"
+        ),
+        "",
+        "### File Tree",
+        f"```\n{context.file_tree}\n```",
+    ]
+
+    if context.wiki_content:
+        sections.extend(["", context.wiki_content])
+
+    if context.notes_content:
+        sections.extend(["", context.notes_content])
+
+    if context.history_content:
+        sections.extend(["", context.history_content])
+
+    if context.resources_summary:
+        sections.extend(["", context.resources_summary])
+
+    sections.extend(
+        [
+            "",
+            "## Important Guidelines",
+            "- You have full visibility into this project's structure and content.",
+            "- When answering questions, reference relevant files and content from above.",
+            "- Use [[wikilinks]] or markdown links when referencing project files.",
+        ]
+    )
+
+    return "\n".join(sections)
+
+
+def inject_repo_context(session_system_prompt: str | None, context: RepoContext) -> str:
+    """Inject repository context into a system prompt.
+
+    If an existing system prompt is provided, the repo context is appended
+    to it. If no system prompt exists, only the repo context is returned.
+
+    Args:
+        session_system_prompt: Optional existing system prompt.
+        context: The repository context to inject.
+
+    Returns:
+        The combined system prompt with repository context.
+    """
+    repo_prompt = build_repo_context_prompt(context)
+
+    if not session_system_prompt:
+        return repo_prompt
+
+    return f"{session_system_prompt}\n\n{repo_prompt}"

--- a/src/santai_cli/core/repo_context.py
+++ b/src/santai_cli/core/repo_context.py
@@ -243,8 +243,8 @@ def build_repo_context_prompt(context: RepoContext) -> str:
         [
             "",
             "## Important Guidelines",
-            "- You have full visibility into this project's structure and content.",
-            "- When answering questions, reference relevant files and content from above.",
+            ("- You have full visibility into this project's structure and content."),
+            ("- When answering questions, reference relevant files and content."),
             "- Use [[wikilinks]] or markdown links when referencing project files.",
         ]
     )

--- a/src/santai_cli/web/app.py
+++ b/src/santai_cli/web/app.py
@@ -18,6 +18,7 @@ from santai_cli.core.project import (
     get_history_entries,
     get_notes,
 )
+from santai_cli.core.repo_context import build_repo_context, inject_repo_context
 
 # Templates and static directories
 TEMPLATES_DIR = Path(__file__).parent / "templates"
@@ -704,6 +705,10 @@ def create_app(project: SantaiProject) -> FastAPI:
         if req.agent:
             system_prompt = load_agent_prompt(req.agent)
 
+        # Inject repository context
+        repo_context = build_repo_context(project)
+        system_prompt = inject_repo_context(system_prompt, repo_context)
+
         session = ChatSession(system_prompt=system_prompt)
         for msg in req.messages:
             if msg.get("role") == "user":
@@ -780,7 +785,6 @@ def create_app(project: SantaiProject) -> FastAPI:
     @app.post("/api/settings")
     async def save_settings(req: SettingsRequest) -> dict[str, str]:
         """Save API keys to the project .env file."""
-        import os
 
         from dotenv import dotenv_values, load_dotenv
 

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -2635,37 +2635,119 @@
 
         .chat-msg.user {
             align-self: flex-end;
-            background: var(--accent, rgba(0, 122, 255, 0.15));
+            background: linear-gradient(135deg, rgba(62, 180, 137, 0.15), rgba(62, 180, 137, 0.1));
             color: var(--text-primary);
             border-bottom-right-radius: 4px;
+            padding: 10px 14px;
+            line-height: 1.5;
         }
 
         .chat-msg.assistant {
             align-self: flex-start;
-            background: rgba(0, 0, 0, 0.04);
+            background: rgba(255, 255, 255, 0.6);
             color: var(--text-primary);
             border-bottom-left-radius: 4px;
+            padding: 12px 16px;
+        }
+
+        .chat-msg.assistant {
+            line-height: 1.6;
+        }
+
+        .chat-msg.assistant > *:first-child {
+            margin-top: 0;
+        }
+
+        .chat-msg.assistant > *:last-child {
+            margin-bottom: 0;
         }
 
         .chat-msg.assistant p {
-            margin: 0 0 8px 0;
+            margin: 0 0 10px 0;
         }
 
-        .chat-msg.assistant p:last-child {
-            margin-bottom: 0;
+        .chat-msg.assistant h1, 
+        .chat-msg.assistant h2, 
+        .chat-msg.assistant h3,
+        .chat-msg.assistant h4 {
+            margin: 16px 0 8px 0;
+            font-weight: 600;
+            line-height: 1.3;
+        }
+
+        .chat-msg.assistant h1 { font-size: 16px; }
+        .chat-msg.assistant h2 { font-size: 15px; }
+        .chat-msg.assistant h3 { font-size: 14px; }
+
+        .chat-msg.assistant ul,
+        .chat-msg.assistant ol {
+            margin: 8px 0;
+            padding-left: 20px;
+        }
+
+        .chat-msg.assistant li {
+            margin: 4px 0;
+        }
+
+        .chat-msg.assistant a {
+            color: var(--accent);
+            text-decoration: none;
+        }
+
+        .chat-msg.assistant a:hover {
+            text-decoration: underline;
         }
 
         .chat-msg.assistant pre {
             background: rgba(0, 0, 0, 0.06);
-            padding: 8px 12px;
+            padding: 12px 14px;
             border-radius: 8px;
             overflow-x: auto;
             font-size: 12px;
+            margin: 10px 0;
         }
 
         .chat-msg.assistant code {
-            font-family: "SF Mono", "Fira Code", monospace;
+            font-family: "SF Mono", "Fira Code", Consolas, monospace;
             font-size: 12px;
+        }
+
+        .chat-msg.assistant :not(pre) > code {
+            background: rgba(0, 0, 0, 0.06);
+            padding: 2px 5px;
+            border-radius: 4px;
+        }
+
+        .chat-msg.assistant blockquote {
+            border-left: 3px solid var(--accent);
+            margin: 10px 0;
+            padding: 8px 12px;
+            background: rgba(0, 0, 0, 0.03);
+            border-radius: 0 6px 6px 0;
+            color: var(--text-secondary);
+        }
+
+        .chat-msg.assistant hr {
+            border: none;
+            border-top: 1px solid rgba(0, 0, 0, 0.1);
+            margin: 16px 0;
+        }
+
+        .chat-msg.assistant table {
+            border-collapse: collapse;
+            margin: 10px 0;
+            font-size: 12px;
+        }
+
+        .chat-msg.assistant th,
+        .chat-msg.assistant td {
+            border: 1px solid rgba(0, 0, 0, 0.1);
+            padding: 6px 10px;
+            text-align: left;
+        }
+
+        .chat-msg.assistant th {
+            background: rgba(0, 0, 0, 0.04);
         }
 
         .chat-msg.system {
@@ -2726,13 +2808,27 @@
             font-size: 13px;
         }
 
+        /* Chat streaming indicator */
+        .chat-msg.assistant.streaming::after {
+            content: '▊';
+            animation: blink 0.8s infinite;
+            color: var(--accent);
+            margin-left: 4px;
+        }
+
+        @keyframes blink {
+            0%, 100% { opacity: 1; }
+            50% { opacity: 0; }
+        }
+
         /* Simple theme overrides for chat */
         body.simple-theme .chat-msg.user {
-            background: rgba(0, 122, 255, 0.1);
+            background: rgba(62, 180, 137, 0.15);
         }
 
         body.simple-theme .chat-msg.assistant {
-            background: rgba(0, 0, 0, 0.03);
+            background: white;
+            border: 1px solid rgba(0, 0, 0, 0.08);
         }
 
         body.simple-theme .chat-input-row input {
@@ -3168,6 +3264,16 @@
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
 
     <script>
+        // Configure marked for security and proper rendering
+        if (typeof marked !== 'undefined') {
+            marked.setOptions({
+                breaks: true,
+                gfm: true,
+                headerIds: false,
+                mangle: false
+            });
+        }
+
         // Theme Management - 2 themes: simple (light) and glass
         function setTheme(theme) {
             document.documentElement.setAttribute('data-theme', theme);
@@ -5295,6 +5401,7 @@
 
             // Create the assistant message element for streaming
             const assistantDiv = appendChatMessage('assistant', '');
+            assistantDiv.classList.add('streaming');
             let fullResponse = '';
 
             try {
@@ -5358,6 +5465,7 @@
                 assistantDiv.innerHTML = `<span style="color: red;">Error: ${e.message}</span>`;
                 console.error('Chat error:', e);
             } finally {
+                assistantDiv.classList.remove('streaming');
                 chatStreaming = false;
                 inputEl.disabled = false;
                 sendBtn.disabled = false;


### PR DESCRIPTION
## Summary
- Add comprehensive repository context to chat sessions (CLI and web)
- Context includes file tree, wiki, notes, history, and resources
- Improve chat message rendering with markdown styling

## Changes
- `core/repo_context.py` (new): Build and inject repo context into system prompts
- `commands/chat.py`: Inject context on session start and agent switch
- `web/app.py`: Inject context into web chat API
- `web/templates/index.html`: Pretty markdown rendering for chat messages

## Testing
- CLI chat: Working with repo context
- Web chat: Working with repo context
- Both: Pretty markdown rendering