### PR TITLE
feat(server): API authentication — localhost no-auth + optional token auth

### DIFF
--- a/src/santai_cli/commands/server.py
+++ b/src/santai_cli/commands/server.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from typing import Annotated
 
 import typer
@@ -24,7 +25,12 @@ def server(
     ] = 8080,
     token: Annotated[
         str | None,
-        typer.Option("--token", "-t", help="Bearer token for API authentication"),
+        typer.Option(
+            "--token",
+            "-t",
+            help="Bearer token for API authentication "
+            "(overrides SANTAI_SERVER_TOKEN env var)",
+        ),
     ] = None,
 ) -> None:
     """Launch the headless API server.
@@ -33,11 +39,16 @@ def server(
     project operations. OpenAPI docs available at /docs.
     Press Ctrl+C to stop the server.
     """
-    app = create_server_app(token=token)
+    # Resolve token: CLI flag takes precedence over env var
+    resolved_token = token or os.environ.get("SANTAI_SERVER_TOKEN") or None
+
+    app = create_server_app(token=resolved_token, host=host)
 
     console.print("[green]Starting Santai API server[/green]")
     console.print(f"[blue]Server running at: http://{host}:{port}[/blue]")
     console.print(f"[blue]API docs at: http://{host}:{port}/docs[/blue]")
+    if resolved_token:
+        console.print("[yellow]Authentication enabled[/yellow]")
     console.print("[dim]Press Ctrl+C to stop[/dim]")
     console.print()
 

--- a/src/santai_cli/server/app.py
+++ b/src/santai_cli/server/app.py
@@ -2,11 +2,17 @@
 
 from __future__ import annotations
 
-from fastapi import FastAPI
+import logging
+
+from fastapi import Depends, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
+from santai_cli.server.auth import create_auth_dependency
 
-def create_server_app(token: str | None = None) -> FastAPI:
+logger = logging.getLogger("santai.server")
+
+
+def create_server_app(token: str | None = None, host: str = "127.0.0.1") -> FastAPI:
     """Create and configure the headless FastAPI server application.
 
     Parameters
@@ -14,12 +20,26 @@ def create_server_app(token: str | None = None) -> FastAPI:
     token:
         Optional bearer token for API authentication.
         When ``None``, all requests are allowed.
+    host:
+        The host the server will bind to. Used to emit a warning
+        when binding to a non-localhost address without a token.
     """
+    # Warn when binding to non-localhost without a token
+    if host != "127.0.0.1" and host != "localhost" and token is None:
+        logger.warning(
+            "Server binding to %s without authentication token. "
+            "Consider using --token or SANTAI_SERVER_TOKEN to secure the API.",
+            host,
+        )
+
+    auth_dep = create_auth_dependency(token)
+
     app = FastAPI(
         title="Santai Server",
         description="Headless API for Santai project operations",
         docs_url="/docs",
         openapi_url="/openapi.json",
+        dependencies=[Depends(auth_dep)],
     )
 
     # CORS middleware for API access from external clients

--- a/src/santai_cli/server/auth.py
+++ b/src/santai_cli/server/auth.py
@@ -1,0 +1,66 @@
+"""Authentication middleware for the Santai API server."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import HTTPException, Request, status
+
+# Paths that skip authentication
+PUBLIC_PATHS: set[str] = {
+    "/api/health",
+    "/docs",
+    "/openapi.json",
+    "/redoc",
+}
+
+
+def create_auth_dependency(token: str | None) -> Any:
+    """Create a FastAPI dependency that enforces bearer token auth.
+
+    Parameters
+    ----------
+    token:
+        The expected bearer token. When ``None``, authentication is
+        disabled and all requests are allowed through.
+
+    Returns
+    -------
+    A callable suitable for use as an app-level dependency.
+    """
+
+    async def verify_token(request: Request) -> None:
+        # No token configured — allow all requests
+        if token is None:
+            return
+
+        # Skip auth for public paths
+        if request.url.path in PUBLIC_PATHS:
+            return
+
+        # Token is configured — require valid Authorization header
+        auth_header = request.headers.get("Authorization")
+        if not auth_header:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Missing authentication token",
+                headers={"WWW-Authenticate": "Bearer"},
+            )
+
+        # Expect "Bearer <token>" format
+        parts = auth_header.split(" ", 1)
+        if len(parts) != 2 or parts[0].lower() != "bearer":
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Invalid authentication token",
+                headers={"WWW-Authenticate": "Bearer"},
+            )
+
+        if parts[1] != token:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Invalid authentication token",
+                headers={"WWW-Authenticate": "Bearer"},
+            )
+
+    return verify_token


### PR DESCRIPTION
## Summary

- Adds bearer token authentication middleware for the santai server API
- Token can be provided via `--token` CLI flag or `SANTAI_SERVER_TOKEN` environment variable (CLI takes precedence)
- When no token is configured, all requests are allowed (localhost-only use case)
- When a token is configured, all endpoints require a valid `Authorization: Bearer <token>` header
- Health check (`/api/health`) and docs (`/docs`, `/openapi.json`) are always accessible without auth
- Emits a warning when binding to a non-localhost address without a token configured

## Changes

- `src/santai_cli/server/auth.py` — New auth module with `create_auth_dependency()`
- `src/santai_cli/server/app.py` — Wire auth dependency into FastAPI app, add non-localhost warning
- `src/santai_cli/commands/server.py` — Resolve token from CLI flag or env var

## Stacking

This PR is stacked on #81 (`68-server-scaffold`).

Closes #69