### PR TITLE
fix: corrected model availability, improved file tree utility

### DIFF
--- a/src/santai_cli/core/chat.py
+++ b/src/santai_cli/core/chat.py
@@ -31,6 +31,13 @@ _NO_SYSTEM_ROLE_MODELS: set[str] = {
     "us.amazon.nova-pro-v1:0",
 }
 
+# These models output interleaved reasoning/thinking in delta.content by default.
+# Disable it so users only see the final answer.
+_DISABLE_THINKING_MODELS: set[str] = {
+    "novapro-bedrock",
+    "us.amazon.nova-pro-v1:0",
+}
+
 
 def _max_tokens_for_model(model: str) -> int:
     return _MAX_TOKENS_BY_MODEL.get(model, _DEFAULT_MAX_TOKENS)
@@ -455,6 +462,8 @@ async def _stream_openai_with_tools(
     # Don't impose a max_tokens cap for proxy providers — they enforce their own limits.
     if not base_url:
         create_kwargs["max_tokens"] = _max_tokens_for_model(model)
+    if model in _DISABLE_THINKING_MODELS:
+        create_kwargs["extra_body"] = {"thinking": {"type": "disabled"}}
     stream = await client.chat.completions.create(**create_kwargs)  # type: ignore[arg-type]
 
     async for chunk in stream:

--- a/src/santai_cli/core/chat.py
+++ b/src/santai_cli/core/chat.py
@@ -27,8 +27,6 @@ _DEFAULT_MAX_TOKENS = 8192
 # These Bedrock-backed models reject a leading system-role message.
 # We merge the system prompt into the first user message instead.
 _NO_SYSTEM_ROLE_MODELS: set[str] = {
-    "deepseekr1-bedrock",
-    "llama3.3-bedrock",
     "novapro-bedrock",
     "us.amazon.nova-pro-v1:0",
 }
@@ -436,12 +434,17 @@ async def _stream_openai_with_tools(
     full_text = ""
 
     messages = session.to_openai_messages()
-    if model in _NO_SYSTEM_ROLE_MODELS and messages and messages[0]["role"] == "system":
-        system_content = messages.pop(0)["content"]
-        for msg in messages:
-            if msg["role"] == "user":
-                msg["content"] = f"{system_content}\n\n{msg['content']}"
-                break
+    if model in _NO_SYSTEM_ROLE_MODELS:
+        # Merge system prompt into first user message
+        if messages and messages[0]["role"] == "system":
+            system_content = messages.pop(0)["content"]
+            for msg in messages:
+                if msg["role"] == "user":
+                    msg["content"] = f"{system_content}\n\n{msg['content']}"
+                    break
+        # Strip any leading non-user messages (e.g. assistant greeting)
+        while messages and messages[0]["role"] != "user":
+            messages.pop(0)
 
     create_kwargs: dict = {
         "model": model,

--- a/src/santai_cli/core/chat.py
+++ b/src/santai_cli/core/chat.py
@@ -33,6 +33,8 @@ _NO_SYSTEM_ROLE_MODELS: set[str] = {
 
 # These models output interleaved reasoning/thinking in delta.content by default.
 # Disable it so users only see the final answer.
+# NOTE: currently the same entries as _NO_SYSTEM_ROLE_MODELS — if you add a model
+# to one set, consider whether it also belongs in the other.
 _DISABLE_THINKING_MODELS: set[str] = {
     "novapro-bedrock",
     "us.amazon.nova-pro-v1:0",

--- a/src/santai_cli/core/chat.py
+++ b/src/santai_cli/core/chat.py
@@ -24,6 +24,15 @@ _MAX_TOKENS_BY_MODEL: dict[str, int] = {
 }
 _DEFAULT_MAX_TOKENS = 8192
 
+# These Bedrock-backed models reject a leading system-role message.
+# We merge the system prompt into the first user message instead.
+_NO_SYSTEM_ROLE_MODELS: set[str] = {
+    "deepseekr1-bedrock",
+    "llama3.3-bedrock",
+    "novapro-bedrock",
+    "us.amazon.nova-pro-v1:0",
+}
+
 
 def _max_tokens_for_model(model: str) -> int:
     return _MAX_TOKENS_BY_MODEL.get(model, _DEFAULT_MAX_TOKENS)
@@ -426,9 +435,17 @@ async def _stream_openai_with_tools(
     pending_tools: dict[int, dict[str, Any]] = {}
     full_text = ""
 
+    messages = session.to_openai_messages()
+    if model in _NO_SYSTEM_ROLE_MODELS and messages and messages[0]["role"] == "system":
+        system_content = messages.pop(0)["content"]
+        for msg in messages:
+            if msg["role"] == "user":
+                msg["content"] = f"{system_content}\n\n{msg['content']}"
+                break
+
     create_kwargs: dict = {
         "model": model,
-        "messages": session.to_openai_messages(),
+        "messages": messages,
         "stream": True,
         "tools": TOOLS_OPENAI,
     }

--- a/src/santai_cli/core/config.py
+++ b/src/santai_cli/core/config.py
@@ -18,6 +18,8 @@ DEFAULT_MODELS: dict[str, str] = {
 
 # Fallback model lists used when the provider's /v1/models API call fails.
 # The live API is always preferred — these are last-resort defaults only.
+# IDs must match what the provider API returns (including date suffixes where
+# the provider requires them, e.g. claude-haiku-4-5-20251001).
 AVAILABLE_MODELS: dict[str, list[str]] = {
     "anthropic": [
         "claude-opus-4-7",

--- a/src/santai_cli/core/config.py
+++ b/src/santai_cli/core/config.py
@@ -16,22 +16,18 @@ DEFAULT_MODELS: dict[str, str] = {
     "openai": "gpt-4o",
 }
 
-# Popular models available per provider (for interactive selection)
+# Fallback model lists used when the provider's /v1/models API call fails.
+# The live API is always preferred — these are last-resort defaults only.
 AVAILABLE_MODELS: dict[str, list[str]] = {
     "anthropic": [
         "claude-opus-4-7",
         "claude-sonnet-4-6",
         "claude-haiku-4-5-20251001",
-        "claude-3-7-sonnet-20250219",
-        "claude-3-5-sonnet-20241022",
-        "claude-3-5-haiku-20241022",
     ],
     "openai": [
-        "gpt-4o",
-        "gpt-4o-mini",
         "gpt-4.1",
         "gpt-4.1-mini",
-        "gpt-4.1-nano",
+        "gpt-4o",
         "o3-mini",
     ],
 }

--- a/src/santai_cli/core/repo_context.py
+++ b/src/santai_cli/core/repo_context.py
@@ -8,11 +8,7 @@ of all files and content in the repository.
 from dataclasses import dataclass
 from pathlib import Path
 
-from santai_cli.core.project import (
-    SantaiProject,
-    get_history_entries,
-    get_notes,
-)
+from santai_cli.core.project import SantaiProject
 
 
 @dataclass
@@ -21,9 +17,6 @@ class RepoContext:
 
     project: SantaiProject
     file_tree: str
-    wiki_content: str
-    notes_content: str
-    history_content: str
     resources_summary: str
 
 
@@ -64,77 +57,6 @@ def _build_file_tree(root: Path, max_depth: int = 4) -> str:
 
     lines.extend(_walk(root))
     return "\n".join(lines)
-
-
-def _format_wiki_content(project: SantaiProject, max_entries: int = 10) -> str:
-    """Format wiki entries for context.
-
-    Args:
-        project: The Santai project.
-        max_entries: Maximum number of wiki entries to include.
-
-    Returns:
-        Formatted wiki content string.
-    """
-    wiki_path = project.wiki_path
-    if not wiki_path.is_dir():
-        return ""
-
-    entries = []
-    for file_path in sorted(wiki_path.glob("*.md"))[:max_entries]:
-        try:
-            content = file_path.read_text(encoding="utf-8")
-            title = file_path.stem.replace("-", " ").replace("_", " ").title()
-            entries.append(f"## {title}\n{content}\n")
-        except (OSError, UnicodeDecodeError):
-            continue
-
-    if not entries:
-        return ""
-
-    return f"## Wiki Content\n\n{'=' * 40}\n\n" + "\n\n".join(entries)
-
-
-def _format_notes_content(project: SantaiProject, max_entries: int = 10) -> str:
-    """Format note entries for context.
-
-    Args:
-        project: The Santai project.
-        max_entries: Maximum number of notes to include.
-
-    Returns:
-        Formatted notes content string.
-    """
-    notes = get_notes(project)
-    if not notes:
-        return ""
-
-    entries = []
-    for note in notes[:max_entries]:
-        entries.append(f"## {note.title}\n{note.content}\n")
-
-    return f"## Notes\n\n{'=' * 40}\n\n" + "\n\n".join(entries)
-
-
-def _format_history_content(project: SantaiProject, max_entries: int = 10) -> str:
-    """Format history entries for context.
-
-    Args:
-        project: The Santai project.
-        max_entries: Maximum number of history entries to include.
-
-    Returns:
-        Formatted history content string.
-    """
-    history = get_history_entries(project)
-    if not history:
-        return ""
-
-    entries = []
-    for entry in history[:max_entries]:
-        entries.append(f"## {entry.title} ({entry.date})\n{entry.content}\n")
-
-    return f"## History\n\n{'=' * 40}\n\n" + "\n\n".join(entries)
 
 
 def _get_resources_summary(project: SantaiProject) -> str:
@@ -178,9 +100,6 @@ def build_repo_context(project: SantaiProject) -> RepoContext:
     This function scans the project directory and generates structured
     context including:
     - File tree structure
-    - Wiki content (most recent entries)
-    - Notes content (most recent entries)
-    - History content (most recent entries)
     - Resources summary
 
     Args:
@@ -192,9 +111,6 @@ def build_repo_context(project: SantaiProject) -> RepoContext:
     return RepoContext(
         project=project,
         file_tree=_build_file_tree(project.root),
-        wiki_content=_format_wiki_content(project),
-        notes_content=_format_notes_content(project),
-        history_content=_format_history_content(project),
         resources_summary=_get_resources_summary(project),
     )
 
@@ -216,21 +132,12 @@ def build_repo_context_prompt(context: RepoContext) -> str:
         "",
         (
             "You have access to this Santai project. "
-            "Below is its structure and key content:"
+            "Below is its structure — use read_file to get the contents of any file."
         ),
         "",
         "### File Tree",
         f"```\n{context.file_tree}\n```",
     ]
-
-    if context.wiki_content:
-        sections.extend(["", context.wiki_content])
-
-    if context.notes_content:
-        sections.extend(["", context.notes_content])
-
-    if context.history_content:
-        sections.extend(["", context.history_content])
 
     if context.resources_summary:
         sections.extend(["", context.resources_summary])
@@ -239,10 +146,10 @@ def build_repo_context_prompt(context: RepoContext) -> str:
         [
             "",
             "## Important Guidelines",
-            "- You have full visibility into this project's structure and content.",
-            "- When answering questions, reference relevant files and content.",
+            "- You can see the file tree above, but you do NOT have the file contents in context.",
+            "- IMPORTANT: Whenever a user asks a question that could be answered by a file in this project (notes, wiki, resources, codebases, or any other file), you MUST call read_file to read the relevant file(s) before answering. Never answer knowledge-base questions from memory — always fetch fresh content with the tool.",
+            "- If multiple files might be relevant, read each one before responding.",
             "- Use [[wikilinks]] or markdown links when referencing project files.",
-            "- IMPORTANT: When a user asks you to summarize, analyze, or answer questions about a specific file, ALWAYS call read_file first to get the full contents. Never answer from memory or the file tree alone — use the tool.",
             "- IMPORTANT: If a read_file result includes 'truncated: true', the file was cut off. Acknowledge this to the user rather than treating the partial content as complete.",
         ]
     )

--- a/src/santai_cli/web/app.py
+++ b/src/santai_cli/web/app.py
@@ -335,9 +335,15 @@ def create_app(project: SantaiProject) -> FastAPI:
 
     @app.post("/api/files")
     async def upload_file(
-        file: UploadFile, path: str = Query(default="")
+        file: UploadFile,
+        path: str = Query(default=""),
+        relative_path: str = Query(default=""),
     ) -> dict[str, str]:
-        """Upload a file to the given path."""
+        """Upload a file to the given path.
+
+        When relative_path is provided (folder upload), the full relative path
+        within the folder is preserved and parent directories are created.
+        """
         target_dir = safe_path(path)
         if not target_dir.is_dir():
             raise HTTPException(
@@ -347,11 +353,17 @@ def create_app(project: SantaiProject) -> FastAPI:
         if not file.filename:
             raise HTTPException(status_code=400, detail="No filename provided")
 
-        file_path = target_dir / file.filename
-        if file_path.exists():
-            raise HTTPException(status_code=409, detail="File already exists")
+        if relative_path:
+            file_path = target_dir / relative_path
+            # Validate the resolved path is within the project root
+            safe_path(str(file_path.relative_to(root_dir)))
+            file_path.parent.mkdir(parents=True, exist_ok=True)
+        else:
+            file_path = target_dir / file.filename
+            if file_path.exists():
+                raise HTTPException(status_code=409, detail="File already exists")
+            safe_path(str(file_path.relative_to(root_dir)))
 
-        safe_path(str(file_path.relative_to(root_dir)))
         with open(file_path, "wb") as f:
             content = await file.read()
             f.write(content)

--- a/src/santai_cli/web/app.py
+++ b/src/santai_cli/web/app.py
@@ -691,9 +691,9 @@ def create_app(project: SantaiProject) -> FastAPI:
         "claude-opus-4-7": "Claude Opus 4.7",
         "claude-sonnet-4-6": "Claude Sonnet 4.6",
         "claude-haiku-4-5-20251001": "Claude Haiku 4.5",
-        "claude-3-7-sonnet-20250219": "Claude 3.7 Sonnet",
-        "claude-3-5-sonnet-20241022": "Claude 3.5 Sonnet",
-        "claude-3-5-haiku-20241022": "Claude 3.5 Haiku",
+        "claude-3-7-sonnet-20250219": "Claude Sonnet 3.7",
+        "claude-3-5-sonnet-20241022": "Claude Sonnet 3.5",
+        "claude-3-5-haiku-20241022": "Claude Haiku 3.5",
         # Anthropic via direct API
         "anthropic-4.5": "Claude Sonnet 4.5",
         # Anthropic via Bedrock
@@ -722,7 +722,13 @@ def create_app(project: SantaiProject) -> FastAPI:
         "gpt-4.1": "GPT-4.1",
         "gpt-4.1-mini": "GPT-4.1 mini",
         "gpt-4.1-nano": "GPT-4.1 nano",
+        "chatgpt-4o-latest": "GPT-4o",
+        "o1": "o1",
+        "o1-mini": "o1-mini",
+        "o1-preview": "o1-preview",
+        "o3": "o3",
         "o3-mini": "o3-mini",
+        "o4-mini": "o4-mini",
         # OpenAI (via proxy)
         "gpt-5big-santai": "GPT-5",
         "gpt-5.4-santai": "GPT-5.4",
@@ -740,13 +746,21 @@ def create_app(project: SantaiProject) -> FastAPI:
         """Convert a raw model ID to a human-readable label.
 
         e.g. 'anthropic-claude-bedrock4.5-haiku'  -> 'Claude Haiku 4.5'
-             'anthropic-claude-bedrock4.6opus'     -> 'Claude Opus 4.6'
+             'claude-3-5-haiku-20241022'           -> 'Claude 3.5 Haiku'
+             'claude-3-7-sonnet-20250219'          -> 'Claude 3.7 Sonnet'
              'gemini-2.5-pro'                      -> 'Gemini 2.5 Pro'
              'llama3.1-70b'                        -> 'Llama 3.1 70b'
              'us.amazon.nova-pro-v1:0'             -> 'Nova Pro'
         """
         # Drop trailing revision suffixes like :0
         model_id = re.sub(r":\d+$", "", model_id)
+        # Strip trailing 8-digit release dates (e.g. -20241022, -20250219)
+        model_id = re.sub(r"-\d{8}$", "", model_id)
+        # Strip trailing YYYY-MM-DD dates (e.g. -2024-11-20)
+        model_id = re.sub(r"-\d{4}-\d{2}-\d{2}$", "", model_id)
+        # Strip trailing -latest alias
+        model_id = re.sub(r"-latest$", "", model_id)
+
         # Split on hyphens/underscores, then expand dot-namespaced word segments
         # (e.g. 'us.amazon.nova') but keep decimal versions ('2.5') and
         # alpha+version segments ('llama3.1') intact.
@@ -761,8 +775,26 @@ def create_app(project: SantaiProject) -> FastAPI:
             else:
                 raw_parts.append(seg)
 
+        # Collapse consecutive single-digit numeric tokens into a dotted version.
+        # e.g. ['claude', '3', '5', 'haiku'] -> ['claude', '3.5', 'haiku']
+        collapsed: list[str] = []
+        i = 0
+        while i < len(raw_parts):
+            if (
+                re.fullmatch(r"\d", raw_parts[i])
+                and i + 1 < len(raw_parts)
+                and re.fullmatch(r"\d+", raw_parts[i + 1])
+            ):
+                collapsed.append(f"{raw_parts[i]}.{raw_parts[i + 1]}")
+                i += 2
+            else:
+                collapsed.append(raw_parts[i])
+                i += 1
+        raw_parts = collapsed
+
         words: list[str] = []
         trailing_versions: list[str] = []
+        is_claude = raw_parts and raw_parts[0].lower() == "claude"
         for part in raw_parts:
             if not part:
                 continue
@@ -776,9 +808,13 @@ def create_app(project: SantaiProject) -> FastAPI:
                 if bm.group(2):
                     words.append(bm.group(2).capitalize())
                 continue
-            # Pure version/numeric segment like '4.5', '70b', 'v1' — keep in position
+            # Pure version/numeric segment — for Claude IDs push to end so the
+            # family word comes first: "Claude Haiku 3.5" not "Claude 3.5 Haiku"
             if re.match(r"^v?\d", low):
-                words.append(part)
+                if is_claude:
+                    trailing_versions.append(part)
+                else:
+                    words.append(part)
                 continue
             # Alpha prefix glued to version, e.g. 'llama3.1', 'gpt4o'
             am = re.match(r"^([a-zA-Z]+)(\d.*)$", part)
@@ -860,6 +896,8 @@ def create_app(project: SantaiProject) -> FastAPI:
                             m.id
                             for m in page.data
                             if m.id.startswith(_OPENAI_CHAT_PREFIXES)
+                            # Exclude dated snapshots like gpt-4o-2024-11-20
+                            and not re.search(r"-\d{4}-\d{2}-\d{2}$", m.id)
                         ],
                         reverse=True,
                     )

--- a/src/santai_cli/web/app.py
+++ b/src/santai_cli/web/app.py
@@ -109,7 +109,7 @@ def get_file_tree(
     for item in sorted(
         base_path.iterdir(), key=lambda x: (not x.is_dir(), x.name.lower())
     ):
-        if item.name.startswith("."):
+        if item.name.startswith(".") or item.name == "rumdl.toml":
             continue
 
         node: dict[str, Any] = {
@@ -318,7 +318,7 @@ def create_app(project: SantaiProject) -> FastAPI:
         for item in sorted(
             target.iterdir(), key=lambda x: (not x.is_dir(), x.name.lower())
         ):
-            if item.name.startswith("."):
+            if item.name.startswith(".") or item.name == "rumdl.toml":
                 continue
             try:
                 items.append(get_file_info(item))
@@ -522,7 +522,7 @@ def create_app(project: SantaiProject) -> FastAPI:
                 for item in sorted(
                     dir_path.iterdir(), key=lambda x: (not x.is_dir(), x.name.lower())
                 ):
-                    if item.name.startswith("."):
+                    if item.name.startswith(".") or item.name == "rumdl.toml":
                         continue
                     node = {
                         "name": item.name,

--- a/src/santai_cli/web/app.py
+++ b/src/santai_cli/web/app.py
@@ -861,7 +861,13 @@ def create_app(project: SantaiProject) -> FastAPI:
 
         config = load_config(project.root)
         models: list[dict[str, str | bool]] = []
+        # Maps provider_name -> {type, display} for providers that failed.
+        provider_errors: dict[str, dict[str, str]] = {}
         for provider_name, provider_config in config.providers.items():
+
+            def _err(kind: str) -> dict[str, str]:
+                return {"type": kind, "display": provider_config.name}
+
             if provider_config.base_url:
                 # Fetch model list from LiteLLM proxy
                 proxy_models: list[str] = []
@@ -877,16 +883,25 @@ def create_app(project: SantaiProject) -> FastAPI:
                         resp.raise_for_status()
                         data = resp.json()
                         proxy_models = [m["id"] for m in data.get("data", [])]
+                except httpx.HTTPStatusError as e:
+                    if e.response.status_code in (401, 403):
+                        provider_errors[provider_name] = _err("invalid_key")
+                    else:
+                        provider_errors[provider_name] = _err("unavailable")
                 except Exception:
-                    pass
-                model_list = proxy_models or [provider_config.model]
+                    provider_errors[provider_name] = _err("unavailable")
+                model_list = proxy_models
             elif provider_name == "anthropic":
                 try:
                     ac = _anthropic.AsyncAnthropic(api_key=provider_config.api_key)
                     page = await ac.models.list(limit=100)
                     model_list = [m.id for m in page.data]
+                except _anthropic.AuthenticationError:
+                    model_list = []
+                    provider_errors[provider_name] = _err("invalid_key")
                 except Exception:
-                    model_list = provider_config.available_models
+                    model_list = []
+                    provider_errors[provider_name] = _err("unavailable")
             elif provider_name == "openai":
                 try:
                     oc = _openai.AsyncOpenAI(api_key=provider_config.api_key)
@@ -901,8 +916,12 @@ def create_app(project: SantaiProject) -> FastAPI:
                         ],
                         reverse=True,
                     )
+                except _openai.AuthenticationError:
+                    model_list = []
+                    provider_errors[provider_name] = _err("invalid_key")
                 except Exception:
-                    model_list = provider_config.available_models
+                    model_list = []
+                    provider_errors[provider_name] = _err("unavailable")
             else:
                 model_list = provider_config.available_models
 
@@ -929,7 +948,11 @@ def create_app(project: SantaiProject) -> FastAPI:
                 seen.add(m["display"])
                 deduped.append(m)
         deduped.sort(key=lambda m: m["display"].lower())
-        return {"models": deduped, "configured": config.has_any_provider}
+        return {
+            "models": deduped,
+            "configured": config.has_any_provider,
+            "errors": provider_errors,
+        }
 
     @app.get("/api/chat/agents")
     async def chat_agents() -> dict[str, Any]:
@@ -1076,10 +1099,6 @@ def create_app(project: SantaiProject) -> FastAPI:
             existing["ANTHROPIC_API_KEY"] = req.anthropic_api_key.strip()
         if req.openai_api_key is not None and req.openai_api_key.strip():
             existing["OPENAI_API_KEY"] = req.openai_api_key.strip()
-
-        # Ensure defaults are present
-        existing.setdefault("ANTHROPIC_MODEL", "claude-sonnet-4-6")
-        existing.setdefault("OPENAI_MODEL", "gpt-4o")
 
         # Write .env file — quote all values so special chars are preserved
         lines = [f'{k}="{v}"\n' for k, v in existing.items()]

--- a/src/santai_cli/web/app.py
+++ b/src/santai_cli/web/app.py
@@ -28,6 +28,9 @@ from santai_cli.core.repo_context import build_repo_context, inject_repo_context
 TEMPLATES_DIR = Path(__file__).parent / "templates"
 STATIC_DIR = Path(__file__).parent / "static"
 
+# Files hidden from all file-tree listings (in addition to dotfiles).
+_HIDDEN_FILES: set[str] = {"rumdl.toml"}
+
 
 class RenameRequest(BaseModel):
     old_path: str
@@ -109,7 +112,7 @@ def get_file_tree(
     for item in sorted(
         base_path.iterdir(), key=lambda x: (not x.is_dir(), x.name.lower())
     ):
-        if item.name.startswith(".") or item.name == "rumdl.toml":
+        if item.name.startswith(".") or item.name in _HIDDEN_FILES:
             continue
 
         node: dict[str, Any] = {
@@ -318,7 +321,7 @@ def create_app(project: SantaiProject) -> FastAPI:
         for item in sorted(
             target.iterdir(), key=lambda x: (not x.is_dir(), x.name.lower())
         ):
-            if item.name.startswith(".") or item.name == "rumdl.toml":
+            if item.name.startswith(".") or item.name in _HIDDEN_FILES:
                 continue
             try:
                 items.append(get_file_info(item))
@@ -522,7 +525,7 @@ def create_app(project: SantaiProject) -> FastAPI:
                 for item in sorted(
                     dir_path.iterdir(), key=lambda x: (not x.is_dir(), x.name.lower())
                 ):
-                    if item.name.startswith(".") or item.name == "rumdl.toml":
+                    if item.name.startswith(".") or item.name in _HIDDEN_FILES:
                         continue
                     node = {
                         "name": item.name,
@@ -758,8 +761,8 @@ def create_app(project: SantaiProject) -> FastAPI:
         """Convert a raw model ID to a human-readable label.
 
         e.g. 'anthropic-claude-bedrock4.5-haiku'  -> 'Claude Haiku 4.5'
-             'claude-3-5-haiku-20241022'           -> 'Claude 3.5 Haiku'
-             'claude-3-7-sonnet-20250219'          -> 'Claude 3.7 Sonnet'
+             'claude-3-5-haiku-20241022'           -> 'Claude Haiku 3.5'
+             'claude-3-7-sonnet-20250219'          -> 'Claude Sonnet 3.7'
              'gemini-2.5-pro'                      -> 'Gemini 2.5 Pro'
              'llama3.1-70b'                        -> 'Llama 3.1 70b'
              'us.amazon.nova-pro-v1:0'             -> 'Nova Pro'
@@ -850,6 +853,18 @@ def create_app(project: SantaiProject) -> FastAPI:
     _anthropic_clients: dict[str, Any] = {}
     _openai_clients: dict[str, Any] = {}
 
+    # Chat-model prefixes to keep from the OpenAI /v1/models response.
+    # Excludes embeddings, TTS, Whisper, DALL-E, legacy completions, etc.
+    _OPENAI_CHAT_PREFIXES = (
+        "gpt-4",
+        "gpt-3.5-turbo",
+        "o1",
+        "o3",
+        "o4",
+        "chatgpt-4o",
+        "gpt-5",
+    )
+
     @app.get("/api/chat/models")
     async def chat_models() -> dict[str, Any]:
         """Return available AI models based on configured API keys.
@@ -863,18 +878,6 @@ def create_app(project: SantaiProject) -> FastAPI:
         import openai as _openai
 
         from santai_cli.core.config import load_config
-
-        # Chat-model prefixes to keep from the OpenAI /v1/models response.
-        # Excludes embeddings, TTS, Whisper, DALL-E, legacy completions, etc.
-        _OPENAI_CHAT_PREFIXES = (
-            "gpt-4",
-            "gpt-3.5-turbo",
-            "o1",
-            "o3",
-            "o4",
-            "chatgpt-4o",
-            "gpt-5",
-        )
 
         config = load_config(project.root)
         models: list[dict[str, str | bool]] = []
@@ -907,6 +910,8 @@ def create_app(project: SantaiProject) -> FastAPI:
                         provider_errors[provider_name] = _err("unavailable")
                 except Exception:
                     provider_errors[provider_name] = _err("unavailable")
+                if not proxy_models and provider_name not in provider_errors:
+                    provider_errors[provider_name] = _err("unavailable")
                 model_list = proxy_models
             elif provider_name == "anthropic":
                 try:
@@ -936,7 +941,6 @@ def create_app(project: SantaiProject) -> FastAPI:
                             m.id
                             for m in page.data
                             if m.id.startswith(_OPENAI_CHAT_PREFIXES)
-                            # Exclude dated snapshots like gpt-4o-2024-11-20
                             # Exclude dated snapshots (e.g. gpt-4o-2024-11-20).
                             # These are identical to the base model and clutter
                             # the list; the base ID is always present alongside them.

--- a/src/santai_cli/web/app.py
+++ b/src/santai_cli/web/app.py
@@ -675,6 +675,17 @@ def create_app(project: SantaiProject) -> FastAPI:
 
     # === Chat API Endpoints ===
 
+    # Models to never show in the dropdown regardless of what the proxy returns.
+    _BLOCKED_MODELS: set[str] = {
+        "deepseekr1-bedrock",  # fakes tool calls as plain text
+        "llama3.3-bedrock",  # fakes tool calls as plain text
+        "llama3.1-bedrock",  # no tool use in streaming mode
+        "llama3.2-1B-bedrock",  # no tool use in streaming mode
+        "qwen3-coder-bedrock",  # invalid model identifier
+        "jamba.2-bedrock",  # deprecated
+        "grok2-xai",  # deprecated
+    }
+
     _MODEL_DISPLAY_NAMES: dict[str, str] = {
         # Direct Anthropic models
         "claude-opus-4-7": "Claude Opus 4.7",
@@ -698,10 +709,6 @@ def create_app(project: SantaiProject) -> FastAPI:
         # Amazon
         "us.amazon.nova-pro-v1:0": "Nova Pro",
         "novapro-bedrock": "Nova Pro",
-        # Meta Llama via Bedrock
-        "llama3.3-bedrock": "Llama 3.3",
-        # DeepSeek via Bedrock
-        "deepseekr1-bedrock": "DeepSeek R1",
         # xAI Grok
         "grok3-xai": "Grok 3",
         # Google Gemini
@@ -827,6 +834,8 @@ def create_app(project: SantaiProject) -> FastAPI:
                 model_list = provider_config.available_models
 
             for model_name in model_list:
+                if model_name in _BLOCKED_MODELS:
+                    continue
                 is_default = model_name == provider_config.model
                 models.append(
                     {

--- a/src/santai_cli/web/app.py
+++ b/src/santai_cli/web/app.py
@@ -700,16 +700,9 @@ def create_app(project: SantaiProject) -> FastAPI:
         "novapro-bedrock": "Nova Pro",
         # Meta Llama via Bedrock
         "llama3.3-bedrock": "Llama 3.3",
-        "llama3.2-1B-bedrock": "Llama 3.2",
-        "llama3.1-bedrock": "Llama 3.1",
         # DeepSeek via Bedrock
         "deepseekr1-bedrock": "DeepSeek R1",
-        # Qwen via Bedrock
-        "qwen3-coder-bedrock": "Qwen3 Coder",
-        # AI21 via Bedrock
-        "jamba.2-bedrock": "Jamba Instruct",
         # xAI Grok
-        "grok2-xai": "Grok 2",
         "grok3-xai": "Grok 3",
         # Google Gemini
         "gemini-flash-2": "Gemini 2.0 Flash",

--- a/src/santai_cli/web/app.py
+++ b/src/santai_cli/web/app.py
@@ -845,6 +845,11 @@ def create_app(project: SantaiProject) -> FastAPI:
                 words.append(part.capitalize())
         return " ".join(words + trailing_versions)
 
+    # Cache provider API clients keyed by api_key so a config change gets a
+    # fresh client automatically without re-instantiating on every request.
+    _anthropic_clients: dict[str, Any] = {}
+    _openai_clients: dict[str, Any] = {}
+
     @app.get("/api/chat/models")
     async def chat_models() -> dict[str, Any]:
         """Return available AI models based on configured API keys.
@@ -905,7 +910,11 @@ def create_app(project: SantaiProject) -> FastAPI:
                 model_list = proxy_models
             elif provider_name == "anthropic":
                 try:
-                    ac = _anthropic.AsyncAnthropic(api_key=provider_config.api_key)
+                    if provider_config.api_key not in _anthropic_clients:
+                        _anthropic_clients[provider_config.api_key] = (
+                            _anthropic.AsyncAnthropic(api_key=provider_config.api_key)
+                        )
+                    ac = _anthropic_clients[provider_config.api_key]
                     page = await ac.models.list(limit=100)
                     model_list = [m.id for m in page.data]
                 except _anthropic.AuthenticationError:
@@ -916,7 +925,11 @@ def create_app(project: SantaiProject) -> FastAPI:
                     provider_errors[provider_name] = _err("unavailable")
             elif provider_name == "openai":
                 try:
-                    oc = _openai.AsyncOpenAI(api_key=provider_config.api_key)
+                    if provider_config.api_key not in _openai_clients:
+                        _openai_clients[provider_config.api_key] = _openai.AsyncOpenAI(
+                            api_key=provider_config.api_key
+                        )
+                    oc = _openai_clients[provider_config.api_key]
                     page = await oc.models.list()
                     model_list = sorted(
                         [
@@ -924,6 +937,9 @@ def create_app(project: SantaiProject) -> FastAPI:
                             for m in page.data
                             if m.id.startswith(_OPENAI_CHAT_PREFIXES)
                             # Exclude dated snapshots like gpt-4o-2024-11-20
+                            # Exclude dated snapshots (e.g. gpt-4o-2024-11-20).
+                            # These are identical to the base model and clutter
+                            # the list; the base ID is always present alongside them.
                             and not re.search(r"-\d{4}-\d{2}-\d{2}$", m.id)
                         ],
                         reverse=True,
@@ -935,6 +951,9 @@ def create_app(project: SantaiProject) -> FastAPI:
                     model_list = []
                     provider_errors[provider_name] = _err("unavailable")
             else:
+                # Unknown provider type (e.g. Bedrock, custom). Use the
+                # pre-configured model list from config — this is intentional
+                # fallback behaviour, not a sign that the provider is broken.
                 model_list = provider_config.available_models
 
             for model_name in model_list:

--- a/src/santai_cli/web/app.py
+++ b/src/santai_cli/web/app.py
@@ -805,15 +805,29 @@ def create_app(project: SantaiProject) -> FastAPI:
         model list dynamically from the proxy's /v1/models endpoint instead
         of using the hardcoded AVAILABLE_MODELS list.
         """
+        import anthropic as _anthropic
         import httpx
+        import openai as _openai
 
         from santai_cli.core.config import load_config
+
+        # Chat-model prefixes to keep from the OpenAI /v1/models response.
+        # Excludes embeddings, TTS, Whisper, DALL-E, legacy completions, etc.
+        _OPENAI_CHAT_PREFIXES = (
+            "gpt-4",
+            "gpt-3.5-turbo",
+            "o1",
+            "o3",
+            "o4",
+            "chatgpt-4o",
+            "gpt-5",
+        )
 
         config = load_config(project.root)
         models: list[dict[str, str | bool]] = []
         for provider_name, provider_config in config.providers.items():
             if provider_config.base_url:
-                # Fetch model list from proxy
+                # Fetch model list from LiteLLM proxy
                 proxy_models: list[str] = []
                 try:
                     base = provider_config.base_url.rstrip("/")
@@ -830,6 +844,27 @@ def create_app(project: SantaiProject) -> FastAPI:
                 except Exception:
                     pass
                 model_list = proxy_models or [provider_config.model]
+            elif provider_name == "anthropic":
+                try:
+                    ac = _anthropic.AsyncAnthropic(api_key=provider_config.api_key)
+                    page = await ac.models.list(limit=100)
+                    model_list = [m.id for m in page.data]
+                except Exception:
+                    model_list = provider_config.available_models
+            elif provider_name == "openai":
+                try:
+                    oc = _openai.AsyncOpenAI(api_key=provider_config.api_key)
+                    page = await oc.models.list()
+                    model_list = sorted(
+                        [
+                            m.id
+                            for m in page.data
+                            if m.id.startswith(_OPENAI_CHAT_PREFIXES)
+                        ],
+                        reverse=True,
+                    )
+                except Exception:
+                    model_list = provider_config.available_models
             else:
                 model_list = provider_config.available_models
 

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -6537,9 +6537,55 @@
                 modelSelect.innerHTML = '';
                 modelList.innerHTML = '';
                 if (modelsData.models.length === 0) {
-                    modelBtn.textContent = 'No models available';
-                    messagesEl.innerHTML = '<div class="chat-no-config">No API keys configured. <a href="#" onclick="event.preventDefault(); showSettingsModal()" style="color: var(--accent, #007aff);">Add your API keys</a> to enable chat.</div>';
+                    const errors = modelsData.errors || {};
+                    const errorEntries = Object.entries(errors);
+                    if (!modelsData.configured) {
+                        modelBtn.textContent = 'No models';
+                        const item = document.createElement('div');
+                        item.className = 'chat-custom-select-option';
+                        item.style.cssText = 'color: var(--text-muted); cursor: default; pointer-events: none;';
+                        item.textContent = 'No API keys configured';
+                        modelList.appendChild(item);
+                        messagesEl.innerHTML = '<div class="chat-no-config">No API keys configured. <a href="#" onclick="event.preventDefault(); showSettingsModal()" style="color: var(--accent, #007aff);">Add your API keys</a> to enable chat.</div>';
+                    } else if (errorEntries.length > 0) {
+                        const invalidProviders = errorEntries
+                            .filter(([, e]) => e.type === 'invalid_key')
+                            .map(([, e]) => e.display);
+                        const unavailableProviders = errorEntries
+                            .filter(([, e]) => e.type === 'unavailable')
+                            .map(([, e]) => e.display);
+                        let msg = '';
+                        let btnText = 'Key error';
+                        if (invalidProviders.length > 0) {
+                            msg += `API key invalid for: ${invalidProviders.join(', ')}. `;
+                            btnText = 'Invalid key';
+                        }
+                        if (unavailableProviders.length > 0) {
+                            msg += `Could not reach: ${unavailableProviders.join(', ')}. `;
+                            if (invalidProviders.length === 0) btnText = 'Unavailable';
+                        }
+                        modelBtn.textContent = btnText;
+                        const item = document.createElement('div');
+                        item.className = 'chat-custom-select-option';
+                        item.style.cssText = 'color: var(--text-muted); cursor: default; pointer-events: none; white-space: normal; line-height: 1.4;';
+                        item.textContent = msg.trim();
+                        modelList.appendChild(item);
+                        messagesEl.innerHTML = `<div class="chat-no-config">${msg.trim()} <a href="#" onclick="event.preventDefault(); showSettingsModal()" style="color: var(--accent, #007aff);">Update your API keys</a></div>`;
+                    } else {
+                        modelBtn.textContent = 'No models';
+                        const item = document.createElement('div');
+                        item.className = 'chat-custom-select-option';
+                        item.style.cssText = 'color: var(--text-muted); cursor: default; pointer-events: none;';
+                        item.textContent = 'No models returned';
+                        modelList.appendChild(item);
+                        messagesEl.innerHTML = '<div class="chat-no-config">No models returned. <a href="#" onclick="event.preventDefault(); showSettingsModal()" style="color: var(--accent, #007aff);">Check your API keys</a></div>';
+                    }
                     return;
+                }
+
+                // Models loaded successfully — clear any stale key-error message
+                if (messagesEl.querySelector('.chat-no-config')) {
+                    messagesEl.innerHTML = '';
                 }
 
                 // Star/default system: localStorage overrides system default

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -4953,6 +4953,8 @@
         let currentDropGroup = null; // <li> currently highlighted as drop target
 
         function isProtectedPath(path) {
+            // Only top-level names are protected — files inside (e.g. notes/my-note.md)
+            // are intentionally moveable; only the folder itself is locked.
             return protectedPaths.includes(path);
         }
 
@@ -5283,26 +5285,30 @@
             document.getElementById('folder-upload-input').click();
         }
 
+        const _MAX_UPLOAD_FILES = 500;
+
         async function handleFolderSelect(event) {
             const files = Array.from(event.target.files);
             event.target.value = '';
             if (files.length === 0) return;
-            let succeeded = 0, failed = 0;
-            for (const file of files) {
-                try {
-                    const relPath = file.webkitRelativePath;
-                    const formData = new FormData();
-                    formData.append('file', file);
-                    const url = relPath
-                        ? `/api/files?path=${encodeURIComponent(currentPath)}&relative_path=${encodeURIComponent(relPath)}`
-                        : `/api/files?path=${encodeURIComponent(currentPath)}`;
-                    const res = await fetch(url, { method: 'POST', body: formData });
+            const capped = files.length > _MAX_UPLOAD_FILES;
+            const batch = capped ? files.slice(0, _MAX_UPLOAD_FILES) : files;
+            const results = await Promise.allSettled(batch.map(file => {
+                const relPath = file.webkitRelativePath;
+                const formData = new FormData();
+                formData.append('file', file);
+                const url = relPath
+                    ? `/api/files?path=${encodeURIComponent(currentPath)}&relative_path=${encodeURIComponent(relPath)}`
+                    : `/api/files?path=${encodeURIComponent(currentPath)}`;
+                return fetch(url, { method: 'POST', body: formData }).then(async res => {
                     if (!res.ok) { const err = await res.json(); throw new Error(err.detail); }
-                    succeeded++;
-                } catch { failed++; }
-            }
+                });
+            }));
+            const succeeded = results.filter(r => r.status === 'fulfilled').length;
+            const failed = results.filter(r => r.status === 'rejected').length;
             if (succeeded > 0) showToast(`Uploaded ${succeeded} file${succeeded !== 1 ? 's' : ''}`);
             if (failed > 0) showToast(`${failed} file${failed !== 1 ? 's' : ''} failed`, true);
+            if (capped) showToast(`Folder too large — only first ${_MAX_UPLOAD_FILES} files uploaded`, true);
             loadFiles(currentPath);
             loadTree();
         }
@@ -5336,10 +5342,14 @@
         // Recursively collect all File objects from a FileSystemEntry, with their
         // paths relative to the dropped item's parent (so the top-level folder name
         // is preserved as the first path segment).
-        async function collectEntryFiles(entry, relPrefix) {
+        // _state = { count, capped } shared across recursive calls to enforce the cap.
+        async function collectEntryFiles(entry, relPrefix, _state = { count: 0, capped: false }) {
             const results = [];
+            if (_state.capped) return results;
             if (entry.isFile) {
+                if (_state.count >= _MAX_UPLOAD_FILES) { _state.capped = true; return results; }
                 await new Promise(resolve => entry.file(f => {
+                    _state.count++;
                     results.push({ file: f, relPath: relPrefix + f.name });
                     resolve();
                 }));
@@ -5353,10 +5363,11 @@
                         reader.readEntries(resolve, reject)
                     );
                     for (const child of batch) {
-                        const children = await collectEntryFiles(child, dirPath);
+                        if (_state.capped) break;
+                        const children = await collectEntryFiles(child, dirPath, _state);
                         results.push(...children);
                     }
-                } while (batch.length > 0);
+                } while (batch.length > 0 && !_state.capped);
             }
             return results;
         }
@@ -5408,8 +5419,9 @@
                     .filter(Boolean);
 
                 let succeeded = 0, failed = 0;
+                const dropState = { count: 0, capped: false };
                 for (const entry of entries) {
-                    const collected = await collectEntryFiles(entry, '');
+                    const collected = await collectEntryFiles(entry, '', dropState);
                     for (const { file, relPath } of collected) {
                         try {
                             const formData = new FormData();
@@ -5425,6 +5437,7 @@
                 }
                 if (succeeded > 0) showToast(`Uploaded ${succeeded} file${succeeded !== 1 ? 's' : ''}`);
                 if (failed > 0) showToast(`${failed} file${failed !== 1 ? 's' : ''} failed`, true);
+                if (dropState.capped) showToast(`Folder too large — only first ${_MAX_UPLOAD_FILES} files uploaded`, true);
                 loadFiles(currentPath);
                 loadTree();
             }

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -396,6 +396,14 @@
             color: var(--accent-hover);
         }
 
+        .tree-item.tree-selected {
+            background: var(--accent-light);
+        }
+
+        .tree-item.tree-previewing {
+            background: rgba(0, 0, 0, 0.06);
+        }
+
         .tree-toggle {
             width: 16px;
             height: 16px;
@@ -787,14 +795,44 @@
             opacity: 0.5;
         }
 
-        .tree-item.drag-over,
         .file-item.drag-over {
             background: var(--accent-light);
             outline: 2px dashed var(--accent);
             outline-offset: -2px;
         }
 
-        .tree-item.drag-over.invalid,
+        @keyframes march-ants-stroke {
+            to { stroke-dashoffset: -10; }
+        }
+
+        li.drag-drop-target {
+            position: relative;
+            border-radius: 8px;
+            background-color: var(--accent-light);
+        }
+
+        li.drag-drop-target > .drag-group-svg {
+            position: absolute;
+            inset: 0;
+            width: 100%;
+            height: 100%;
+            pointer-events: none;
+            overflow: visible;
+        }
+
+        li.drag-drop-target > .drag-group-svg rect {
+            x: 0.75px;
+            y: 0.75px;
+            width: calc(100% - 1.5px);
+            height: calc(100% - 1.5px);
+            rx: 7px;
+            fill: none;
+            stroke: var(--accent);
+            stroke-width: 1.5;
+            stroke-dasharray: 6 4;
+            animation: march-ants-stroke 0.8s linear infinite;
+        }
+
         .file-item.drag-over.invalid {
             background: rgba(239, 68, 68, 0.1);
             outline-color: #ef4444;
@@ -4088,6 +4126,8 @@
         
         let currentPath = '';
         let selectedItem = null;
+        let selectedItems = new Set(); // paths of multi-selected tree items
+        let lastClickedPath = null;    // anchor for shift-range selection
         let files = [];
         let previewPath = null;
         let previewReturnClusterId = null; // set when a file is opened from a cluster list
@@ -4116,6 +4156,7 @@
                 toggleGraphFullscreen();
             }
             previewPath = path;
+            updateTreePreviewState();
             window.activeClusterId = null;
             const content = document.getElementById('preview-content');
 
@@ -4237,6 +4278,7 @@
 
         function resetPreviewState() {
             previewPath = null;
+            updateTreePreviewState();
             previewReturnClusterId = null;
             window.activeClusterId = null;
             document.getElementById('preview-back-btn').style.display = 'none';
@@ -4824,10 +4866,52 @@
 
         // Move item (drag and drop)
         const protectedPaths = ['codebases', 'history', 'notes', 'resources', 'wiki', 'AGENTS.md', 'CLAUDE.md', 'README.md', 'rumdl.toml'];
-        let draggedItem = null;
+        let draggedItems = null;    // array of { path, name, isDir } for current drag
+        let currentDropGroup = null; // <li> currently highlighted as drop target
 
         function isProtectedPath(path) {
             return protectedPaths.includes(path);
+        }
+
+        function getFlatVisibleTreeItems() {
+            return Array.from(document.querySelectorAll('#tree-view .tree-item'));
+        }
+
+        function updateTreeSelection() {
+            const inMultiSelect = selectedItems.size > 0;
+            document.querySelectorAll('#tree-view .tree-item').forEach(el => {
+                el.classList.toggle('tree-selected', selectedItems.has(el.dataset.path));
+                // Suppress the green folder-active highlight while a multi-select is active
+                if (inMultiSelect) {
+                    el.classList.remove('active');
+                } else if (el.dataset.path === currentPath) {
+                    el.classList.add('active');
+                }
+            });
+            updateTreePreviewState();
+        }
+
+        function updateTreePreviewState() {
+            document.querySelectorAll('#tree-view .tree-item').forEach(el => {
+                el.classList.toggle('tree-previewing', el.dataset.path === previewPath && !selectedItems.has(el.dataset.path));
+            });
+        }
+
+        // Returns the <li> that should receive the drag-drop-target highlight.
+        // For folders: the folder's own <li> (wraps header + children).
+        // For files inside a named folder: that folder's <li>.
+        // For root-level files: just the file's own <li>.
+        function findGroupLi(treeItem, isDir) {
+            const li = treeItem.parentElement;
+            if (!li || li.tagName !== 'LI') return null;
+            if (isDir) return li;
+
+            // File: use the parent folder's <li> (including the root <li> for root-level files)
+            const parentUl = li.parentElement;
+            if (!parentUl) return li;
+            const parentLi = parentUl.parentElement;
+            if (!parentLi || parentLi.tagName !== 'LI') return li;
+            return parentLi;
         }
 
         function handleDragStart(event, path, name, isDir) {
@@ -4835,76 +4919,158 @@
                 event.preventDefault();
                 return;
             }
-            draggedItem = { path, name, isDir };
+            // If this item is part of a multi-selection, drag all selected items
+            if (selectedItems.size > 1 && selectedItems.has(path)) {
+                draggedItems = [];
+                getFlatVisibleTreeItems().forEach(el => {
+                    if (selectedItems.has(el.dataset.path)) {
+                        draggedItems.push({
+                            path: el.dataset.path,
+                            name: el.dataset.path.split('/').pop(),
+                            isDir: el.dataset.isDir === 'true'
+                        });
+                    }
+                });
+            } else {
+                draggedItems = [{ path, name, isDir }];
+            }
             event.target.classList.add('dragging');
             event.dataTransfer.effectAllowed = 'move';
             event.dataTransfer.setData('text/plain', path);
         }
 
+        function applyDropGroupHighlight(li) {
+            li.classList.add('drag-drop-target');
+            const svgNS = 'http://www.w3.org/2000/svg';
+            const svg = document.createElementNS(svgNS, 'svg');
+            svg.classList.add('drag-group-svg');
+            svg.appendChild(document.createElementNS(svgNS, 'rect'));
+            li.insertBefore(svg, li.firstChild);
+        }
+
+        function clearDropGroupHighlight() {
+            if (currentDropGroup) {
+                currentDropGroup.classList.remove('drag-drop-target');
+                const svg = currentDropGroup.querySelector(':scope > .drag-group-svg');
+                if (svg) svg.remove();
+                currentDropGroup = null;
+            }
+        }
+
         function handleDragEnd(event) {
             event.target.classList.remove('dragging');
+            clearDropGroupHighlight();
             document.querySelectorAll('.drag-over').forEach(el => el.classList.remove('drag-over', 'invalid'));
-            draggedItem = null;
+            draggedItems = null;
         }
 
         function handleDragOver(event, targetPath, targetIsDir) {
             event.preventDefault();
-            if (!draggedItem || !targetIsDir) return;
+            if (!draggedItems) return;
 
-            // Can't drop onto itself
-            if (draggedItem.path === targetPath) return;
-            // Can't drop into the folder it's already in
-            const currentParent = draggedItem.path.split('/').slice(0, -1).join('/');
-            if (currentParent === targetPath) return;
-            // Can't drop a folder into itself or its descendants
-            if (draggedItem.isDir && (targetPath === draggedItem.path || targetPath.startsWith(draggedItem.path + '/'))) return;
+            // For file targets, drop lands in the file's parent folder
+            const dropFolder = targetIsDir ? targetPath : targetPath.split('/').slice(0, -1).join('/');
+
+            const primary = draggedItems[0];
+            const isNoOp = primary.path === dropFolder
+                || (draggedItems.length === 1 && primary.path.split('/').slice(0, -1).join('/') === dropFolder)
+                || (draggedItems.length === 1 && primary.isDir && (dropFolder === primary.path || dropFolder.startsWith(primary.path + '/')));
+
+            if (isNoOp) {
+                clearDropGroupHighlight();
+                return;
+            }
 
             event.dataTransfer.dropEffect = 'move';
-            event.target.closest('.tree-item, .file-item')?.classList.add('drag-over');
+
+            const treeItem = event.target.closest('#tree-view .tree-item');
+            if (!treeItem) return;
+
+            const groupLi = findGroupLi(treeItem, targetIsDir);
+            if (groupLi !== currentDropGroup) {
+                clearDropGroupHighlight();
+                currentDropGroup = groupLi;
+                if (currentDropGroup) applyDropGroupHighlight(currentDropGroup);
+            }
         }
 
         function handleDragLeave(event) {
-            event.target.closest('.tree-item, .file-item')?.classList.remove('drag-over', 'invalid');
+            // Tree group highlighting is managed by handleDragOver / handleDragEnd.
+            // Only clean up .file-item drag-over (file browser panel).
+            const fileItem = event.target.closest('.file-item');
+            if (fileItem) fileItem.classList.remove('drag-over', 'invalid');
         }
 
         async function handleDrop(event, targetPath, targetIsDir) {
             event.preventDefault();
-            event.target.closest('.tree-item, .file-item')?.classList.remove('drag-over', 'invalid');
+            clearDropGroupHighlight();
 
-            if (!draggedItem || !targetIsDir) return;
-            // Can't drop onto itself
-            if (draggedItem.path === targetPath) return;
-            // Can't drop into the folder it's already in
-            const currentParent = draggedItem.path.split('/').slice(0, -1).join('/');
-            if (currentParent === targetPath) return;
-            // Can't drop a folder into itself or its descendants
-            if (draggedItem.isDir && (targetPath === draggedItem.path || targetPath.startsWith(draggedItem.path + '/'))) return;
+            if (!draggedItems) return;
 
-            // Save item data before async operation (draggedItem gets nulled by handleDragEnd)
-            const itemPath = draggedItem.path;
-            const itemName = draggedItem.name;
+            // For file targets, drop lands in the file's parent folder
+            const dropFolder = targetIsDir ? targetPath : targetPath.split('/').slice(0, -1).join('/');
 
-            try {
-                const res = await fetch('/api/files/move', {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({
-                        source_path: itemPath,
-                        target_folder: targetPath
-                    })
-                });
-
-                if (!res.ok) {
-                    const err = await res.json();
-                    throw new Error(err.detail || 'Failed to move');
-                }
-
-                showToast(`Moved "${itemName}" to ${targetPath || 'root'}`);
-                loadFiles(currentPath);
-                loadTree();
-            } catch (err) {
-                showToast(err.message, true);
+            const primary = draggedItems[0];
+            if (primary.path === dropFolder) return;
+            if (draggedItems.length === 1) {
+                const currentParent = primary.path.split('/').slice(0, -1).join('/');
+                if (currentParent === dropFolder) return;
+                if (primary.isDir && (dropFolder === primary.path || dropFolder.startsWith(primary.path + '/'))) return;
             }
+
+            // Save items before async (draggedItems gets nulled by handleDragEnd)
+            const items = draggedItems.slice();
+
+            // Filter to moveable items — skip protected top-level paths so files
+            // inside locked folders (notes/*, wiki/*, etc.) still move correctly
+            const moveable = items.filter(item => !isProtectedPath(item.path));
+            if (moveable.length === 0) return;
+
+            if (moveable.length === 1) {
+                const item = moveable[0];
+                try {
+                    const res = await fetch('/api/files/move', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ source_path: item.path, target_folder: dropFolder })
+                    });
+                    if (!res.ok) {
+                        const err = await res.json();
+                        throw new Error(err.detail || 'Failed to move');
+                    }
+                    showToast(`Moved "${item.name}" to ${dropFolder || 'root'}`);
+                } catch (err) {
+                    showToast(err.message, true);
+                    return;
+                }
+            } else {
+                const results = await Promise.allSettled(moveable.map(item =>
+                    fetch('/api/files/move', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ source_path: item.path, target_folder: dropFolder })
+                    }).then(async res => {
+                        if (!res.ok) {
+                            const err = await res.json();
+                            throw new Error(err.detail || 'Failed to move');
+                        }
+                        return res;
+                    })
+                ));
+                const succeeded = results.filter(r => r.status === 'fulfilled').length;
+                const failed = results.filter(r => r.status === 'rejected');
+                if (succeeded > 0) {
+                    showToast(`Moved ${succeeded} item${succeeded !== 1 ? 's' : ''} to ${dropFolder || 'root'}`);
+                }
+                if (failed.length > 0) {
+                    showToast(failed[0].reason?.message || 'Some items failed to move', true);
+                }
+            }
+
+            selectedItems.clear();
+            updateTreeSelection();
+            loadFiles(currentPath);
+            loadTree();
         }
 
         async function confirmRename() {
@@ -5064,7 +5230,7 @@
         document.addEventListener('dragover', (e) => {
             e.preventDefault();
             // Only show drop zone for external file drags, not internal moves
-            if (!draggedItem) {
+            if (!draggedItems) {
                 document.getElementById('drop-zone').classList.add('show');
             }
         });
@@ -5080,7 +5246,7 @@
             document.getElementById('drop-zone').classList.remove('show');
 
             // Only handle file uploads if not an internal drag
-            if (!draggedItem && e.dataTransfer.files.length > 0) {
+            if (!draggedItems && e.dataTransfer.files.length > 0) {
                 const files = e.dataTransfer.files;
                 for (const file of files) {
                     await uploadFile(file);
@@ -5333,15 +5499,19 @@
 
             // Tree item
             const canDrag = node.path && !isProtected;
-            html += `<div class="tree-item${isActive ? ' active' : ''}"
+            const isSelected = selectedItems.has(node.path);
+            const isPreviewing = !isSelected && node.path === previewPath;
+            // Suppress folder-active green while a multi-selection is in progress
+            const showActive = isActive && selectedItems.size === 0;
+            html += `<div class="tree-item${showActive ? ' active' : ''}${isSelected ? ' tree-selected' : ''}${isPreviewing ? ' tree-previewing' : ''}"
                          data-path="${node.path}"
                          data-is-dir="${node.is_dir}"
                          ${canDrag ? 'draggable="true"' : ''}
                          ${canDrag ? `ondragstart="handleDragStart(event, '${node.path}', '${node.name}', ${node.is_dir})"` : ''}
                          ondragend="handleDragEnd(event)"
-                         ${node.is_dir ? `ondragover="handleDragOver(event, '${node.path}', true)"` : ''}
-                         ${node.is_dir ? `ondragleave="handleDragLeave(event)"` : ''}
-                         ${node.is_dir ? `ondrop="handleDrop(event, '${node.path}', true)"` : ''}
+                         ondragover="handleDragOver(event, '${node.path}', ${node.is_dir})"
+                         ondragleave="handleDragLeave(event)"
+                         ondrop="handleDrop(event, '${node.path}', ${node.is_dir})"
                          onclick="handleTreeClick(event, '${node.path}', ${node.is_dir}, ${hasChildren})"
                          ondblclick="handleTreeDblClick(event, '${node.path}', ${node.is_dir})">`;
 
@@ -5471,6 +5641,47 @@
             // Don't do anything if clicking on toggle (it handles itself)
             if (event.target.closest('.tree-toggle')) return;
 
+            if (event.shiftKey) {
+                // Use last clicked item as anchor; fall back to the currently-previewed file
+                const anchor = lastClickedPath || previewPath;
+                if (anchor) {
+                    const items = getFlatVisibleTreeItems();
+                    const fromIdx = items.findIndex(el => el.dataset.path === anchor);
+                    const toIdx = items.findIndex(el => el.dataset.path === path);
+                    if (fromIdx !== -1 && toIdx !== -1) {
+                        const [start, end] = fromIdx <= toIdx ? [fromIdx, toIdx] : [toIdx, fromIdx];
+                        selectedItems = new Set(items.slice(start, end + 1).map(el => el.dataset.path));
+                    } else {
+                        selectedItems.add(path);
+                    }
+                } else {
+                    selectedItems.add(path);
+                }
+                updateTreeSelection();
+                return;
+            }
+
+            if (event.metaKey || event.ctrlKey) {
+                // When starting a fresh selection, automatically include the previewed file
+                if (selectedItems.size === 0 && previewPath) {
+                    selectedItems.add(previewPath);
+                }
+                // Toggle the clicked item in/out of selection
+                if (selectedItems.has(path)) {
+                    selectedItems.delete(path);
+                } else {
+                    selectedItems.add(path);
+                }
+                lastClickedPath = path;
+                updateTreeSelection();
+                return;
+            }
+
+            // Regular click: clear multi-selection
+            selectedItems.clear();
+            lastClickedPath = path;
+            updateTreeSelection();
+
             if (isDir) {
                 if (hasChildren) {
                     // Non-empty folder: single click just toggles expand/collapse
@@ -5505,6 +5716,8 @@
 
         // Update tree active state when path changes
         function updateTreeActiveState() {
+            // Don't restore the active indicator while a multi-select is in progress
+            if (selectedItems.size > 0) return;
             document.querySelectorAll('.tree-item').forEach(item => {
                 if (item.dataset.path === currentPath) {
                     item.classList.add('active');

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -626,8 +626,8 @@
         .upload-popup button {
             display: flex;
             align-items: center;
-            gap: 5px;
-            padding: 16px 7px;
+            gap: 3px;
+            padding: 16px 8px 16px 9px;
             background: none;
             border: none;
             font-size: 13px;
@@ -3744,7 +3744,7 @@
                     </button>
                     <div class="upload-popup" id="upload-popup">
                         <button onclick="triggerFolderUpload()">
-                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" style="width:16px;height:16px;">
+                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" style="width:16px;height:16px;margin-left:-1px;">
                                 <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 12.75V12A2.25 2.25 0 014.5 9.75h15A2.25 2.25 0 0121.75 12v.75m-8.69-6.44l-2.12-2.12a1.5 1.5 0 00-1.061-.44H4.5A2.25 2.25 0 002.25 6v12a2.25 2.25 0 002.25 2.25h15A2.25 2.25 0 0021.75 18V9a2.25 2.25 0 00-2.25-2.25h-5.379a1.5 1.5 0 01-1.06-.44z" />
                             </svg>
                             Folder Upload

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -569,8 +569,75 @@
             gap: 8px;
         }
 
-        .actions .btn-upload {
+        .btn-upload-split {
             grid-column: 1 / -1;
+            position: relative;
+            display: flex;
+            gap: 1px;
+        }
+
+        .btn-upload-split .btn-upload-main {
+            flex: 1;
+            border-radius: 12px 0 0 12px;
+            justify-content: center;
+            transition: border-radius 0.1s;
+        }
+
+        .btn-upload-split .btn-upload-caret {
+            padding: 10px 10px;
+            border-radius: 0 12px 12px 0;
+            border-left: 1px solid rgba(255,255,255,0.3);
+            transition: border-radius 0.1s;
+        }
+
+        .btn-upload-split .btn-upload-caret svg {
+            transition: transform 0.2s ease;
+        }
+
+        .btn-upload-split:has(.upload-popup.open) .btn-upload-caret {
+            border-radius: 0 0 12px 0;
+        }
+
+        .btn-upload-split:has(.upload-popup.open) .btn-upload-caret svg {
+            transform: rotate(180deg);
+        }
+
+        .upload-popup {
+            display: none;
+            position: absolute;
+            bottom: 100%;
+            right: 0;
+            background: rgba(255, 255, 255, 0.7);
+            backdrop-filter: blur(12px);
+            border: 1px solid rgba(0, 0, 0, 0.08);
+            border-bottom: none;
+            border-radius: 12px 12px 0 12px;
+            box-shadow: 0 -4px 16px rgba(0, 0, 0, 0.08);
+            overflow: hidden;
+            z-index: 200;
+            width: max-content;
+        }
+
+        .upload-popup.open {
+            display: flex;
+            flex-direction: column;
+        }
+
+        .upload-popup button {
+            display: flex;
+            align-items: center;
+            gap: 5px;
+            padding: 16px 7px;
+            background: none;
+            border: none;
+            font-size: 13px;
+            color: #333;
+            cursor: pointer;
+            white-space: nowrap;
+        }
+
+        .upload-popup button:hover {
+            background: rgba(0, 0, 0, 0.05);
         }
 
         .actions .btn {
@@ -747,7 +814,7 @@
         .tree-actions {
             display: none;
             gap: 2px;
-            margin-left: auto;
+            flex-shrink: 0;
         }
 
         .tree-item:hover .tree-actions {
@@ -1764,7 +1831,7 @@
         }
 
         /* Hidden file input */
-        #file-input {
+        #file-input, #folder-upload-input {
             display: none;
         }
 
@@ -3663,12 +3730,27 @@
                     </svg>
                     New Folder
                 </button>
-                <button class="btn btn-primary btn-upload" onclick="triggerUpload()">
-                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" style="width:16px;height:16px;">
-                        <path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5m-13.5-9L12 3m0 0l4.5 4.5M12 3v13.5" />
-                    </svg>
-                    Upload
-                </button>
+                <div class="btn-upload-split" id="upload-split">
+                    <button class="btn btn-primary btn-upload-main" onclick="triggerUpload()">
+                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" style="width:16px;height:16px;">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5m-13.5-9L12 3m0 0l4.5 4.5M12 3v13.5" />
+                        </svg>
+                        File Upload
+                    </button>
+                    <button class="btn btn-primary btn-upload-caret" onclick="toggleUploadMenu(event)" title="More upload options">
+                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" style="width:14px;height:14px;">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 15.75l7.5-7.5 7.5 7.5" />
+                        </svg>
+                    </button>
+                    <div class="upload-popup" id="upload-popup">
+                        <button onclick="triggerFolderUpload()">
+                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" style="width:16px;height:16px;">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 12.75V12A2.25 2.25 0 014.5 9.75h15A2.25 2.25 0 0121.75 12v.75m-8.69-6.44l-2.12-2.12a1.5 1.5 0 00-1.061-.44H4.5A2.25 2.25 0 002.25 6v12a2.25 2.25 0 002.25 2.25h15A2.25 2.25 0 0021.75 18V9a2.25 2.25 0 00-2.25-2.25h-5.379a1.5 1.5 0 01-1.06-.44z" />
+                            </svg>
+                            Folder Upload
+                        </button>
+                    </div>
+                </div>
             </div>
         </aside>
 
@@ -4082,8 +4164,9 @@
     <!-- Toast -->
     <div class="toast" id="toast"></div>
 
-    <!-- Hidden file input -->
+    <!-- Hidden file inputs -->
     <input type="file" id="file-input" multiple onchange="handleFileSelect(event)">
+    <input type="file" id="folder-upload-input" webkitdirectory multiple onchange="handleFolderSelect(event)">
 
     <!-- Marked.js for Markdown rendering -->
     <script src="https://cdn.jsdelivr.net/npm/marked@15.0.12/marked.min.js" integrity="sha384-948ahk4ZmxYVYOc+rxN1H2gM1EJ2Duhp7uHtZ4WSLkV4Vtx5MUqnV+l7u9B+jFv+" crossorigin="anonymous"></script>
@@ -5195,6 +5278,50 @@
             document.getElementById('file-input').click();
         }
 
+        function triggerFolderUpload() {
+            closeUploadMenu();
+            document.getElementById('folder-upload-input').click();
+        }
+
+        async function handleFolderSelect(event) {
+            const files = Array.from(event.target.files);
+            event.target.value = '';
+            if (files.length === 0) return;
+            let succeeded = 0, failed = 0;
+            for (const file of files) {
+                try {
+                    const relPath = file.webkitRelativePath;
+                    const formData = new FormData();
+                    formData.append('file', file);
+                    const url = relPath
+                        ? `/api/files?path=${encodeURIComponent(currentPath)}&relative_path=${encodeURIComponent(relPath)}`
+                        : `/api/files?path=${encodeURIComponent(currentPath)}`;
+                    const res = await fetch(url, { method: 'POST', body: formData });
+                    if (!res.ok) { const err = await res.json(); throw new Error(err.detail); }
+                    succeeded++;
+                } catch { failed++; }
+            }
+            if (succeeded > 0) showToast(`Uploaded ${succeeded} file${succeeded !== 1 ? 's' : ''}`);
+            if (failed > 0) showToast(`${failed} file${failed !== 1 ? 's' : ''} failed`, true);
+            loadFiles(currentPath);
+            loadTree();
+        }
+
+        function toggleUploadMenu(e) {
+            e.stopPropagation();
+            document.getElementById('upload-popup').classList.toggle('open');
+        }
+
+        function closeUploadMenu() {
+            document.getElementById('upload-popup').classList.remove('open');
+        }
+
+        document.addEventListener('click', (e) => {
+            if (!document.getElementById('upload-split').contains(e.target)) {
+                closeUploadMenu();
+            }
+        });
+
         async function handleFileSelect(event) {
             const files = event.target.files;
             for (const file of files) {
@@ -5203,6 +5330,35 @@
             event.target.value = '';
             loadFiles(currentPath);
             loadTree();
+        }
+
+
+        // Recursively collect all File objects from a FileSystemEntry, with their
+        // paths relative to the dropped item's parent (so the top-level folder name
+        // is preserved as the first path segment).
+        async function collectEntryFiles(entry, relPrefix) {
+            const results = [];
+            if (entry.isFile) {
+                await new Promise(resolve => entry.file(f => {
+                    results.push({ file: f, relPath: relPrefix + f.name });
+                    resolve();
+                }));
+            } else if (entry.isDirectory) {
+                const dirPath = relPrefix + entry.name + '/';
+                const reader = entry.createReader();
+                // readEntries may return results in batches — keep calling until empty.
+                let batch;
+                do {
+                    batch = await new Promise((resolve, reject) =>
+                        reader.readEntries(resolve, reject)
+                    );
+                    for (const child of batch) {
+                        const children = await collectEntryFiles(child, dirPath);
+                        results.push(...children);
+                    }
+                } while (batch.length > 0);
+            }
+            return results;
         }
 
         async function uploadFile(file) {
@@ -5246,11 +5402,29 @@
             document.getElementById('drop-zone').classList.remove('show');
 
             // Only handle file uploads if not an internal drag
-            if (!draggedItems && e.dataTransfer.files.length > 0) {
-                const files = e.dataTransfer.files;
-                for (const file of files) {
-                    await uploadFile(file);
+            if (!draggedItems && e.dataTransfer.items && e.dataTransfer.items.length > 0) {
+                const entries = Array.from(e.dataTransfer.items)
+                    .map(item => item.webkitGetAsEntry?.())
+                    .filter(Boolean);
+
+                let succeeded = 0, failed = 0;
+                for (const entry of entries) {
+                    const collected = await collectEntryFiles(entry, '');
+                    for (const { file, relPath } of collected) {
+                        try {
+                            const formData = new FormData();
+                            formData.append('file', file);
+                            const url = relPath.includes('/')
+                                ? `/api/files?path=${encodeURIComponent(currentPath)}&relative_path=${encodeURIComponent(relPath)}`
+                                : `/api/files?path=${encodeURIComponent(currentPath)}`;
+                            const res = await fetch(url, { method: 'POST', body: formData });
+                            if (!res.ok) { const err = await res.json(); throw new Error(err.detail); }
+                            succeeded++;
+                        } catch { failed++; }
+                    }
                 }
+                if (succeeded > 0) showToast(`Uploaded ${succeeded} file${succeeded !== 1 ? 's' : ''}`);
+                if (failed > 0) showToast(`${failed} file${failed !== 1 ? 's' : ''} failed`, true);
                 loadFiles(currentPath);
                 loadTree();
             }
@@ -5528,11 +5702,8 @@
             }
             html += `<span class="tree-name">${displayName}</span>`;
 
-            // Toggle chevron (on right side for folders)
-            html += `<span class="tree-toggle${isExpanded ? ' expanded' : ''}${!hasChildren ? ' hidden' : ''}"
-                          onclick="toggleTreeNode(event, '${node.path}')">${chevronIcon}</span>`;
-
-            // Action buttons (only for non-root and non-protected items)
+            // Action buttons (only for non-root and non-protected items) — rendered
+            // before the toggle so the chevron stays anchored at the far right.
             if (node.path && !isProtected) {
                 html += `<span class="tree-actions">
                     <button class="tree-action-btn edit-btn" onclick="event.stopPropagation(); editItem('${node.path}', '${node.name}')" title="Rename">
@@ -5547,6 +5718,10 @@
                     </button>
                 </span>`;
             }
+
+            // Toggle chevron last so it stays anchored at the far right
+            html += `<span class="tree-toggle${isExpanded ? ' expanded' : ''}${!hasChildren ? ' hidden' : ''}"
+                          onclick="toggleTreeNode(event, '${node.path}')">${chevronIcon}</span>`;
 
             html += '</div>';
 


### PR DESCRIPTION
Summary
  - Multi-select drag and drop — users can hold Shift or Command/Ctrl and click to select multiple files in the file tree (Shift for selecting files in a row, Command/Ctrl for individually selecting files consecutive or not), then drag them all to a new folder
  - Live model fetching — the /api/chat/models endpoint now calls the Anthropic and OpenAI APIs at request time to return available models dynamically
  - Added a _BLOCKED_MODELS set in app.py to suppress models that don't support tool calls or are deprecated (DeepSeek R1, Llama 3.x Bedrock, Qwen3 Coder Bedrock, Jamba 2, Grok 2)
  - Nova Pro on Bedrock rejects a leading system-role message; chat.py now merges the system prompt into the first user message for models in _NO_SYSTEM_ROLE_MODELS
  - Removed pre-loading of truncated wiki, notes, and history content into the system prompt, instead the system prompt now shows only the file tree and instructs the model to call read_file explicitly; reduces token usage on every request and ensures whole file content is used as context
 - Display name improvements - Auto-converts model names like "claude-3-5-haiku-20241022" to "Claude Haiku 3.5" in the model selection dropdown
 - Now users can upload folders, not just files (drag and drop or through “File Upload”/“Folder Upload”)
<img width="254" height="104" alt="Screenshot 2026-05-11 at 3 06 18 PM" src="https://github.com/user-attachments/assets/1c8db6b1-1e8d-4622-a083-462b1766890d" />

 - The open/close folder chevrons stay in place, the delete and edit icons are rendered to the left on hover
<img width="207" height="100" alt="Screenshot 2026-05-11 at 3 08 22 PM" src="https://github.com/user-attachments/assets/8767c072-5b0d-4a43-abb7-3c947afb7c12" />
  ---
  
Test Plan

- [ ] Multi-select — Cmd/Ctrl+click: Click a file, then Cmd+click a second file; both should show the tree-selected highlight. Cmd+click again to deselect one.
- [ ] Multi-select — Shift+click range: Click a file, then Shift+click another two or more items below it; all items in the range (inclusive) should be selected. Drag to a folder and verify all files move.
- [ ] Multi-drag to file: Drag a selection onto a file (not a folder); verify items land in that file's parent folder.
<img width="281" height="530" alt="image" src="https://github.com/user-attachments/assets/05283116-7b71-4f5c-9045-5678cb0b8b5a" />

- [ ] Protected paths blocked: Try to include notes/ or wiki/ in a multi-select drag; they should not move.
- [ ] Folder upload — drag a folder from local files into the file tree and confirm it is uploaded; use the "Folder Upload" button and confirm the folder selected is uploaded.
- [ ] Live model list — Anthropic: Open the model selector in the web UI; Claude models should reflect what's actually available in the Anthropic account, not the hardcoded fallback.
- [ ] Blocked models absent: Confirm DeepSeek R1 (Bedrock), Llama 3.x (Bedrock), and Grok 2 do not appear in the model dropdown.
- [ ] Display names: Check that model names render as ex. "Claude Haiku 3.5" (family name before version), not "Claude 3.5 Haiku".
- [ ] Bedrock Nova Pro: Start a chat with Nova Pro; verify the first response succeeds without a system-role error.
- [ ] Fallback on API failure: Temporarily set an invalid API key; verify invalid/unavailable errors are displayed directly in the model dropdown instead of falling back to hardcoded models that don't work with a bad key.
<img width="395" height="151" alt="Screenshot 2026-05-11 at 9 43 26 AM" src="https://github.com/user-attachments/assets/5fbe93ba-209e-4c35-8a73-283637226a9d" />
