### PR TITLE
Added "New File" functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,28 @@ uv sync
 uv run santai --help
 ```
 
-> **Picking up local changes:** `uv tool install` copies the package into an isolated venv, so edits or branch switches in your clone won't affect the global `santai` until you reinstall. For active development, use an editable install instead:
->
-> ```bash
-> uv tool install --editable --from . santai-cli --force
-> ```
->
-> Otherwise, re-run `uv tool install --from . santai-cli --force` after each change (the `--force` is required — without it, `uv` treats an already-installed package as a no-op). To track a different branch in a separate directory, use `git worktree add` and point the editable install at that path.
+### Picking up local changes
+
+`uv tool install` copies the package into an isolated venv, so edits or branch switches in your clone won't affect the global `santai` until you reinstall. For active development, use an editable install so the global `santai` tracks your working tree:
+
+```bash
+uv tool install --editable --from . santai-cli --force
+```
+
+Otherwise, re-run the install after each change:
+
+```bash
+uv tool install --from . santai-cli --force
+```
+
+The `--force` flag is required — without it, `uv` treats an already-installed package as a no-op.
+
+To track a different branch in a separate directory, use a git worktree and point the editable install at that path:
+
+```bash
+git worktree add ../santai-cli-other other-branch
+uv tool install --editable --from ../santai-cli-other santai-cli --force
+```
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,14 @@ uv sync
 uv run santai --help
 ```
 
