### PR TITLE
fix(tui): close file modal when clicking outside the panel

### DIFF
--- a/src/santai_cli/tui/app.py
+++ b/src/santai_cli/tui/app.py
@@ -661,6 +661,11 @@ class NoteDetailScreen(ModalScreen):
             )
             yield Static(id="notes-modal-body")
 
+    def on_click(self, event) -> None:
+        """Dismiss when clicking the dimmed area outside the modal panel."""
+        if event.widget is self:
+            self.dismiss()
+
     def on_mount(self) -> None:
         """Populate note content."""
         theme = ThemeManager.get_current_theme()
@@ -1027,6 +1032,11 @@ class FilePreviewScreen(ModalScreen):
                 id="file-preview-title",
             )
             yield Static(id="file-preview-body")
+
+    def on_click(self, event) -> None:
+        """Dismiss when clicking the dimmed area outside the modal panel."""
+        if event.widget is self:
+            self.dismiss()
 
     def on_mount(self) -> None:
         """Load file content."""


### PR DESCRIPTION
## Summary
- Closes #76
- Adds `on_click` handlers to `FilePreviewScreen` and `NoteDetailScreen` that dismiss the modal when the click lands on the dimmed area outside the inner panel (i.e. `event.widget is self`).
- Clicks inside the panel still bubble normally and do not close the file.

Edit/Add/Move/Confirm modals are intentionally left captive so accidental outside-clicks cannot drop unsaved input.

## Test plan
- [ ] Run `santai ui`, open a note via the Notes panel, and click outside the inner panel — modal closes.

## Screenshot
<img width="1418" height="917" alt="Screenshot 2026-05-15 at 11 58 50 AM" src="https://github.com/user-attachments/assets/ca3f1ab2-e535-4fa1-8f8d-48e6f3722a02" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)