### PR TITLE
feat(docker): Add Dockerfile and Docker Compose for the CLI tool

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,37 @@
+# Version control
+.git
+.gitignore
+
+# Python artifacts
+__pycache__
+*.py[cod]
+*.egg-info
+build/
+dist/
+wheels/
+
+# Virtual environments
+.venv
+.env
+
+# IDE / editor
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# CI / tooling caches
+.ruff_cache
+.rumdl_cache
+.mypy_cache
+.pytest_cache
+
+# Documentation build
+site/
+
+# Claude / AI local settings
+.claude/
+
+# OS files
+.DS_Store
+Thumbs.db

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,48 @@
+# ---- Stage 1: build ------------------------------------------------
+FROM python:3.12-slim AS builder
+
+# Install uv (fast Python package manager)
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+
+WORKDIR /app
+
+# Copy dependency manifests first for layer caching
+COPY pyproject.toml uv.lock ./
+
+# Install runtime dependencies only (no dev group)
+RUN uv sync --frozen --no-dev --no-install-project
+
+# Copy the rest of the source code
+COPY . .
+
+# Install the project itself into the venv
+RUN uv sync --frozen --no-dev
+
+
+# ---- Stage 2: runtime ----------------------------------------------
+FROM python:3.12-slim AS runtime
+
+# Create a non-root user
+RUN groupadd --gid 1000 santai \
+    && useradd --uid 1000 --gid santai --create-home santai
+
+WORKDIR /app
+
+# Copy the virtual environment and source from the builder
+COPY --from=builder /app /app
+
+# Put the venv on the PATH so `santai` is directly callable
+ENV PATH="/app/.venv/bin:$PATH"
+
+# Default working directory for santai projects (mountable volume)
+RUN mkdir -p /data && chown santai:santai /data
+WORKDIR /data
+
+USER santai
+
+# Expose the web dashboard port
+EXPOSE 8000
+
+# Default entrypoint — can be overridden in docker-compose
+ENTRYPOINT ["santai"]
+CMD ["--help"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,10 @@ RUN uv sync --frozen --no-dev
 # ---- Stage 2: runtime ----------------------------------------------
 FROM python:3.12-slim AS runtime
 
+# Install git (required by `santai init` to initialize repos)
+RUN apt-get update && apt-get install -y --no-install-recommends git \
+    && rm -rf /var/lib/apt/lists/*
+
 # Create a non-root user
 RUN groupadd --gid 1000 santai \
     && useradd --uid 1000 --gid santai --create-home santai

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,43 @@
+# Santai CLI - Docker Compose
+# Usage:
+#   docker compose up santai-web       # Start the web dashboard on port 8000
+#   docker compose run santai-cli --help  # Run any santai CLI command
+#
+# Environment:
+#   Copy .env.example to .env and fill in your API keys before running.
+
+services:
+  # ── CLI service (one-off commands) ─────────────────────────────────
+  santai-cli:
+    build: .
+    image: santai-cli:latest
+    env_file:
+      - path: .env
+        required: false
+    volumes:
+      - santai-data:/data
+    # Override entrypoint args via: docker compose run santai-cli <command>
+    # Examples:
+    #   docker compose run santai-cli init myproject
+    #   docker compose run santai-cli --help
+    stdin_open: true
+    tty: true
+
+  # ── Web dashboard service ──────────────────────────────────────────
+  santai-web:
+    build: .
+    image: santai-cli:latest
+    env_file:
+      - path: .env
+        required: false
+    ports:
+      - "8000:8000"
+    volumes:
+      - santai-data:/data
+    # Start the web dashboard bound to 0.0.0.0 so it is reachable
+    # from outside the container, and skip auto-opening a browser.
+    command: ["web", "--host", "0.0.0.0", "--port", "8000", "--no-open"]
+
+volumes:
+  santai-data:
+    driver: local

--- a/src/santai_cli/cli.py
+++ b/src/santai_cli/cli.py
@@ -156,8 +156,9 @@ _COMMANDS: list[dict[str, str | list[str]]] = [
             "Press Ctrl+C to stop the server."
         ),
         "options": [
-            "--port, -p INT  Port to run the server on [default: 8000]",
-            "--no-open       Don't automatically open the browser",
+            "--port, -p INT    Port to run the server on [default: 8000]",
+            "--host, -H TEXT   Host to bind the server to [default: 127.0.0.1]",
+            "--no-open         Don't automatically open the browser",
         ],
     },
 ]

--- a/src/santai_cli/commands/web.py
+++ b/src/santai_cli/commands/web.py
@@ -21,6 +21,10 @@ def web(
         int,
         typer.Option("--port", "-p", help="Port to run the server on"),
     ] = 8000,
+    host: Annotated[
+        str,
+        typer.Option("--host", "-H", help="Host to bind the server to"),
+    ] = "127.0.0.1",
     no_open: Annotated[
         bool,
         typer.Option("--no-open", help="Don't automatically open browser"),
@@ -63,7 +67,7 @@ def web(
     # Run server
     uvicorn.run(
         app,
-        host="127.0.0.1",
+        host=host,
         port=port,
         log_level="warning",
     )


### PR DESCRIPTION
## Summary

- Add Docker support so the santai CLI can be built and run as a container
- Add a `--host` flag to `santai web` so the server can bind to `0.0.0.0` inside containers
- Install `git` in the runtime image so `santai init` can initialize repos

## Changes

### New files
- **`Dockerfile`** — Multi-stage build using `python:3.12-slim` + `uv`. Builder stage installs dependencies, runtime stage includes `git` and runs as non-root `santai` user.
- **`docker-compose.yml`** — Two services: `santai-cli` (interactive CLI) and `santai-web` (FastAPI dashboard on port 8000). Shared `santai-data` volume. `.env` file is optional.
- **`.dockerignore`** — Excludes `.git`, `__pycache__`, `.venv`, `.env`, build artifacts, and IDE files.

### Modified files
- **`src/santai_cli/commands/web.py`** — Added `--host / -H` option (default `127.0.0.1`) so the web server can bind to `0.0.0.0` in Docker.
- **`src/santai_cli/cli.py`** — Updated verbose help to document the new `--host` option.

## Usage

```bash
# Build
docker build -t santai-cli .

# Run CLI commands
docker run --rm santai-cli --help
docker run --rm santai-cli init myproject

# Docker Compose — web dashboard on http://localhost:8000
docker compose up santai-web

# Docker Compose — interactive CLI
docker compose run --rm santai-cli init myproject

# Shell into the container
docker run --rm -it --entrypoint /bin/bash santai-cli
```

## Tested

- `docker build -t santai-cli .` succeeds
- `docker run --rm santai-cli --help` prints help
- `docker run --rm santai-cli init myproject` creates project with git repo
- `docker compose run --rm santai-cli --help` works via compose
- `ruff check` and `ty check` pass on all modified files

Closes #51