+> **Picking up local changes:** `uv tool install` copies the package into an isolated venv, so edits or branch switches in your clone won't affect the global `santai` until you reinstall. For active development, use an editable install instead:
+>
+> ```bash
+> uv tool install --editable --from . santai-cli --force
+> ```
+>
+> Otherwise, re-run `uv tool install --from . santai-cli --force` after each change (the `--force` is required — without it, `uv` treats an already-installed package as a no-op). To track a different branch in a separate directory, use `git worktree add` and point the editable install at that path.
+
 ## Quick Start
 
 ```bash

--- a/src/santai_cli/web/app.py
+++ b/src/santai_cli/web/app.py
@@ -35,6 +35,11 @@ class MkdirRequest(BaseModel):
     name: str
 
 
+class TouchRequest(BaseModel):
+    path: str
+    name: str
+
+
 class FileContentRequest(BaseModel):
     content: str
 
@@ -406,6 +411,28 @@ def create_app(project: SantaiProject) -> FastAPI:
             "path": str(new_dir.relative_to(root_dir)),
         }
 
+    @app.post("/api/files/touch")
+    async def touch_file(req: TouchRequest) -> dict[str, str]:
+        """Create a new empty file."""
+        parent = safe_path(req.path)
+        if not parent.is_dir():
+            raise HTTPException(
+                status_code=400, detail="Parent path is not a directory"
+            )
+
+        new_file = parent / req.name
+        safe_path(str(new_file.relative_to(root_dir)))
+        if new_file.exists():
+            raise HTTPException(
+                status_code=409, detail="A file with that name already exists"
+            )
+
+        new_file.touch()
+        return {
+            "message": "File created",
+            "path": str(new_file.relative_to(root_dir)),
+        }
+
     @app.post("/api/files/move")
     async def move_file(req: MoveRequest) -> dict[str, str]:
         """Move a file or directory to a new location."""
@@ -746,7 +773,9 @@ def create_app(project: SantaiProject) -> FastAPI:
                     session, req.provider, provider_config, req.model
                 ):
                     if isinstance(chunk, dict):
-                        data = json.dumps({"type": "file_written", "path": chunk["path"]})
+                        data = json.dumps(
+                            {"type": "file_written", "path": chunk["path"]}
+                        )
                     else:
                         data = json.dumps({"type": "chunk", "content": chunk})
                     yield f"data: {data}\n\n"

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -579,12 +579,16 @@
         }
 
         .actions {
-            display: flex;
+            display: grid;
+            grid-template-columns: 1fr 1fr;
             gap: 8px;
         }
 
+        .actions .btn-upload {
+            grid-column: 1 / -1;
+        }
+
         .actions .btn {
-            flex: 1;
             justify-content: center;
             gap: 6px;
         }
@@ -3409,17 +3413,23 @@
             </nav>
 
             <div class="actions">
-                <button class="btn btn-primary" onclick="triggerUpload()">
+                <button class="btn" onclick="showNewFileModal()">
                     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                        <path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5m-13.5-9L12 3m0 0l4.5 4.5M12 3v13.5" />
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H8.25m3.75 9v6m3-3H9m1.5-12H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 00-9-9z" />
                     </svg>
-                    Upload
+                    New File
                 </button>
                 <button class="btn" onclick="showNewFolderModal()">
                     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                         <path stroke-linecap="round" stroke-linejoin="round" d="M12 10.5v6m3-3H9m4.06-7.19l-2.12-2.12a1.5 1.5 0 00-1.061-.44H4.5A2.25 2.25 0 002.25 6v12a2.25 2.25 0 002.25 2.25h15A2.25 2.25 0 0021.75 18V9a2.25 2.25 0 00-2.25-2.25h-5.379a1.5 1.5 0 01-1.06-.44z" />
                     </svg>
                     New Folder
+                </button>
+                <button class="btn btn-primary btn-upload" onclick="triggerUpload()">
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5m-13.5-9L12 3m0 0l4.5 4.5M12 3v13.5" />
+                    </svg>
+                    Upload
                 </button>
             </div>
         </aside>
@@ -3743,6 +3753,18 @@
             <input type="text" class="modal-input" id="folder-input" placeholder="Folder name">
             <div class="modal-actions" style="justify-content: flex-start;">
                 <button class="btn btn-primary" onclick="confirmNewFolder()">Create</button>
+                <button class="btn" onclick="closeModals()">Cancel</button>
+            </div>
+        </div>
+    </div>
+
+    <!-- New File Modal -->
+    <div class="modal-overlay" id="new-file-modal">
+        <div class="modal">
+            <h2>New File</h2>
+            <input type="text" class="modal-input" id="new-file-input" placeholder="File name (e.g. notes.md)">
+            <div class="modal-actions" style="justify-content: flex-start;">
+                <button class="btn btn-primary" onclick="confirmNewFile()">Create</button>
                 <button class="btn" onclick="closeModals()">Cancel</button>
             </div>
         </div>
@@ -4763,6 +4785,39 @@
             }
         }
 
+        function showNewFileModal() {
+            document.getElementById('new-file-input').value = '';
+            document.getElementById('new-file-modal').classList.add('show');
+            document.getElementById('new-file-input').focus();
+        }
+
+        async function confirmNewFile() {
+            const name = document.getElementById('new-file-input').value.trim();
+            if (!name) return;
+
+            try {
+                const res = await fetch('/api/files/touch', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ path: currentPath, name })
+                });
+
+                if (!res.ok) {
+                    const err = await res.json();
+                    throw new Error(err.detail || 'Failed to create file');
+                }
+
+                const data = await res.json();
+                closeModals();
+                showToast('File created');
+                loadFiles(currentPath);
+                loadTree();
+                openFilePreview(data.path);
+            } catch (err) {
+                showToast(err.message, true);
+            }
+        }
+
         // Upload
         function triggerUpload() {
             document.getElementById('file-input').click();
@@ -4921,12 +4976,24 @@
             if (e.key === 'Escape') closeModals();
         });
 
+        document.getElementById('new-file-input').addEventListener('keydown', (e) => {
+            if (e.key === 'Enter') confirmNewFile();
+            if (e.key === 'Escape') closeModals();
+        });
+
         document.getElementById('edit-textarea').addEventListener('keydown', (e) => {
             if (e.key === 'Escape') closeModals();
             if (e.key === 's' && (e.ctrlKey || e.metaKey)) {
                 e.preventDefault();
                 saveFileContent();
             }
+        });
+
+        ['anthropic-key-input', 'openai-key-input'].forEach(id => {
+            document.getElementById(id).addEventListener('keydown', (e) => {
+                if (e.key === 'Enter') saveSettings();
+                if (e.key === 'Escape') closeModals();
+            });
         });
 
         // Toast

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -3845,9 +3845,9 @@
                 </p>
             </div>
 
-            <div class="modal-actions" style="margin-top: 20px; justify-content: flex-end;">
-                <button class="btn" onclick="closeModals()">Cancel</button>
+            <div class="modal-actions" style="margin-top: 20px; justify-content: flex-start;">
                 <button class="btn btn-primary" id="settings-save-btn" onclick="saveSettings()">Save</button>
+                <button class="btn" onclick="closeModals()">Cancel</button>
             </div>
         </div>
     </div>

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -591,6 +591,8 @@
         .actions .btn {
             justify-content: center;
             gap: 6px;
+            font-size: 12px;
+            white-space: nowrap;
         }
 
         .btn {
@@ -3414,19 +3416,19 @@
 
             <div class="actions">
                 <button class="btn" onclick="showNewFileModal()">
-                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" style="width:18px;height:18px;">
                         <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H8.25m3.75 9v6m3-3H9m1.5-12H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 00-9-9z" />
                     </svg>
                     New File
                 </button>
                 <button class="btn" onclick="showNewFolderModal()">
-                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" style="width:18px;height:18px;">
                         <path stroke-linecap="round" stroke-linejoin="round" d="M12 10.5v6m3-3H9m4.06-7.19l-2.12-2.12a1.5 1.5 0 00-1.061-.44H4.5A2.25 2.25 0 002.25 6v12a2.25 2.25 0 002.25 2.25h15A2.25 2.25 0 0021.75 18V9a2.25 2.25 0 00-2.25-2.25h-5.379a1.5 1.5 0 01-1.06-.44z" />
                     </svg>
                     New Folder
                 </button>
                 <button class="btn btn-primary btn-upload" onclick="triggerUpload()">
-                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" style="width:16px;height:16px;">
                         <path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5m-13.5-9L12 3m0 0l4.5 4.5M12 3v13.5" />
                     </svg>
                     Upload

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -7198,6 +7198,12 @@
                 e.preventDefault();
                 e.stopPropagation();
 
+                // Close any open modal first
+                if (document.querySelector('.modal-overlay.show')) {
+                    closeModals();
+                    return;
+                }
+
                 // In preview-only mode, go to home page
                 if (document.documentElement.classList.contains('preview-only-mode')) {
                     window.location.href = '/';


### PR DESCRIPTION
Nothing major. The chatbot could already create new files, but now users can manually do it through a button.
<img width="299" height="1050" alt="Screenshot 2026-04-28 at 11 38 55 AM" src="https://github.com/user-attachments/assets/6a995e1c-1c4d-4b08-a54c-abebe517ccd6" />
- New file creation — added a "New File" button to the file browser sidebar that opens a modal for naming and creating an empty file. The file is immediately opened for preview after creation.                                                                                                                                                               
- Implemented enter key support for modals — pressing Enter now confirms actions, just as Esc cancels/closes.                                                  
- Action button layout polish — sidebar action buttons are reorganized into a 2-column grid with updated icons and font sizing; Upload is promoted to a full-width primary button below the two creation actions.                                                           
                  
Test plan                                                                                                                             
- [ ] Create a new file from the sidebar — verify it appears in the file tree and opens in preview                                        
- [ ] Attempt to create a file with a duplicate name — verify a toast error appears
- [ ] Confirm Enter key submits the New File modal and Escape dismisses it                                                                
- [ ] Confirm Enter key saves API key settings
- [ ] Verify Upload button still works and spans full width    