### PR TITLE
feat(docker): use PyPI install instead of source build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+# No source is copied into the image (installed from PyPI),
+# but keep this file to avoid accidentally sending large context
+# if the build context is ever referenced.
+.git
+.venv
+__pycache__
+*.pyc
+.env
+*.egg-info
+dist/
+build/
+.ruff_cache/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+# Santai CLI — lightweight image installing from PyPI
+FROM python:3.12-slim
+
+# Install system dependencies (git is required by `santai init`)
+RUN apt-get update && apt-get install -y --no-install-recommends git \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install santai-cli from PyPI
+RUN pip install --no-cache-dir santai-cli
+
+# Create a non-root user
+RUN groupadd --gid 1000 santai \
+    && useradd --uid 1000 --gid santai --create-home santai
+
+# Default working directory for santai projects (mountable volume)
+RUN mkdir -p /data && chown santai:santai /data
+WORKDIR /data
+
+USER santai
+
+# Expose the web dashboard port
+EXPOSE 8000
+
+# Default entrypoint — override command via docker compose
+ENTRYPOINT ["santai"]
+CMD ["--help"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,43 @@
+# Santai CLI - Docker Compose
+# Usage:
+#   docker compose up santai-web          # Start the web dashboard on port 8000
+#   docker compose run santai-cli --help  # Run any santai CLI command
+#
+# Environment:
+#   Copy .env.example to .env and fill in your API keys before running.
+
+services:
+  # ── CLI service (one-off commands) ─────────────────────────────────
+  santai-cli:
+    build: .
+    image: santai-cli:latest
+    env_file:
+      - path: .env
+        required: false
+    volumes:
+      - santai-data:/data
+    # Override entrypoint args via: docker compose run santai-cli <command>
+    # Examples:
+    #   docker compose run santai-cli init myproject
+    #   docker compose run santai-cli --help
+    stdin_open: true
+    tty: true
+
+  # ── Web dashboard service ──────────────────────────────────────────
+  santai-web:
+    build: .
+    image: santai-cli:latest
+    env_file:
+      - path: .env
+        required: false
+    ports:
+      - "8000:8000"
+    volumes:
+      - santai-data:/data
+    # Start the web dashboard bound to 0.0.0.0 so it is reachable
+    # from outside the container, and skip auto-opening a browser.
+    command: ["web", "--host", "0.0.0.0", "--port", "8000", "--no-open"]
+
+volumes:
+  santai-data:
+    driver: local


### PR DESCRIPTION
## Summary

- Replaces the multi-stage source-copy Dockerfile with a single-stage image that installs `santai-cli` directly from PyPI via `pip install santai-cli`
- Maintains the same docker-compose services (`santai-cli` for interactive CLI, `santai-web` for the FastAPI dashboard on port 8000)
- Produces a smaller, simpler image with no build tools, source tree, or virtual environment overhead

## Changes

| File | Description |
|------|-------------|
| `Dockerfile` | Single-stage `python:3.12-slim` image with `pip install santai-cli` |
| `docker-compose.yml` | Two services with shared volume and env_file support |
| `.dockerignore` | Minimal ignore file to keep build context clean |

## Usage

```bash
# Build the image
docker build -t santai-cli .

# Start the web dashboard
docker compose up santai-web

# Run CLI commands
docker compose run santai-cli --help
docker compose run santai-cli init myproject
```

## Notes

- The existing `51-docker-support` branch used a source-copy + `uv sync` approach. This PR supersedes that approach now that `santai-cli` is published on PyPI.
- `.env.example` already exists on main with the required API key configuration.

Closes #64