### PR TITLE
Update push/pull to use bases endpoints (Part 2 of Pull/Push Fix)

### DIFF
--- a/src/santai_cli/commands/pull.py
+++ b/src/santai_cli/commands/pull.py
@@ -7,6 +7,7 @@ import tempfile
 import zipfile
 from pathlib import Path
 from typing import Annotated
+from urllib.parse import urlencode
 
 import typer
 from rich.console import Console
@@ -28,6 +29,28 @@ def _format_size(size_bytes: int) -> str:
     return f"{size_bytes / (1024 * 1024):.1f} MB"
 
 
+def _resolve_base_id(backend: str, token: str, username: str, name: str) -> str | None:
+    """Return the base ID for (username, name), or None if not found."""
+    import urllib.error
+    import urllib.request
+
+    qs = urlencode({"author": username, "search": name, "limit": "20"})
+    req = urllib.request.Request(
+        f"{backend}/bases/?{qs}",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            data = json.loads(resp.read())
+    except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError):
+        return None
+
+    for base in data.get("data", []):
+        if base.get("name") == name and base.get("author") == username:
+            return str(base["id"])
+    return None
+
+
 def pull(
     name: Annotated[
         str,
@@ -47,6 +70,11 @@ def pull(
         console.print("Not logged in. Run [bold]santai login[/bold] first.")
         raise typer.Exit(1)
 
+    username = creds.get("username", "")
+    if not username:
+        console.print("[red]Could not determine username from credentials.[/red]")
+        raise typer.Exit(1)
+
     dest_path = Path(dest or name).resolve()
 
     if dest_path.exists():
@@ -58,8 +86,13 @@ def pull(
 
     console.print(f"Looking up [bold]{name}[/bold]...")
 
+    base_id = _resolve_base_id(backend, creds["token"], username, name)
+    if not base_id:
+        console.print(f"[red]Project '{name}' not found.[/red]")
+        raise typer.Exit(1)
+
     req = urllib.request.Request(
-        f"{backend}/santai-repos/download/{name}",
+        f"{backend}/bases/{base_id}/download",
         headers={"Authorization": f"Bearer {creds['token']}"},
     )
 

--- a/src/santai_cli/commands/pull.py
+++ b/src/santai_cli/commands/pull.py
@@ -44,11 +44,6 @@ def pull(
         console.print("Not logged in. Run [bold]santai login[/bold] first.")
         raise typer.Exit(1)
 
-    username = creds.get("username", "")
-    if not username:
-        console.print("[red]Could not determine username from credentials.[/red]")
-        raise typer.Exit(1)
-
     dest_path = Path(dest or name).resolve()
 
     if dest_path.exists():
@@ -60,7 +55,7 @@ def pull(
 
     console.print(f"Looking up [bold]{name}[/bold]...")
 
-    base_id = resolve_base_id(backend, creds["token"], username, name)
+    base_id = resolve_base_id(backend, creds["token"], name)
     if not base_id:
         console.print(f"[red]Project '{name}' not found.[/red]")
         raise typer.Exit(1)

--- a/src/santai_cli/commands/pull.py
+++ b/src/santai_cli/commands/pull.py
@@ -7,18 +7,14 @@ import tempfile
 import zipfile
 from pathlib import Path
 from typing import Annotated
-from urllib.parse import urlencode
 
 import typer
 from rich.console import Console
 
 from santai_cli.commands.auth import DEFAULT_HUB_URL, load_credentials
+from santai_cli.core.hub import get_backend_url, resolve_base_id
 
 console = Console()
-
-
-def _get_backend_url(hub_url: str) -> str:
-    return hub_url.replace(":3000", ":3001") if ":3000" in hub_url else hub_url
 
 
 def _format_size(size_bytes: int) -> str:
@@ -27,28 +23,6 @@ def _format_size(size_bytes: int) -> str:
     if size_bytes < 1024 * 1024:
         return f"{size_bytes / 1024:.1f} KB"
     return f"{size_bytes / (1024 * 1024):.1f} MB"
-
-
-def _resolve_base_id(backend: str, token: str, username: str, name: str) -> str | None:
-    """Return the base ID for (username, name), or None if not found."""
-    import urllib.error
-    import urllib.request
-
-    qs = urlencode({"author": username, "search": name, "limit": "20"})
-    req = urllib.request.Request(
-        f"{backend}/bases/?{qs}",
-        headers={"Authorization": f"Bearer {token}"},
-    )
-    try:
-        with urllib.request.urlopen(req, timeout=15) as resp:
-            data = json.loads(resp.read())
-    except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError):
-        return None
-
-    for base in data.get("data", []):
-        if base.get("name") == name and base.get("author") == username:
-            return str(base["id"])
-    return None
 
 
 def pull(
@@ -82,11 +56,11 @@ def pull(
         raise typer.Exit(1)
 
     hub = creds.get("hub_url", DEFAULT_HUB_URL)
-    backend = _get_backend_url(hub)
+    backend = get_backend_url(hub)
 
     console.print(f"Looking up [bold]{name}[/bold]...")
 
-    base_id = _resolve_base_id(backend, creds["token"], username, name)
+    base_id = resolve_base_id(backend, creds["token"], username, name)
     if not base_id:
         console.print(f"[red]Project '{name}' not found.[/red]")
         raise typer.Exit(1)

--- a/src/santai_cli/commands/push.py
+++ b/src/santai_cli/commands/push.py
@@ -7,12 +7,13 @@ import tempfile
 import zipfile
 from pathlib import Path
 from typing import Annotated
-from urllib.parse import quote, urlencode
+from urllib.parse import quote
 
 import typer
 from rich.console import Console
 
 from santai_cli.commands.auth import DEFAULT_HUB_URL, load_credentials
+from santai_cli.core.hub import get_backend_url, resolve_base_id
 from santai_cli.core.project import is_santai_project
 
 console = Console()
@@ -43,38 +44,12 @@ def _should_include(path: Path, ignored_files: set[str]) -> bool:
     )
 
 
-def _get_backend_url(hub_url: str) -> str:
-    return hub_url.replace(":3000", ":3001") if ":3000" in hub_url else hub_url
-
-
 def _format_size(size_bytes: int) -> str:
     if size_bytes < 1024:
         return f"{size_bytes} B"
     if size_bytes < 1024 * 1024:
         return f"{size_bytes / 1024:.1f} KB"
     return f"{size_bytes / (1024 * 1024):.1f} MB"
-
-
-def _resolve_base_id(backend: str, token: str, username: str, name: str) -> str | None:
-    """Return the base ID for (username, name), or None if not found."""
-    import urllib.error
-    import urllib.request
-
-    qs = urlencode({"author": username, "search": name, "limit": "20"})
-    req = urllib.request.Request(
-        f"{backend}/bases/?{qs}",
-        headers={"Authorization": f"Bearer {token}"},
-    )
-    try:
-        with urllib.request.urlopen(req, timeout=15) as resp:
-            data = json.loads(resp.read())
-    except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError):
-        return None
-
-    for base in data.get("data", []):
-        if base.get("name") == name and base.get("author") == username:
-            return str(base["id"])
-    return None
 
 
 def push(
@@ -127,11 +102,11 @@ def push(
 
     project_name = name or project_dir.name
     hub = creds.get("hub_url", DEFAULT_HUB_URL)
-    backend = _get_backend_url(hub)
+    backend = get_backend_url(hub)
 
     console.print(f"Looking up [bold]{project_name}[/bold]...")
 
-    base_id = _resolve_base_id(backend, creds["token"], username, project_name)
+    base_id = resolve_base_id(backend, creds["token"], username, project_name)
     if not base_id:
         console.print(f"[red]Project '{project_name}' not found.[/red]")
         console.print(

--- a/src/santai_cli/commands/push.py
+++ b/src/santai_cli/commands/push.py
@@ -84,11 +84,6 @@ def push(
         console.print("Not logged in. Run [bold]santai login[/bold] first.")
         raise typer.Exit(1)
 
-    username = creds.get("username", "")
-    if not username:
-        console.print("[red]Could not determine username from credentials.[/red]")
-        raise typer.Exit(1)
-
     # Determine which files to exclude
     ignored_files = set(SENSITIVE_FILES)
     env_path = project_dir / ".env"
@@ -106,7 +101,7 @@ def push(
 
     console.print(f"Looking up [bold]{project_name}[/bold]...")
 
-    base_id = resolve_base_id(backend, creds["token"], username, project_name)
+    base_id = resolve_base_id(backend, creds["token"], project_name)
     if not base_id:
         console.print(f"[red]Project '{project_name}' not found.[/red]")
         console.print(

--- a/src/santai_cli/commands/push.py
+++ b/src/santai_cli/commands/push.py
@@ -13,7 +13,7 @@ import typer
 from rich.console import Console
 
 from santai_cli.commands.auth import DEFAULT_HUB_URL, load_credentials
-from santai_cli.core.hub import get_backend_url, resolve_base_id
+from santai_cli.core.hub import create_base, get_backend_url, resolve_base_id
 from santai_cli.core.project import is_santai_project
 
 console = Console()
@@ -103,11 +103,11 @@ def push(
 
     base_id = resolve_base_id(backend, creds["token"], project_name)
     if not base_id:
-        console.print(f"[red]Project '{project_name}' not found.[/red]")
-        console.print(
-            "[yellow]Create it first at the hub, then push.[/yellow]"
-        )
-        raise typer.Exit(1)
+        console.print(f"  Not found — creating [bold]{project_name}[/bold]...")
+        base_id = create_base(backend, creds["token"], project_name)
+        if not base_id:
+            console.print(f"[red]Failed to create project '{project_name}'.[/red]")
+            raise typer.Exit(1)
 
     console.print(f"Packaging [bold]{project_name}[/bold]...")
 

--- a/src/santai_cli/commands/push.py
+++ b/src/santai_cli/commands/push.py
@@ -7,7 +7,7 @@ import tempfile
 import zipfile
 from pathlib import Path
 from typing import Annotated
-from urllib.parse import quote
+from urllib.parse import quote, urlencode
 
 import typer
 from rich.console import Console
@@ -55,6 +55,28 @@ def _format_size(size_bytes: int) -> str:
     return f"{size_bytes / (1024 * 1024):.1f} MB"
 
 
+def _resolve_base_id(backend: str, token: str, username: str, name: str) -> str | None:
+    """Return the base ID for (username, name), or None if not found."""
+    import urllib.error
+    import urllib.request
+
+    qs = urlencode({"author": username, "search": name, "limit": "20"})
+    req = urllib.request.Request(
+        f"{backend}/bases/?{qs}",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            data = json.loads(resp.read())
+    except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError):
+        return None
+
+    for base in data.get("data", []):
+        if base.get("name") == name and base.get("author") == username:
+            return str(base["id"])
+    return None
+
+
 def push(
     name: Annotated[
         str | None,
@@ -87,6 +109,11 @@ def push(
         console.print("Not logged in. Run [bold]santai login[/bold] first.")
         raise typer.Exit(1)
 
+    username = creds.get("username", "")
+    if not username:
+        console.print("[red]Could not determine username from credentials.[/red]")
+        raise typer.Exit(1)
+
     # Determine which files to exclude
     ignored_files = set(SENSITIVE_FILES)
     env_path = project_dir / ".env"
@@ -101,6 +128,16 @@ def push(
     project_name = name or project_dir.name
     hub = creds.get("hub_url", DEFAULT_HUB_URL)
     backend = _get_backend_url(hub)
+
+    console.print(f"Looking up [bold]{project_name}[/bold]...")
+
+    base_id = _resolve_base_id(backend, creds["token"], username, project_name)
+    if not base_id:
+        console.print(f"[red]Project '{project_name}' not found.[/red]")
+        console.print(
+            "[yellow]Create it first at the hub, then push.[/yellow]"
+        )
+        raise typer.Exit(1)
 
     console.print(f"Packaging [bold]{project_name}[/bold]...")
 
@@ -136,15 +173,10 @@ def push(
 
         body_parts.append(f"--{boundary}\r\n".encode())
         body_parts.append(
-            f'Content-Disposition: form-data; name="repoZip"; filename="{quote(project_name)}.zip"\r\n'.encode()
+            f'Content-Disposition: form-data; name="file"; filename="{quote(project_name)}.zip"\r\n'.encode()
         )
         body_parts.append(b"Content-Type: application/zip\r\n\r\n")
         body_parts.append(zip_bytes)
-        body_parts.append(b"\r\n")
-
-        body_parts.append(f"--{boundary}\r\n".encode())
-        body_parts.append(b'Content-Disposition: form-data; name="repoName"\r\n\r\n')
-        body_parts.append(project_name.encode())
         body_parts.append(b"\r\n")
 
         body_parts.append(f"--{boundary}--\r\n".encode())
@@ -152,7 +184,7 @@ def push(
         body = b"".join(body_parts)
 
         req = urllib.request.Request(
-            f"{backend}/santai-repos/upload",
+            f"{backend}/bases/{base_id}/upload",
             data=body,
             method="POST",
             headers={
@@ -166,7 +198,7 @@ def push(
                 data = json.loads(resp.read())
                 console.print(
                     f"[green]Pushed [bold]{project_name}[/bold] "
-                    f"({_format_size(data.get('size', zip_size))})[/green]"
+                    f"(version {data.get('version', '?')})[/green]"
                 )
         except urllib.error.HTTPError as e:
             if e.code == 401:

--- a/src/santai_cli/core/hub.py
+++ b/src/santai_cli/core/hub.py
@@ -1,0 +1,32 @@
+"""Helpers for communicating with the Santai Hub backend."""
+
+from __future__ import annotations
+
+import json
+from urllib.parse import urlencode
+
+
+def get_backend_url(hub_url: str) -> str:
+    return hub_url.replace(":3000", ":3001") if ":3000" in hub_url else hub_url
+
+
+def resolve_base_id(backend: str, token: str, username: str, name: str) -> str | None:
+    """Return the base ID for (username, name), or None if not found."""
+    import urllib.error
+    import urllib.request
+
+    qs = urlencode({"author": username, "search": name, "limit": "20"})
+    req = urllib.request.Request(
+        f"{backend}/bases/?{qs}",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            data = json.loads(resp.read())
+    except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError):
+        return None
+
+    for base in data.get("data", []):
+        if base.get("name") == name and base.get("author") == username:
+            return str(base["id"])
+    return None

--- a/src/santai_cli/core/hub.py
+++ b/src/santai_cli/core/hub.py
@@ -9,6 +9,29 @@ def get_backend_url(hub_url: str) -> str:
     return hub_url.replace(":3000", ":3001") if ":3000" in hub_url else hub_url
 
 
+def create_base(backend: str, token: str, name: str) -> str | None:
+    """Create a new base with the given name and return its ID, or None on failure."""
+    import urllib.error
+    import urllib.request
+
+    body = json.dumps({"name": name}).encode()
+    req = urllib.request.Request(
+        f"{backend}/bases/init",
+        data=body,
+        method="POST",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            data = json.loads(resp.read())
+            return str(data["id"]) if "id" in data else None
+    except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError):
+        return None
+
+
 def resolve_base_id(backend: str, token: str, name: str) -> str | None:
     """Return the base ID for the authenticated user's base with the given name."""
     import urllib.error

--- a/src/santai_cli/core/hub.py
+++ b/src/santai_cli/core/hub.py
@@ -3,21 +3,19 @@
 from __future__ import annotations
 
 import json
-from urllib.parse import urlencode
 
 
 def get_backend_url(hub_url: str) -> str:
     return hub_url.replace(":3000", ":3001") if ":3000" in hub_url else hub_url
 
 
-def resolve_base_id(backend: str, token: str, username: str, name: str) -> str | None:
-    """Return the base ID for (username, name), or None if not found."""
+def resolve_base_id(backend: str, token: str, name: str) -> str | None:
+    """Return the base ID for the authenticated user's base with the given name."""
     import urllib.error
     import urllib.request
 
-    qs = urlencode({"author": username, "search": name, "limit": "20"})
     req = urllib.request.Request(
-        f"{backend}/bases/?{qs}",
+        f"{backend}/me/bases",
         headers={"Authorization": f"Bearer {token}"},
     )
     try:
@@ -26,7 +24,7 @@ def resolve_base_id(backend: str, token: str, username: str, name: str) -> str |
     except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError):
         return None
 
-    for base in data.get("data", []):
-        if base.get("name") == name and base.get("author") == username:
+    for base in data.get("bases", []):
+        if base.get("name") == name:
             return str(base["id"])
     return None


### PR DESCRIPTION
## Summary

- `santai push` and `santai pull` now hit the correct backend endpoints (`/bases/:id/download` and `/bases/:id/upload`) instead of the old `/santai-repos/*` routes that didn't exist
- Name-to-ID resolution uses `GET /me/bases` (Bearer-token-aware) so private bases are correctly found
- On first push, if the base doesn't exist yet it is automatically created via `POST /bases/init` — no manual hub setup required
- Shared hub helpers (`get_backend_url`, `resolve_base_id`, `create_base`) extracted into `src/santai_cli/core/hub.py` to avoid duplication between commands

## Test plan

- Can't test without part of the pull/push fix within the Santai Hub, so can test after both merged.  

Tested locally with both changes at the same time and it seemed ok:

<img width="661" height="204" alt="Screenshot 2026-05-12 at 10 44 42 AM" src="https://github.com/user-attachments/assets/1a735546-c175-48f1-8d33-61b60dc19e03" />
<img width="1627" height="550" alt="Screenshot 2026-05-12 at 10 44 11 AM" src="https://github.com/user-attachments/assets/4231deaf-6ee2-44aa-9150-8b2fc14ea11b" />
<img width="525" height="95" alt="Screenshot 2026-05-12 at 10 43 29 AM" src="https://github.com/user-attachments/assets/2e7478d7-854c-4f41-832e-b866e7993eea" />
