### PR TITLE
feat: Publish to PyPI and add MIT License

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Santai Engineering
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,18 @@ readme = "README.md"
 authors = [
     { name = "Santai Engineering", email = "engineering@sant.ai" }
 ]
+license = { text = "MIT" }
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
+    "Topic :: Utilities",
+]
 requires-python = ">=3.12"
 dependencies = [
     "typer>=0.12.0,<1.0",
@@ -30,6 +42,11 @@ dev = [
 
 [project.scripts]
 santai = "santai_cli.cli:app"
+
+[project.urls]
+Homepage = "https://github.com/santai-inc/santai-cli"
+Repository = "https://github.com/santai-inc/santai-cli"
+Issues = "https://github.com/santai-inc/santai-cli/issues"
 
 [build-system]
 requires = ["hatchling"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "santai-cli"
 version = "0.1.0"
-description = "Santai project management CLI"
+description = "A CLI Collaborative Knowledge Base Management System"
 readme = "README.md"
 authors = [
     { name = "Santai Engineering", email = "engineering@sant.ai" }


### PR DESCRIPTION
## Summary

- Add MIT `LICENSE` file to the repository root
- Update `pyproject.toml` with `license` field, PyPI trove classifiers, and `project.urls`
- Update project description to "A CLI Collaborative Knowledge Base Management System"
- Package builds and metadata verified with `uv build`

Closes #25