### PR TITLE
docs: add MkDocs documentation site

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ wheels/
 
 # Environment secrets
 .env
+
+# MkDocs build output
+site/

--- a/README.md
+++ b/README.md
@@ -102,6 +102,29 @@ santai web
 santai web --port 3000
 ```
 
+### `santai push` / `santai pull`
+
+Sync projects with Santai Hub (requires `santai login`).
+
+```bash
+santai push                  # Upload current project
+santai pull my-project       # Download a project
+```
+
+### `santai login` / `santai logout` / `santai whoami`
+
+Authenticate with Santai Hub.
+
+```bash
+santai login                 # Browser-based auth flow
+santai whoami                # Show current user
+santai logout                # Clear credentials
+```
+
+---
+
+For detailed usage, options, and examples for all commands, see the [full documentation](https://santai-inc.github.io/santai-cli/commands/).
+
 ## Project Structure
 
 A Santai project contains these directories:
@@ -121,6 +144,9 @@ uv sync --group dev
 uv run santai --help
 ruff format .
 ruff check --fix .
+
+# Serve documentation locally
+uv run mkdocs serve
 ```
 
 ### Source Layout
@@ -134,6 +160,9 @@ src/santai_cli/
 │   ├── cherry_pick.py   # santai cherry-pick
 │   ├── merge.py         # santai merge
 │   ├── chat.py          # santai chat
+│   ├── auth.py          # santai login/logout/whoami
+│   ├── push.py          # santai push
+│   ├── pull.py          # santai pull
 │   ├── ui.py            # santai ui
 │   └── web.py           # santai web
 ├── core/

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -1,0 +1,136 @@
+# Agent Profiles
+
+Agent profiles are specialized system prompts that shape how the AI assistant behaves during `santai chat` sessions. Each agent is tuned for a specific workflow within your Santai project.
+
+## Using Agents
+
+Load an agent when starting a chat:
+
+```bash
+santai chat --agent research
+```
+
+Or switch agents mid-session with the `/agent` command:
+
+```
+You: /agent wiki
+Switched to agent: wiki
+Conversation history cleared.
+```
+
+List available agents:
+
+```
+You: /agent
+```
+
+## Built-in Agents
+
+### documentation
+
+Creates and maintains structured documentation across Santai project directories.
+
+- **Permissions**: Can edit files and run commands
+- **Use for**: Writing history entries, wiki pages, resource documentation, and project-level docs
+- **Example**: "Write a history entry summarizing today's architecture discussion"
+
+### linting
+
+Enforces content quality and consistency across project files.
+
+- **Permissions**: Can edit files and run commands
+- **Use for**: Checking markdown quality, history file naming conventions, notes formatting, wiki consistency, and cross-directory coherence
+- **Reports issues as**: Error, Warning, or Info severity levels
+- **Example**: "Review all my history entries for formatting issues"
+
+### research
+
+Investigates topics and gathers context for project knowledge bases.
+
+- **Permissions**: Read-only (cannot edit files), can run commands and access the web
+- **Use for**: Technology evaluation, domain investigation, codebase analysis, context recovery, and external research
+- **Example**: "What are the tradeoffs between REST and GraphQL for our use case?"
+
+### summarizer
+
+Condenses project context into clear, actionable summaries.
+
+- **Permissions**: Read-only (cannot edit files), can run commands
+- **Use for**: Project overviews, history summaries, notes triage, resource digests, wiki summaries, and cross-directory synthesis
+- **Example**: "Summarize the last month of history entries"
+
+### wiki
+
+Curates and maintains the `wiki/` directory as the single source of truth for AI agent context.
+
+- **Permissions**: Can edit files and run commands
+- **Use for**: Managing architecture docs, conventions, domain knowledge, and operational context in the wiki
+- **Example**: "Create a wiki page documenting our deployment process"
+
+## Agent Categories
+
+| Category | Agents | Can modify files? |
+|----------|--------|-------------------|
+| Content-modifying | documentation, linting, wiki | Yes |
+| Read-only | research, summarizer | No |
+
+## Recommended Workflows
+
+### Knowledge Capture
+
+```
+research → documentation → wiki
+```
+
+1. Use `research` to investigate a topic
+2. Use `documentation` to write up findings as a history entry or resource
+3. Use `wiki` to distill key takeaways into the wiki
+
+### Project Onboarding
+
+Use `summarizer` to quickly understand an existing project:
+
+```bash
+santai chat --agent summarizer
+```
+
+Ask it to give you an overview of the project, summarize recent history, or triage notes.
+
+### Content Quality Audit
+
+Use `linting` to review your project's content:
+
+```bash
+santai chat --agent linting
+```
+
+Ask it to check history entry formatting, note quality, or wiki completeness.
+
+### Decision Documentation
+
+```
+research → documentation
+```
+
+1. Use `research` to analyze options
+2. Use `documentation` to record the decision as a dated history entry
+
+## Creating Custom Agents
+
+Agent profiles are markdown files in the `agents/` directory of the Santai CLI package. Each file has YAML frontmatter:
+
+```yaml
+---
+description: Brief description of what this agent does
+mode: subagent
+permission:
+  edit: allow    # or deny
+  bash: allow    # or deny
+  web: allow     # or deny
+---
+
+Your system prompt content goes here.
+Describe the agent's role, capabilities, and behavior.
+```
+
+The `description` field appears in the agent listing. The body of the markdown file becomes the system prompt sent to the AI model.

