### PR TITLE
Clarify env var and configuration documentation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,7 @@ ANTHROPIC_API_KEY=your-anthropic-api-key-here
 OPENAI_API_KEY=your-openai-compatible-api-key-here
 # OPENAI_MODEL=gpt-4o
 
-# Optional: only set this if you use a custom proxy (e.g. LiteLLM, Azure).
+# Optional: only set this if you use a custom proxy (e.g. LiteLLM, Azure). 
+# If set, the OPENAI_API_KEY should also be updated to match the OpenAI-compatible proxy. 
 # If omitted, the standard OpenAI endpoint (https://api.openai.com/v1) is used.
 # OPENAI_API_BASE_URL=https://your-proxy-url.example.com/

--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # Santai CLI - AI Chatbot Configuration
-# Copy this file to .env and fill in your API keys.
+# Copy this file to .env to the santai knowledge base repo itself and fill in your API keys there. 
 # At least one provider key is required for `santai chat` to work.
 #
 # Just drop in your API key(s) below — no other configuration is needed
@@ -10,8 +10,9 @@ ANTHROPIC_API_KEY=your-anthropic-api-key-here
 # ANTHROPIC_MODEL=claude-sonnet-4-20250514
 
 # --- OpenAI ---
-OPENAI_API_KEY=your-openai-api-key-here
+OPENAI_API_KEY=your-openai-compatible-api-key-here
 # OPENAI_MODEL=gpt-4o
+
 # Optional: only set this if you use a custom proxy (e.g. LiteLLM, Azure).
 # If omitted, the standard OpenAI endpoint (https://api.openai.com/v1) is used.
-# OPENAI_API_BASE_URL=https://your-proxy-url.example.com/v1
+# OPENAI_API_BASE_URL=https://your-proxy-url.example.com/

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -20,6 +20,10 @@ OPENAI_API_KEY=sk-...
 # Optional: override default models
 ANTHROPIC_MODEL=claude-sonnet-4-20250514
 OPENAI_MODEL=gpt-4o
+
+# Optional: custom OpenAI-compatible proxy (e.g. LiteLLM, Azure).
+# If set, OPENAI_API_KEY should match the proxy's expected key.
+OPENAI_API_BASE_URL=https://your-proxy-url.example.com/
 ```
 
 !!! warning
@@ -31,8 +35,9 @@ OPENAI_MODEL=gpt-4o
 |----------|----------|---------|-------------|
 | `ANTHROPIC_API_KEY` | At least one provider | — | Your Anthropic API key |
 | `ANTHROPIC_MODEL` | No | `claude-sonnet-4-20250514` | Default Anthropic model |
-| `OPENAI_API_KEY` | At least one provider | — | Your OpenAI API key |
+| `OPENAI_API_KEY` | At least one provider | — | Your OpenAI (or OpenAI-compatible) API key |
 | `OPENAI_MODEL` | No | `gpt-4o` | Default OpenAI model |
+| `OPENAI_API_BASE_URL` | No | `https://api.openai.com/v1` | Custom OpenAI-compatible endpoint (e.g. LiteLLM, Azure). When set, `OPENAI_API_KEY` should match the proxy. |
 | `SANTAI_HUB_URL` | No | `http://localhost:3000` | Santai Hub URL for push/pull/auth |
 
 You need at least one provider key configured for AI chat. You can configure both to have access to models from both providers.


### PR DESCRIPTION
## Summary
- Document `OPENAI_API_BASE_URL` in `docs/configuration.md` (env vars table + example `.env` snippet) so users know about the OpenAI-compatible proxy override.
- Note that `OPENAI_API_KEY` should match the proxy when `OPENAI_API_BASE_URL` is set.
- Tidy up `.env.example` wording around the OpenAI-compatible key and proxy.

Closes #95.

## Test plan
- [ ] `mkdocs serve` renders the configuration page with the new row + snippet.
- [ ] Manual read-through of `.env.example` for clarity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)