--- a/docs/commands/auth.md
+++ b/docs/commands/auth.md
@@ -1,0 +1,111 @@
+# Authentication
+
+Santai CLI can authenticate with Santai Hub for cloud sync features (`push` and `pull`). Three commands manage authentication: `login`, `logout`, and `whoami`.
+
+Credentials are stored locally at `~/.config/santai/credentials.json` with restricted permissions (600).
+
+---
+
+## santai login
+
+Authenticate with Santai Hub via the browser.
+
+### Usage
+
+```bash
+santai login [OPTIONS]
+```
+
+### Options
+
+| Option | Short | Default | Description |
+|--------|-------|---------|-------------|
+| `--hub-url` | — | `SANTAI_HUB_URL` or `http://localhost:3000` | Santai Hub URL |
+| `--port` | `-p` | Auto-detected | Fixed port for callback server (useful for SSH tunneling) |
+
+### Behavior
+
+1. Starts a local HTTP server to receive the authentication callback
+2. Opens your browser to the Hub's CLI authentication page
+3. After you authenticate in the browser, the Hub redirects back to the local server with a token
+4. The token and username are saved to `~/.config/santai/credentials.json`
+
+### Examples
+
+Standard login:
+
+```bash
+santai login
+```
+
+Login to a custom Hub instance:
+
+```bash
+santai login --hub-url https://hub.example.com
+```
+
+Login with a fixed callback port (useful when port-forwarding over SSH):
+
+```bash
+santai login --port 9876
+```
+
+### Timeout
+
+The login flow times out after **120 seconds**. Press `Ctrl+C` to cancel early.
+
+---
+
+## santai logout
+
+Log out of Santai Hub by clearing stored credentials.
+
+### Usage
+
+```bash
+santai logout
+```
+
+### Behavior
+
+Removes the credentials file at `~/.config/santai/credentials.json`. If not currently logged in, prints a message and exits.
+
+---
+
+## santai whoami
+
+Show the currently authenticated user and verify the session is still valid.
+
+### Usage
+
+```bash
+santai whoami
+```
+
+### Behavior
+
+1. Reads stored credentials
+2. Verifies the token against the Hub server
+3. Displays username, name, email, Hub URL, and session expiration
+
+If the session has expired, credentials are cleared and you're prompted to re-authenticate.
+
+If the Hub is unreachable (offline), it falls back to showing the cached username.
+
+### Example Output
+
+```
+Logged in as johndoe
+  Name:  John Doe
+  Email: john@example.com
+  Hub:   http://localhost:3000
+  Expires: 2025-05-17T08:00:00Z
+```
+
+---
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `SANTAI_HUB_URL` | `http://localhost:3000` | Override the default Hub URL for all auth commands |

--- a/docs/commands/chat.md
+++ b/docs/commands/chat.md
@@ -1,0 +1,114 @@
+# santai chat
+
+Start an interactive AI chat session with support for multiple providers, model selection, and agent profiles.
+
+## Usage
+
+```bash
+santai chat [OPTIONS]
+```
+
+## Options
+
+| Option | Short | Default | Description |
+|--------|-------|---------|-------------|
+| `--agent` | `-a` | None | Agent profile name to use as system prompt |
+| `--model` | `-m` | None | Model to use (skips interactive selection) |
+
+## Prerequisites
+
+At least one AI provider API key must be configured in a `.env` file. See [Configuration](../configuration.md) for details.
+
+## Interactive Model Selection
+
+When launched without `--model`, santai presents an interactive numbered list of available models based on your configured API keys:
+
+```
+Available models:
+
+  Anthropic:
+    1. claude-sonnet-4-20250514 *
+    2. claude-opus-4-20250514
+    3. claude-haiku-4-20250514
+
+  OpenAI:
+    4. gpt-4o *
+    5. gpt-4o-mini
+    6. o3-mini
+    7. gpt-4.1
+    8. gpt-4.1-mini
+    9. gpt-4.1-nano
+
+Select a model (number):
+```
+
+Models marked with `*` are the configured defaults. If only one provider is configured with a single model, it is auto-selected.
+
+## REPL Commands
+
+Once in the chat session, these slash commands are available:
+
+| Command | Description |
+|---------|-------------|
+| `/quit`, `/exit`, `/q` | Exit the chat |
+| `/clear` | Clear conversation history (keeps system prompt) |
+| `/agent` | List available agents |
+| `/agent <name>` | Switch to a different agent (clears conversation history) |
+| `/model` | Re-select the model interactively |
+| `/help` | Show available commands |
+
+## Agent Profiles
+
+Load an agent profile to set a specialized system prompt:
+
+```bash
+santai chat --agent research
+santai chat --agent documentation
+santai chat --agent wiki
+```
+
+See [Agent Profiles](../agents.md) for details on each agent.
+
+## Examples
+
+Start a chat with the default model selection:
+
+```bash
+santai chat
+```
+
+Start with a specific model:
+
+```bash
+santai chat --model gpt-4o
+santai chat --model claude-sonnet-4-20250514
+```
+
+Use an agent profile with a specific model:
+
+```bash
+santai chat --agent research --model gpt-4o
+```
+
+Switch agents mid-session:
+
+```
+You: /agent wiki
+Switched to agent: wiki
+Conversation history cleared.
+
+You: What pages should I add to the wiki?
+```
+
+## Streaming
+
+Responses are streamed in real-time with Rich markdown rendering at 12fps. The chat supports long-running responses with a maximum token limit of 4096 per response.
+
+## Error Handling
+
+The chat provides friendly error messages for common issues:
+
+- **401 / Authentication error** — Invalid API key
+- **429 / Rate limit** — Too many requests, wait and retry
+- **Model not found** — The specified model is not available
+- **No API keys configured** — Instructions for setting up `.env`

--- a/docs/commands/cherry_pick.md
+++ b/docs/commands/cherry_pick.md
@@ -1,0 +1,76 @@
+# santai cherry-pick
+
+Selectively copy specific files or folders from one Santai project into another.
+
+Unlike `copy` (which clones an entire project) or `merge` (which combines two full projects), `cherry-pick` lets you move just the pieces you need between knowledge bases.
+
+## Usage
+
+```bash
+santai cherry-pick SOURCE DESTINATION FILES...
+```
+
+## Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `SOURCE` | Source Santai project path (or `.` for current directory) |
+| `DESTINATION` | Destination Santai project path (or `.`) |
+| `FILES...` | One or more files or folders to cherry-pick (relative paths inside the source project) |
+
+## Options
+
+| Option | Description |
+|--------|-------------|
+| `--overwrite` | Overwrite existing files in the destination without prompting |
+| `--skip` | Silently skip files that already exist in the destination |
+| `--dry-run` | Show what would be copied without actually copying |
+
+## Behavior
+
+1. Validates that both source and destination are valid Santai projects
+2. Resolves each target path:
+    - Direct relative paths (e.g., `notes/idea.md`)
+    - Bare filenames searched across Santai directories (e.g., `idea.md`)
+3. For directories, recursively collects all files (excluding `.git`, `.ruff_cache`, `.rumdl_cache`, `__pycache__`, `.venv`)
+4. Copies files to the same relative path in the destination
+5. On conflicts:
+    - With `--overwrite`: replaces existing files
+    - With `--skip`: silently skips
+    - Otherwise: prompts interactively for each conflict
+6. Reports a summary of copied, overwritten, and skipped files
+
+## Examples
+
+Cherry-pick a single file:
+
+```bash
+santai cherry-pick ./kb-large ./kb-small notes/idea.md
+```
+
+Cherry-pick an entire directory and a specific file:
+
+```bash
+santai cherry-pick ./research ./writing wiki/ resources/outline.md
+```
+
+Preview what would be copied:
+
+```bash
+santai cherry-pick . ../other-kb notes/ --dry-run
+```
+
+Overwrite all conflicts without prompting:
+
+```bash
+santai cherry-pick ./source ./dest wiki/architecture.md --overwrite
+```
+
+Skip existing files silently:
+
+```bash
+santai cherry-pick ./source ./dest resources/ --skip
+```
+
+!!! tip
+    Use `--dry-run` first to preview exactly which files will be copied and which already exist in the destination.

--- a/docs/commands/copy.md
+++ b/docs/commands/copy.md
@@ -1,0 +1,46 @@
+# santai copy
+
+Copy a Santai project to a new location with a fresh git history.
+
+## Usage
+
+```bash
+santai copy SOURCE DESTINATION
+```
+
+## Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `SOURCE` | Path to the source Santai project (or `.` for the current directory) |
+| `DESTINATION` | Directory name for the copy (must not already exist) |
+
+## Behavior
+
+1. Validates that the source is a valid Santai project (contains `resources/`, `codebases/`, `history/`, `notes/`)
+2. Creates the destination directory
+3. Copies all project files, **excluding**:
+    - `.git/`
+    - `.ruff_cache/`
+    - `.rumdl_cache/`
+    - `__pycache__/`
+    - `.venv/`
+4. Initializes a fresh git repository in the destination
+5. Installs pre-commit hooks via prek
+
+## Examples
+
+Copy the current project to a new directory:
+
+```bash
+santai copy . my-project-v2
+```
+
+Copy from a specific path:
+
+```bash
+santai copy ~/projects/research ~/projects/research-fork
+```
+
+!!! tip
+    This is useful for creating a clean fork of a project without carrying over git history, while preserving all content and structure.

--- a/docs/commands/index.md
+++ b/docs/commands/index.md
@@ -1,0 +1,29 @@
+# Command Reference
+
+Santai CLI provides commands for managing your project. Each command is described in detail on its own page.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| [`santai init`](init.md) | Initialize a new Santai project |
+| [`santai copy`](copy.md) | Copy a project with fresh git history |
+| [`santai cherry-pick`](cherry_pick.md) | Cherry-pick specific files between projects |
+| [`santai merge`](merge.md) | Merge two Santai projects into one |
+| [`santai chat`](chat.md) | Start an interactive AI chat session |
+| [`santai ui`](ui.md) | Launch the TUI dashboard |
+| [`santai web`](web.md) | Launch the web dashboard |
+| [`santai push`](push.md) | Push project to Santai Hub |
+| [`santai pull`](pull.md) | Pull project from Santai Hub |
+| [`santai login`](auth.md) | Authenticate with Santai Hub |
+| [`santai logout`](auth.md) | Log out of Santai Hub |
+| [`santai whoami`](auth.md) | Show current authenticated user |
+
+## Global Options
+
+```bash
+santai --help           # Show help
+santai --help --verbose # Show extended help with keybindings and tips
+```
+
+The `--verbose` / `-v` flag on the top-level help renders a Rich-formatted help page with all commands, keybindings, quick start instructions, project structure, and tips.

--- a/docs/commands/init.md
+++ b/docs/commands/init.md
@@ -1,0 +1,65 @@
+# santai init
+
+Initialize a new Santai project with the standard directory structure, git repository, and configuration files.
+
+## Usage
+
+```bash
+santai init [NAME]
+```
+
+## Arguments
+
+| Argument | Default | Description |
+|----------|---------|-------------|
+| `NAME` | `.` | Directory name to create and initialize. Use `.` to initialize in the current directory. |
+
+## What It Creates
+
+### Directories
+
+Each directory is created with a `.gitkeep` file so it is tracked by git:
+
+| Directory | Purpose |
+|-----------|---------|
+| `resources/` | Reference materials — markdown, PDFs, images, documents |
+| `codebases/` | Code repositories and references |
+| `history/` | Dated markdown entries documenting major changes and decisions |
+| `notes/` | General notes, scratch space, quick thoughts |
+| `wiki/` | Curated knowledge for AI agent context grounding |
+
+### Files
+
+| File | Purpose |
+|------|---------|
+| `AGENTS.md` | Project structure documentation and conventions for AI agents |
+| `README.md` | Project readme (pre-filled with project name) |
+| `CLAUDE.md` | AI assistant context pointer (links to AGENTS.md) |
+| `.pre-commit-config.yaml` | Pre-commit hook config for rumdl markdown linting |
+| `rumdl.toml` | Markdown linter configuration |
+| `.env.example` | Template for AI chat API keys |
+| `.gitignore` | Ignores `.env` files |
+
+### Git Setup
+
+- Initializes a new git repository
+- Installs pre-commit hooks via [prek](https://github.com/santai-inc/prek) (warns if prek is not installed)
+
+## Examples
+
+Create a new project in a new directory:
+
+```bash
+santai init my-research-project
+cd my-research-project
+```
+
+Initialize in the current (empty) directory:
+
+```bash
+mkdir my-project && cd my-project
+santai init .
+```
+
+!!! warning
+    The target directory must be empty or non-existent. `santai init` will refuse to overwrite existing files.

--- a/docs/commands/merge.md
+++ b/docs/commands/merge.md
@@ -1,0 +1,44 @@
+# santai merge
+
+Merge two Santai projects into a single new project.
+
+## Usage
+
+```bash
+santai merge SOURCE1 SOURCE2 DESTINATION
+```
+
+## Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `SOURCE1` | Primary Santai project — its files take precedence on conflicts |
+| `SOURCE2` | Secondary Santai project to merge in |
+| `DESTINATION` | Directory name for the merged project (must not already exist) |
+
+## Behavior
+
+1. Validates that both sources are valid Santai projects
+2. Copies the primary project (`SOURCE1`) fully to the destination (excluding `.git` and cache directories)
+3. Merges the secondary project (`SOURCE2`) — copies files that don't already exist in the destination
+4. **Conflicts**: If a file exists in both projects at the same relative path, the primary project's version wins and the secondary file is skipped
+5. Initializes a fresh git repository
+6. Installs pre-commit hooks via prek
+7. Reports a merge summary: files copied from secondary, files skipped due to conflicts
+
+## Examples
+
+Merge two research projects (first project takes precedence):
+
+```bash
+santai merge project-a project-b merged-project
+```
+
+The merged project will contain:
+
+- All files from `project-a`
+- Files from `project-b` that don't conflict with `project-a`
+- A fresh git history
+
+!!! note
+    The merge is file-level, not content-level. If both projects have `notes/ideas.md`, only the version from `SOURCE1` will be kept. The command reports which files were skipped so you can manually reconcile them.

--- a/docs/commands/pull.md
+++ b/docs/commands/pull.md
@@ -1,0 +1,55 @@
+# santai pull
+
+Pull a Santai project from Santai Hub to your local machine.
+
+## Usage
+
+```bash
+santai pull NAME [OPTIONS]
+```
+
+## Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `NAME` | Project name to pull from the Hub |
+
+## Options
+
+| Option | Short | Default | Description |
+|--------|-------|---------|-------------|
+| `--dest` | `-d` | Same as `NAME` | Destination directory for the pulled project |
+
+## Prerequisites
+
+- Must be logged in (`santai login`)
+
+## Behavior
+
+1. Looks up the project by name on Santai Hub
+2. Downloads the project archive
+3. Extracts to the destination directory
+
+## Examples
+
+Pull a project (creates a directory with the project name):
+
+```bash
+santai pull my-research-kb
+```
+
+Pull to a specific directory:
+
+```bash
+santai pull my-research-kb --dest ~/projects/research
+```
+
+## Error Handling
+
+| Error | Cause |
+|-------|-------|
+| Not logged in | Run `santai login` first |
+| Destination already exists | Choose a different path or remove the existing directory |
+| Project not found | The named project doesn't exist on your Hub account |
+| Session expired | Re-authenticate with `santai login` |
+| Download failed | Network issue or expired URL — try again |

--- a/docs/commands/push.md
+++ b/docs/commands/push.md
@@ -1,0 +1,61 @@
+# santai push
+
+Push the current Santai project to Santai Hub for cloud backup and sharing.
+
+## Usage
+
+```bash
+santai push [NAME]
+```
+
+## Arguments
+
+| Argument | Default | Description |
+|----------|---------|-------------|
+| `NAME` | Current directory name | Project name on the Hub |
+
+## Prerequisites
+
+- Must be logged in (`santai login`)
+- Must be run from within a valid Santai project directory
+
+## Behavior
+
+1. Validates the current directory is a Santai project
+2. Packages the project into a zip archive, **excluding**:
+    - `.git/`
+    - `.ruff_cache/`
+    - `.rumdl_cache/`
+    - `__pycache__/`
+    - `.venv/`
+    - `node_modules/`
+3. Validates the archive is under 50 MB
+4. Uploads to Santai Hub
+
+## Examples
+
+Push with the default name (current directory name):
+
+```bash
+santai push
+```
+
+Push with a custom name:
+
+```bash
+santai push my-research-kb
+```
+
+## Size Limit
+
+The maximum upload size is **50 MB** (compressed). If your project exceeds this, consider excluding large binary files or using `.gitignore`-style filtering.
+
+## Error Handling
+
+| Error | Cause |
+|-------|-------|
+| Not a Santai project | Missing required directories |
+| Not logged in | Run `santai login` first |
+| Archive exceeds 50 MB | Project too large after compression |
+| Session expired | Re-authenticate with `santai login` |
+| Could not reach the hub | Network issue or hub is down |

--- a/docs/commands/ui.md
+++ b/docs/commands/ui.md
@@ -1,0 +1,81 @@
+# santai ui
+
+Launch the terminal UI (TUI) dashboard for visual project exploration.
+
+## Usage
+
+```bash
+santai ui [OPTIONS]
+```
+
+## Options
+
+| Option | Short | Default | Description |
+|--------|-------|---------|-------------|
+| `--theme` | `-t` | `btop` | Theme to use: `claude`, `catppuccin`, `btop`, `light` |
+
+## Requirements
+
+Must be run from within a valid Santai project directory.
+
+## Dashboard Panels
+
+The TUI provides a multi-panel dashboard:
+
+- **Directory tree** — Browse all files across your project directories
+- **Project statistics** — File counts per directory, total size, file type distribution, recent files
+- **Notes panel** — Quick view of your notes with previews
+- **File graph** — Force-directed graph visualization showing links between your documents, rendered with Braille characters
+
+## Keybindings
+
+| Key | Action |
+|-----|--------|
+| `q` | Quit |
+| `r` | Refresh all panels |
+| `g` | Toggle fullscreen graph |
+| `/` | Open graph search |
+| `f` | Filter graph by directory |
+| `t` | Open theme selector |
+| `n` | Add a new note |
+| `p` | Cycle color palette within current theme |
+| `c` | Clear graph search/filter |
+| `x` | Open the chat panel |
+| `Esc` | Back / exit fullscreen graph |
+
+## Themes
+
+Four themes are available:
+
+| Theme | Description |
+|-------|-------------|
+| `btop` (default) | Inspired by the btop system monitor |
+| `claude` | Anthropic Claude-inspired colors |
+| `catppuccin` | Catppuccin pastel theme |
+| `light` | Light background theme |
+
+Switch themes at launch:
+
+```bash
+santai ui --theme catppuccin
+```
+
+Or press `t` within the TUI to switch interactively.
+
+## Chat Panel
+
+Press `x` to open a modal chat screen within the TUI. This uses the same chat engine as `santai chat`, supporting model selection and agent profiles.
+
+## Examples
+
+Launch with the default theme:
+
+```bash
+santai ui
+```
+
+Launch with the light theme:
+
+```bash
+santai ui --theme light
+```

--- a/docs/commands/web.md
+++ b/docs/commands/web.md
@@ -1,0 +1,63 @@
+# santai web
+
+Launch a web-based dashboard for browsing your project in a browser.
+
+## Usage
+
+```bash
+santai web [OPTIONS]
+```
+
+## Options
+
+| Option | Short | Default | Description |
+|--------|-------|---------|-------------|
+| `--port` | `-p` | `8000` | Port to run the server on |
+| `--no-open` | — | `False` | Don't automatically open the browser |
+
+## Requirements
+
+Must be run from within a valid Santai project directory.
+
+## Features
+
+The web dashboard provides:
+
+- **Project overview** — Directory statistics and file type breakdown
+- **History browser** — Rendered history entries
+- **Notes viewer** — Browse all notes
+- **File graph** — Interactive visualization of document links
+- **Chat panel** — Streaming AI chat with model and agent selection
+
+## API Endpoints
+
+The web dashboard exposes a REST API that powers the frontend:
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/api/stats` | GET | Project statistics |
+| `/api/history` | GET | All history entries |
+| `/api/notes` | GET | All notes |
+| `/api/graph` | GET | File graph nodes and edges |
+| `/api/chat` | POST | Chat with SSE streaming |
+| `/api/chat/models` | GET | Available chat models |
+| `/api/chat/agents` | GET | Available agent profiles |
+
+## Examples
+
+Launch on the default port (opens browser automatically):
+
+```bash
+santai web
+```
+
+Launch on a custom port without opening the browser:
+
+```bash
+santai web --port 3000 --no-open
+```
+
+Stop the server with `Ctrl+C`.
+
+!!! tip
+    The web dashboard is useful for sharing your project view with others or for a more visual browsing experience compared to the TUI.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,86 @@
+# Configuration
+
+Santai CLI uses environment variables for AI chat configuration. These are loaded from a `.env` file in your project root.
+
+## Setting Up the `.env` File
+
+When you run `santai init`, a `.env.example` template is created. Copy it and fill in your keys:
+
+```bash
+cp .env.example .env
+```
+
+Then edit `.env` with your API keys:
+
+```bash
+# At least one provider key is required
+ANTHROPIC_API_KEY=sk-ant-...
+OPENAI_API_KEY=sk-...
+
+# Optional: override default models
+ANTHROPIC_MODEL=claude-sonnet-4-20250514
+OPENAI_MODEL=gpt-4o
+```
+
+!!! warning
+    The `.env` file is gitignored by default. Never commit API keys to version control.
+
+## Environment Variables
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `ANTHROPIC_API_KEY` | At least one provider | — | Your Anthropic API key |
+| `ANTHROPIC_MODEL` | No | `claude-sonnet-4-20250514` | Default Anthropic model |
+| `OPENAI_API_KEY` | At least one provider | — | Your OpenAI API key |
+| `OPENAI_MODEL` | No | `gpt-4o` | Default OpenAI model |
+| `SANTAI_HUB_URL` | No | `http://localhost:3000` | Santai Hub URL for push/pull/auth |
+
+You need at least one provider key configured for AI chat. You can configure both to have access to models from both providers.
+
+## Available Models
+
+### Anthropic
+
+| Model | Notes |
+|-------|-------|
+| `claude-sonnet-4-20250514` | Default |
+| `claude-opus-4-20250514` | |
+| `claude-haiku-4-20250514` | |
+
+### OpenAI
+
+| Model | Notes |
+|-------|-------|
+| `gpt-4o` | Default |
+| `gpt-4o-mini` | |
+| `o3-mini` | |
+| `gpt-4.1` | |
+| `gpt-4.1-mini` | |
+| `gpt-4.1-nano` | |
+
+## Overriding the Default Model
+
+Set the `ANTHROPIC_MODEL` or `OPENAI_MODEL` environment variable to change which model is selected by default in the interactive picker:
+
+```bash
+# .env
+ANTHROPIC_MODEL=claude-opus-4-20250514
+OPENAI_MODEL=gpt-4.1
+```
+
+You can also bypass the interactive picker entirely with the `--model` flag:
+
+```bash
+santai chat --model gpt-4o-mini
+```
+
+## API Key Validation
+
+Santai performs basic validation on API keys:
+
+- Keys starting with `your-` are rejected (these are placeholders from the `.env.example` template)
+- Invalid or expired keys will produce a clear authentication error when you attempt to chat
+
+## Where the `.env` Is Loaded From
+
+The `.env` file is loaded from the project root directory (the directory containing your Santai project directories). If no Santai project is detected, it falls back to the current working directory.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,175 @@
+# Getting Started
+
+This guide walks you through installing santai, creating your first project, and exploring it with the built-in tools.
+
+## Installation
+
+### Using uv (recommended)
+
+```bash
+uv tool install santai-cli
+```
+
+### Using pip
+
+```bash
+pip install santai-cli
+```
+
+### From source
+
+```bash
+git clone https://github.com/santai-inc/santai-cli.git
+cd santai-cli
+uv sync
+uv run santai --help
+```
+
+## Creating Your First Project
+
+Initialize a new Santai project:
+
+```bash
+santai init my-project
+```
+
+This creates the following structure:
+
+```
+my-project/
+├── .git/
+├── .gitignore
+├── .env.example
+├── .pre-commit-config.yaml
+├── AGENTS.md
+├── CLAUDE.md
+├── README.md
+├── rumdl.toml
+├── resources/
+│   └── .gitkeep
+├── codebases/
+│   └── .gitkeep
+├── history/
+│   └── .gitkeep
+├── notes/
+│   └── .gitkeep
+└── wiki/
+    └── .gitkeep
+```
+
+You can also initialize in the current directory:
+
+```bash
+mkdir my-project && cd my-project
+santai init .
+```
+
+!!! note
+    The target directory must be empty or non-existent. Santai will not overwrite existing files.
+
+## Adding Content
+
+### Notes
+
+Drop markdown or text files into `notes/` for quick reference:
+
+```bash
+echo "# Meeting Notes\nDiscussed the new API design." > notes/api-meeting.md
+```
+
+### History Entries
+
+History entries use a date-prefixed naming convention:
+
+```bash
+echo "# Decided on REST over GraphQL\nTeam voted unanimously." > history/2025-04-17-api-decision.md
+```
+
+The filename format is `YYYY-MM-DD-description.md`. The description becomes the display title (hyphens are replaced with spaces and title-cased).
+
+### Resources and Codebases
+
+Place reference documents in `resources/` and code in `codebases/`:
+
+```bash
+cp ~/design-spec.pdf resources/
+git clone https://github.com/example/repo.git codebases/repo
+```
+
+### Wiki
+
+The `wiki/` directory is intended for curated knowledge that grounds AI agents:
+
+```bash
+echo "# Architecture Overview\nThe system uses a microservices pattern..." > wiki/architecture.md
+```
+
+## Exploring Your Project
+
+### Terminal UI
+
+Launch the TUI dashboard to get an overview of your project:
+
+```bash
+santai ui
+```
+
+This opens an interactive terminal dashboard with:
+
+- Directory tree browser
+- Project statistics
+- Notes panel
+- Interactive file graph showing links between documents
+
+Key bindings:
+
+| Key | Action |
+|-----|--------|
+| `q` | Quit |
+| `r` | Refresh all panels |
+| `g` | Toggle fullscreen graph |
+| `/` | Search the graph |
+| `f` | Filter graph by directory |
+| `t` | Open theme selector |
+| `n` | Add a new note |
+| `p` | Cycle color palette |
+| `c` | Clear graph search/filter |
+| `x` | Open the chat panel |
+
+### Web Dashboard
+
+For a browser-based experience:
+
+```bash
+santai web
+```
+
+This starts a local server at `http://127.0.0.1:8000` and opens your browser automatically. Use `--no-open` to skip the browser launch, or `--port` to change the port.
+
+### AI Chat
+
+Set up your API keys first (see [Configuration](configuration.md)), then start chatting:
+
+```bash
+santai chat
+```
+
+You'll be prompted to select a model. Use `--model` to skip the selection:
+
+```bash
+santai chat --model claude-sonnet-4-20250514
+santai chat --model gpt-4o
+```
+
+Load an agent profile for specialized behavior:
+
+```bash
+santai chat --agent research
+```
+
+## Next Steps
+
+- [Command Reference](commands/index.md) — Detailed docs for every command
+- [Configuration](configuration.md) — Set up API keys and customize models
+- [Agent Profiles](agents.md) — Learn about the built-in AI agent profiles
+- [Use Cases](use-cases.md) — Common workflows and recipes

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,50 @@
+# Santai CLI
+
+**Santai CLI** is a project management tool designed for organizing knowledge, resources, and code references into a structured workspace. It provides a terminal UI, a web dashboard, and an AI-powered chat interface to help you manage and navigate your project context.
+
+## What is a Santai Project?
+
+A Santai project is a directory with a defined structure for organizing information:
+
+| Directory | Purpose |
+|-----------|---------|
+| `resources/` | Reference materials — markdown, PDFs, images, documents |
+| `codebases/` | Code repositories and references |
+| `history/` | Dated markdown entries documenting major changes and decisions |
+| `notes/` | General notes, scratch space, and quick thoughts |
+| `wiki/` | Important context for grounding AI agents and solidifying project knowledge |
+
+Santai provides tools to create, browse, analyze, and chat about this structure through three interfaces: a CLI, a TUI dashboard, and a web dashboard.
+
+## Features
+
+- **Project scaffolding** — `santai init` creates a complete project structure with git, pre-commit hooks, and markdown linting
+- **Project operations** — Copy, merge, and cherry-pick between projects while preserving structure
+- **AI chat** — Interactive chat with Anthropic and OpenAI models, with swappable agent profiles for different workflows
+- **Cloud sync** — Push and pull projects to Santai Hub for backup and sharing
+- **TUI dashboard** — Terminal-based dashboard with file graph visualization, directory stats, notes panel, and theme support
+- **Web dashboard** — Browser-based dashboard with the same features plus a streaming chat panel
+- **File graph** — Automatic detection and visualization of links between your project files
+
+## Quick Install
+
+```bash
+# Install with uv (recommended)
+uv tool install santai-cli
+
+# Or install with pip
+pip install santai-cli
+```
+
+Then create your first project:
+
+```bash
+santai init my-project
+cd my-project
+santai ui
+```
+
+## Requirements
+
+- Python 3.12 or newer
+- [uv](https://docs.astral.sh/uv/) (recommended) or pip

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -1,0 +1,231 @@
+# Use Cases
+
+Practical workflows and recipes for getting the most out of Santai CLI.
+
+## Starting a New Research Project
+
+Set up a structured workspace for a research effort:
+
+```bash
+# Create the project
+santai init api-migration-research
+cd api-migration-research
+
+# Add reference materials
+cp ~/specs/current-api.md resources/
+cp ~/specs/target-api.md resources/
+
+# Clone relevant codebases
+git clone https://github.com/org/api-service.git codebases/api-service
+
+# Set up AI chat for research
+cp .env.example .env
+# Edit .env with your API keys
+
+# Start researching with the research agent
+santai chat --agent research
+```
+
+## Documenting Architecture Decisions
+
+Use the history directory and AI agents to create a decision log:
+
+```bash
+# Start a chat session with the documentation agent
+santai chat --agent documentation --model claude-sonnet-4-20250514
+```
+
+In the chat, ask it to write a history entry:
+
+```
+You: Write a history entry for today about our decision to use PostgreSQL 
+     over MongoDB. Key reasons: ACID compliance, existing team expertise, 
+     and better support for relational data in our domain model.
+```
+
+The agent will create a properly formatted `history/YYYY-MM-DD-description.md` file.
+
+## Building a Project Knowledge Base
+
+Incrementally build a wiki that serves as ground truth for AI agents:
+
+```bash
+# Research a topic
+santai chat --agent research
+# "What are our deployment environments and how do they differ?"
+
+# Capture findings in the wiki
+santai chat --agent wiki
+# "Create a wiki page documenting our deployment environments"
+
+# Review quality
+santai chat --agent linting
+# "Check the wiki for completeness and consistency"
+```
+
+## Onboarding to an Existing Project
+
+When joining a project that already has Santai structure:
+
+```bash
+cd existing-project
+
+# Get a quick overview
+santai chat --agent summarizer
+# "Give me a complete overview of this project"
+# "Summarize the last 10 history entries"
+# "What's in the wiki?"
+
+# Browse visually
+santai ui
+
+# Or in the browser
+santai web
+```
+
+## Cherry-Picking Between Knowledge Bases
+
+When you need specific files from one project in another without merging everything:
+
+```bash
+# Preview what you'd get
+santai cherry-pick ./large-kb ./focused-kb wiki/architecture.md notes/ --dry-run
+
+# Copy the files
+santai cherry-pick ./large-kb ./focused-kb wiki/architecture.md notes/
+
+# Copy an entire directory, overwriting conflicts
+santai cherry-pick ./research ./writing resources/ --overwrite
+```
+
+This is particularly useful when:
+
+- Splitting a large KB into focused sub-projects
+- Sharing specific reference materials across projects
+- Pulling in wiki context from a team KB into a personal one
+
+## Merging Two Research Streams
+
+When separate research efforts need to be combined:
+
+```bash
+# Both must be valid Santai projects
+santai merge frontend-research backend-research combined-research
+```
+
+After merging, review what was combined:
+
+```bash
+cd combined-research
+santai ui
+```
+
+!!! note
+    The merge command reports which files were skipped due to conflicts. Check the output and manually reconcile any important files that were in both projects.
+
+## Forking a Project for a New Phase
+
+Create a clean copy when starting a new phase of work:
+
+```bash
+santai copy current-project phase-2-project
+cd phase-2-project
+
+# Add a history entry marking the fork
+echo "# Phase 2 Kickoff\nForked from phase 1 project to begin implementation." \
+  > history/2025-04-17-phase-2-kickoff.md
+```
+
+## Cloud Sync Workflow
+
+Push your project to Santai Hub for backup or sharing, and pull it on another machine:
+
+```bash
+# Authenticate (one-time setup)
+santai login
+
+# Push your project
+cd my-project
+santai push
+
+# On another machine, pull it down
+santai login
+santai pull my-project
+```
+
+## Quick Notes Workflow
+
+Use the notes directory as scratch space during research:
+
+```bash
+cd my-project
+
+# Quick note from the command line
+echo "# Idea: Use webhooks instead of polling\nCould reduce API calls by 90%" \
+  > notes/webhook-idea.md
+
+# Add notes interactively in the TUI
+santai ui
+# Press 'n' to add a new note
+
+# Review all notes
+santai ui  # Check the notes panel
+```
+
+## Exploring File Relationships
+
+The file graph visualization tracks links between your documents:
+
+1. Add cross-references in your markdown files using standard links:
+    ```markdown
+    See [Architecture Overview](../wiki/architecture.md) for context.
+    Related: [[deployment-process]]
+    ```
+
+2. View the graph:
+    ```bash
+    santai ui  # Press 'g' for fullscreen graph
+    # or
+    santai web  # Graph panel in the dashboard
+    ```
+
+3. Search and filter the graph:
+    - Press `/` to search for specific files
+    - Press `f` to filter by directory (e.g., show only wiki links)
+
+The graph detects both standard markdown links and wikilinks (`[[page]]` and `[[page|display text]]`).
+
+## Multi-Model Comparison
+
+Compare responses from different AI models on the same question:
+
+```bash
+# Ask Anthropic
+santai chat --model claude-sonnet-4-20250514
+# Ask your question, note the response, then /quit
+
+# Ask OpenAI
+santai chat --model gpt-4o
+# Ask the same question, compare responses
+```
+
+## Content Quality Audit
+
+Run a quality check across your entire project:
+
+```bash
+santai chat --agent linting
+```
+
+In the chat:
+
+```
+You: Audit the entire project. Check:
+     - History entry filename conventions
+     - Markdown formatting quality
+     - Wiki completeness
+     - Cross-references between documents
+     - Notes that should be promoted to wiki or history
+```
+
+The linting agent will report issues with Error, Warning, and Info severity levels.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,68 @@
+site_name: Santai CLI Documentation
+site_description: Documentation for the Santai project management CLI
+site_url: https://santai-inc.github.io/santai-cli
+
+repo_name: santai-inc/santai-cli
+repo_url: https://github.com/santai-inc/santai-cli
+
+theme:
+  name: material
+  palette:
+    - scheme: default
+      primary: teal
+      accent: amber
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - scheme: slate
+      primary: teal
+      accent: amber
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - navigation.instant
+    - navigation.tracking
+    - navigation.sections
+    - navigation.expand
+    - navigation.top
+    - content.code.copy
+    - content.code.annotate
+    - search.suggest
+    - search.highlight
+  icon:
+    repo: fontawesome/brands/github
+
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.tabbed:
+      alternate_style: true
+  - tables
+  - attr_list
+  - md_in_html
+  - toc:
+      permalink: true
+
+nav:
+  - Home: index.md
+  - Getting Started: getting-started.md
+  - Commands:
+      - Overview: commands/index.md
+      - init: commands/init.md
+      - copy: commands/copy.md
+      - cherry-pick: commands/cherry_pick.md
+      - merge: commands/merge.md
+      - chat: commands/chat.md
+      - ui: commands/ui.md
+      - web: commands/web.md
+      - push: commands/push.md
+      - pull: commands/pull.md
+      - Authentication: commands/auth.md
+  - Configuration: configuration.md
+  - Agent Profiles: agents.md
+  - Use Cases: use-cases.md


### PR DESCRIPTION
## Summary

- Adds a full MkDocs documentation site using the Material theme, configured in `mkdocs.yml` with dark/light mode toggle, code copy, search, and navigation features.
- Includes 10 documentation pages covering all CLI commands (`init`, `copy`, `merge`, `chat`, `history`, `ui`, `web`), getting started guide, configuration reference, agent profiles, and use cases.
- Adds `site/` to `.gitignore` to exclude MkDocs build output.

## Pages

| Page | Description |
|------|-------------|
| `docs/index.md` | Home — project overview, features, quick install |
| `docs/getting-started.md` | Setup and first project walkthrough |
| `docs/commands/*.md` | Individual command reference (8 pages) |
| `docs/configuration.md` | Environment and API key configuration |
| `docs/agents.md` | Agent profile system documentation |
| `docs/use-cases.md` | Common workflows and usage patterns |