### PR TITLE
feat: updated graph linking algorithm, enabled dynamic graph legend, improved cluster auto-naming

### DIFF
--- a/src/santai_cli/core/project.py
+++ b/src/santai_cli/core/project.py
@@ -341,16 +341,25 @@ MARKDOWN_LINK_PATTERN = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
 WIKILINK_PATTERN = re.compile(r"\[\[([^\]|]+)(?:\|[^\]]+)?\]\]")
 
 
+_SKIP_DIRS = frozenset({"__pycache__", "node_modules", ".venv", "venv", ".git"})
+
+
 def _get_directory_name(file_path: Path, project_root: Path) -> str:
-    """Get the santai directory name for a file."""
+    """Get the directory category for a file relative to the project root.
+
+    Returns the first path component for files in subdirectories,
+    or "unassigned" for files sitting directly at the project root.
+    """
     try:
         relative = file_path.relative_to(project_root)
         parts = relative.parts
-        if parts and parts[0] in SANTAI_DIRS:
+        if len(parts) == 1:
+            return "unassigned"
+        if parts:
             return parts[0]
     except ValueError:
         pass
-    return "other"
+    return "unassigned"
 
 
 def _extract_links(content: str) -> list[tuple[str, str]]:
@@ -623,61 +632,103 @@ def _compute_semantic_edges(
     return edges
 
 
+def _add_file_to_graph(
+    file_path: Path,
+    directory: str,
+    project_root: Path,
+    nodes: list[GraphNode],
+    file_map: dict[str, Path],
+    file_contents: dict[str, str],
+    text_extensions: set[str],
+) -> None:
+    """Add a single file to the graph data structures."""
+    try:
+        relative_path = file_path.relative_to(project_root)
+        file_id = str(relative_path)
+        stat = file_path.stat()
+
+        nodes.append(
+            GraphNode(
+                id=file_id,
+                name=file_path.name,
+                directory=directory,
+                file_type=file_path.suffix.lower() if file_path.suffix else "(no ext)",
+                size_bytes=stat.st_size,
+            )
+        )
+        file_map[file_id] = file_path
+
+        if file_path.suffix.lower() in text_extensions:
+            try:
+                file_contents[file_id] = file_path.read_text(encoding="utf-8")
+            except UnicodeDecodeError:
+                pass
+
+    except (OSError, ValueError):
+        pass
+
+
 def get_file_graph(project: SantaiProject) -> FileGraph:
     """Build a graph of files and their backlinks.
 
-    Scans all markdown and text files in the project directories,
-    extracts links, and builds a graph representation.
+    Scans all files in the project: known santai dirs, root-level files
+    (shown as "unassigned"), and any other root-level subdirectories.
     """
     nodes: list[GraphNode] = []
     edges: list[GraphEdge] = []
     file_map: dict[str, Path] = {}  # file_id -> Path
     file_contents: dict[str, str] = {}  # file_id -> content
 
-    # Collect all text-based files
     text_extensions = {".md", ".txt", ".markdown"}
 
+    # Known santai subdirectories
     for dir_name in SANTAI_DIRS:
         dir_path = project.root / dir_name
         if not dir_path.is_dir():
             continue
 
         for file_path in dir_path.rglob("*"):
-            if not file_path.is_file():
+            if not file_path.is_file() or file_path.name.startswith("."):
                 continue
-            if file_path.name.startswith("."):
-                continue
+            _add_file_to_graph(
+                file_path,
+                dir_name,
+                project.root,
+                nodes,
+                file_map,
+                file_contents,
+                text_extensions,
+            )
 
-            try:
-                relative_path = file_path.relative_to(project.root)
-                file_id = str(relative_path)
-                stat = file_path.stat()
-
-                # Create node for all files
-                nodes.append(
-                    GraphNode(
-                        id=file_id,
-                        name=file_path.name,
-                        directory=dir_name,
-                        file_type=file_path.suffix.lower()
-                        if file_path.suffix
-                        else "(no ext)",
-                        size_bytes=stat.st_size,
-                    )
+    # Root-level files (directly in project root) → "unassigned"
+    # Plus non-SANTAI, non-hidden root subdirectories
+    santai_and_skip = set(SANTAI_DIRS) | _SKIP_DIRS
+    for entry in project.root.iterdir():
+        if entry.name.startswith("."):
+            continue
+        if entry.is_file():
+            _add_file_to_graph(
+                entry,
+                "unassigned",
+                project.root,
+                nodes,
+                file_map,
+                file_contents,
+                text_extensions,
+            )
+        elif entry.is_dir() and entry.name not in santai_and_skip:
+            for file_path in entry.rglob("*"):
+                if not file_path.is_file() or file_path.name.startswith("."):
+                    continue
+                _add_file_to_graph(
+                    file_path,
+                    entry.name,
+                    project.root,
+                    nodes,
+                    file_map,
+                    file_contents,
+                    text_extensions,
                 )
-
-                file_map[file_id] = file_path
-
-                # Read content for text files (for link extraction)
-                if file_path.suffix.lower() in text_extensions:
-                    try:
-                        content = file_path.read_text(encoding="utf-8")
-                        file_contents[file_id] = content
-                    except UnicodeDecodeError:
-                        pass
-
-            except (OSError, ValueError):
-                continue
 
     # Extract links and create reference edges
     for source_id, content in file_contents.items():

--- a/src/santai_cli/core/project.py
+++ b/src/santai_cli/core/project.py
@@ -343,6 +343,17 @@ WIKILINK_PATTERN = re.compile(r"\[\[([^\]|]+)(?:\|[^\]]+)?\]\]")
 
 _SKIP_DIRS = frozenset({"__pycache__", "node_modules", ".venv", "venv", ".git"})
 
+# Project meta-files that should never appear as graph nodes
+_GRAPH_EXCLUDE_NAMES = frozenset(
+    {
+        "AGENTS.md",
+        "CLAUDE.md",
+        "README.md",
+        "README.rst",
+        "rumdl.toml",
+    }
+)
+
 
 def _get_directory_name(file_path: Path, project_root: Path) -> str:
     """Get the directory category for a file relative to the project root.
@@ -642,6 +653,8 @@ def _add_file_to_graph(
     text_extensions: set[str],
 ) -> None:
     """Add a single file to the graph data structures."""
+    if file_path.name in _GRAPH_EXCLUDE_NAMES:
+        return
     try:
         relative_path = file_path.relative_to(project_root)
         file_id = str(relative_path)

--- a/src/santai_cli/core/project.py
+++ b/src/santai_cli/core/project.py
@@ -61,7 +61,7 @@ class GraphEdge:
 
     source: str  # Source file id
     target: str  # Target file id
-    link_text: str  # The text that was linked
+    link_text: str = ""  # The text that was linked
     edge_type: str = field(default="reference")  # "reference" or "semantic"
 
 
@@ -602,6 +602,38 @@ def _cosine(a: dict[str, float], b: dict[str, float]) -> float:
     return dot / (mag_a * mag_b) if mag_a and mag_b else 0.0
 
 
+def _name_tokens(filename: str) -> set[str]:
+    """Extract meaningful alpha tokens from a filename (no extension, no digits)."""
+    stem = Path(filename).stem.lower()
+    words = re.findall(r"[a-z]{3,}", stem)
+    return {w for w in words if w not in _STOP_WORDS}
+
+
+def _compute_name_edges(
+    nodes: list[GraphNode],
+    existing_pairs: set[tuple[str, str]],
+) -> list[GraphEdge]:
+    """Connect files that share significant filename tokens (e.g. assignment series)."""
+    token_to_ids: dict[str, list[str]] = {}
+    for node in nodes:
+        for token in _name_tokens(node.name):
+            token_to_ids.setdefault(token, []).append(node.id)
+
+    edges: list[GraphEdge] = []
+    seen = set(existing_pairs)
+    for node_ids in token_to_ids.values():
+        if len(node_ids) < 2:
+            continue
+        for i, id_a in enumerate(node_ids):
+            for id_b in node_ids[i + 1 :]:
+                pair = (min(id_a, id_b), max(id_a, id_b))
+                if pair in seen:
+                    continue
+                seen.add(pair)
+                edges.append(GraphEdge(source=id_a, target=id_b, edge_type="name"))
+    return edges
+
+
 def _compute_semantic_edges(
     file_contents: dict[str, str],
     existing_pairs: set[tuple[str, str]],
@@ -692,7 +724,33 @@ def get_file_graph(project: SantaiProject) -> FileGraph:
     file_map: dict[str, Path] = {}  # file_id -> Path
     file_contents: dict[str, str] = {}  # file_id -> content
 
-    text_extensions = {".md", ".txt", ".markdown"}
+    text_extensions = {
+        ".md",
+        ".txt",
+        ".markdown",
+        # Code files — tokenizer extracts identifiers and comments
+        ".py",
+        ".cpp",
+        ".cc",
+        ".cxx",
+        ".c",
+        ".h",
+        ".hpp",
+        ".js",
+        ".ts",
+        ".jsx",
+        ".tsx",
+        ".java",
+        ".rb",
+        ".go",
+        ".rs",
+        ".cs",
+        ".swift",
+        ".kt",
+        ".scala",
+        ".sql",
+        ".sh",
+    }
 
     # Known santai subdirectories
     for dir_name in SANTAI_DIRS:
@@ -762,5 +820,9 @@ def get_file_graph(project: SantaiProject) -> FileGraph:
     # Add semantic edges for topically related files with no explicit link
     existing_pairs = {(e.source, e.target) for e in edges}
     edges.extend(_compute_semantic_edges(file_contents, existing_pairs))
+
+    # Add name-based edges for files sharing significant filename tokens
+    existing_pairs = {(e.source, e.target) for e in edges}
+    edges.extend(_compute_name_edges(nodes, existing_pairs))
 
     return FileGraph(nodes=nodes, edges=edges)

--- a/src/santai_cli/core/project.py
+++ b/src/santai_cli/core/project.py
@@ -344,33 +344,15 @@ WIKILINK_PATTERN = re.compile(r"\[\[([^\]|]+)(?:\|[^\]]+)?\]\]")
 _SKIP_DIRS = frozenset({"__pycache__", "node_modules", ".venv", "venv", ".git"})
 
 # Project meta-files that should never appear as graph nodes
-_GRAPH_EXCLUDE_NAMES = frozenset(
+_GRAPH_EXCLUDE_NAMES_LOWER = frozenset(
     {
-        "AGENTS.md",
-        "CLAUDE.md",
-        "README.md",
-        "README.rst",
+        "agents.md",
+        "claude.md",
+        "readme.md",
+        "readme.rst",
         "rumdl.toml",
     }
 )
-
-
-def _get_directory_name(file_path: Path, project_root: Path) -> str:
-    """Get the directory category for a file relative to the project root.
-
-    Returns the first path component for files in subdirectories,
-    or "unassigned" for files sitting directly at the project root.
-    """
-    try:
-        relative = file_path.relative_to(project_root)
-        parts = relative.parts
-        if len(parts) == 1:
-            return "unassigned"
-        if parts:
-            return parts[0]
-    except ValueError:
-        pass
-    return "unassigned"
 
 
 def _extract_links(content: str) -> list[tuple[str, str]]:
@@ -620,7 +602,8 @@ def _compute_name_edges(
             token_to_ids.setdefault(token, []).append(node.id)
 
     edges: list[GraphEdge] = []
-    seen = set(existing_pairs)
+    # Normalize to sorted pairs so direction-sensitive existing_pairs don't miss dedup
+    seen = {(min(a, b), max(a, b)) for a, b in existing_pairs}
     for node_ids in token_to_ids.values():
         if len(node_ids) < 2:
             continue
@@ -685,7 +668,7 @@ def _add_file_to_graph(
     text_extensions: set[str],
 ) -> None:
     """Add a single file to the graph data structures."""
-    if file_path.name in _GRAPH_EXCLUDE_NAMES:
+    if file_path.name.lower() in _GRAPH_EXCLUDE_NAMES_LOWER:
         return
     try:
         relative_path = file_path.relative_to(project_root)
@@ -810,9 +793,13 @@ def get_file_graph(project: SantaiProject) -> FileGraph:
                     text_extensions,
                 )
 
-    # Extract links and create reference edges
+    # Extract links and create reference edges — only from prose/markdown files,
+    # not code files (whose [text](url) in comments isn't meaningful graph structure)
+    _prose_extensions = {".md", ".txt", ".markdown"}
     for source_id, content in file_contents.items():
         source_path = file_map[source_id]
+        if source_path.suffix.lower() not in _prose_extensions:
+            continue
         links = _extract_links(content)
 
         for link_text, link_target in links:

--- a/src/santai_cli/core/project.py
+++ b/src/santai_cli/core/project.py
@@ -1,7 +1,9 @@
 """Project detection and data loading for Santai projects."""
 
+import math
 import re
-from dataclasses import dataclass
+from collections import Counter
+from dataclasses import dataclass, field
 from datetime import date, datetime
 from pathlib import Path
 
@@ -60,6 +62,7 @@ class GraphEdge:
     source: str  # Source file id
     target: str  # Target file id
     link_text: str  # The text that was linked
+    edge_type: str = field(default="reference")  # "reference" or "semantic"
 
 
 @dataclass
@@ -439,6 +442,187 @@ def _resolve_link(
     return None
 
 
+_STOP_WORDS = frozenset(
+    {
+        "a",
+        "an",
+        "and",
+        "are",
+        "as",
+        "at",
+        "be",
+        "been",
+        "by",
+        "can",
+        "did",
+        "do",
+        "for",
+        "from",
+        "had",
+        "has",
+        "have",
+        "he",
+        "her",
+        "him",
+        "his",
+        "how",
+        "if",
+        "in",
+        "is",
+        "it",
+        "its",
+        "my",
+        "no",
+        "not",
+        "of",
+        "on",
+        "or",
+        "our",
+        "she",
+        "so",
+        "than",
+        "that",
+        "the",
+        "their",
+        "them",
+        "then",
+        "there",
+        "these",
+        "they",
+        "this",
+        "those",
+        "through",
+        "to",
+        "up",
+        "was",
+        "we",
+        "were",
+        "what",
+        "when",
+        "which",
+        "who",
+        "will",
+        "with",
+        "would",
+        "you",
+        "your",
+        "very",
+        "also",
+        "all",
+        "any",
+        "both",
+        "each",
+        "few",
+        "more",
+        "most",
+        "one",
+        "other",
+        "same",
+        "such",
+        "about",
+        "but",
+        "into",
+        "here",
+        "just",
+        "over",
+        "only",
+    }
+)
+
+_MARKDOWN_STRIP = re.compile(
+    r"```.*?```|`[^`]+`|\[([^\]]+)\]\([^)]+\)|\[\[([^\]|]+)(?:\|[^\]]+)?\]\]|#{1,6} |[*_~]",
+    re.DOTALL,
+)
+
+
+def _tokenize(text: str) -> list[str]:
+    """Strip markdown syntax and return meaningful lowercase words (min 3 chars)."""
+    cleaned = _MARKDOWN_STRIP.sub(lambda m: m.group(1) or m.group(2) or " ", text)
+    words = re.findall(r"[a-z]{3,}", cleaned.lower())
+    return [w for w in words if w not in _STOP_WORDS]
+
+
+def _tfidf_vectors(
+    file_contents: dict[str, str],
+) -> dict[str, dict[str, float]]:
+    """Return a TF-IDF vector (sparse dict) per file id."""
+    doc_terms: dict[str, Counter] = {}
+    for file_id, content in file_contents.items():
+        tokens = _tokenize(content)
+        if len(tokens) >= 20:  # skip very short files
+            doc_terms[file_id] = Counter(tokens)
+
+    n = len(doc_terms)
+    if n < 2:
+        return {}
+
+    df: Counter = Counter()
+    for terms in doc_terms.values():
+        df.update(terms.keys())
+
+    # Smoothed IDF: log((1+n)/(1+df)) + 1  — keeps shared terms at reduced weight
+    # instead of zeroing them out, which breaks small corpora (e.g. n=2).
+    idf = {term: math.log((1 + n) / (1 + count)) + 1.0 for term, count in df.items()}
+
+    vectors: dict[str, dict[str, float]] = {}
+    for file_id, terms in doc_terms.items():
+        total = sum(terms.values())
+        vectors[file_id] = {
+            term: (count / total) * idf[term] for term, count in terms.items()
+        }
+    return vectors
+
+
+def _cosine(a: dict[str, float], b: dict[str, float]) -> float:
+    dot = sum(a.get(t, 0.0) * v for t, v in b.items())
+    if dot == 0.0:
+        return 0.0
+    mag_a = math.sqrt(sum(v * v for v in a.values()))
+    mag_b = math.sqrt(sum(v * v for v in b.values()))
+    return dot / (mag_a * mag_b) if mag_a and mag_b else 0.0
+
+
+def _compute_semantic_edges(
+    file_contents: dict[str, str],
+    existing_pairs: set[tuple[str, str]],
+    threshold: float = 0.15,
+    max_per_node: int = 3,
+) -> list[GraphEdge]:
+    """Add semantic edges between topically related files that lack explicit links."""
+    vectors = _tfidf_vectors(file_contents)
+    ids = list(vectors.keys())
+
+    # Score all candidate pairs
+    scored: list[tuple[float, str, str]] = []
+    for i, id_a in enumerate(ids):
+        for id_b in ids[i + 1 :]:
+            if (id_a, id_b) in existing_pairs or (id_b, id_a) in existing_pairs:
+                continue
+            sim = _cosine(vectors[id_a], vectors[id_b])
+            if sim >= threshold:
+                scored.append((sim, id_a, id_b))
+
+    scored.sort(key=lambda x: x[0], reverse=True)
+
+    budget: Counter = Counter()
+    edges: list[GraphEdge] = []
+    for sim, id_a, id_b in scored:
+        if budget[id_a] >= max_per_node or budget[id_b] >= max_per_node:
+            continue
+        edges.append(
+            GraphEdge(
+                source=id_a,
+                target=id_b,
+                link_text=f"~{sim:.2f}",
+                edge_type="semantic",
+            )
+        )
+        budget[id_a] += 1
+        budget[id_b] += 1
+
+    return edges
+
+
 def get_file_graph(project: SantaiProject) -> FileGraph:
     """Build a graph of files and their backlinks.
 
@@ -495,7 +679,7 @@ def get_file_graph(project: SantaiProject) -> FileGraph:
             except (OSError, ValueError):
                 continue
 
-    # Extract links and create edges
+    # Extract links and create reference edges
     for source_id, content in file_contents.items():
         source_path = file_map[source_id]
         links = _extract_links(content)
@@ -510,5 +694,9 @@ def get_file_graph(project: SantaiProject) -> FileGraph:
                         link_text=link_text,
                     )
                 )
+
+    # Add semantic edges for topically related files with no explicit link
+    existing_pairs = {(e.source, e.target) for e in edges}
+    edges.extend(_compute_semantic_edges(file_contents, existing_pairs))
 
     return FileGraph(nodes=nodes, edges=edges)

--- a/src/santai_cli/core/project.py
+++ b/src/santai_cli/core/project.py
@@ -750,6 +750,15 @@ def get_file_graph(project: SantaiProject) -> FileGraph:
         ".scala",
         ".sql",
         ".sh",
+        # Markup / config / data — often contain meaningful prose or keys
+        ".html",
+        ".htm",
+        ".json",
+        ".yaml",
+        ".yml",
+        ".toml",
+        ".xml",
+        ".csv",
     }
 
     # Known santai subdirectories

--- a/src/santai_cli/tui/app.py
+++ b/src/santai_cli/tui/app.py
@@ -249,8 +249,29 @@ class GraphPanel(Static):
         "history": "#b1b9f9",  # lavender
         "notes": "#d77757",  # terracotta
         "wiki": "#f5c542",  # gold
-        "other": "#6b6560",  # warm gray
+        "unassigned": "#9b9ba8",  # muted blue-gray for root-level files
+        "other": "#6b6560",  # warm gray fallback
     }
+
+    # Colors assigned round-robin (by hash) to dynamically discovered dirs
+    _EXTRA_PALETTE = [
+        "#e07b54",  # orange
+        "#54b8e0",  # sky blue
+        "#b054e0",  # purple
+        "#54e0a8",  # mint
+        "#e0c454",  # amber
+        "#c454e0",  # violet
+        "#54e07b",  # lime
+        "#e05480",  # rose
+    ]
+
+    @classmethod
+    def get_dir_color(cls, dir_name: str) -> str:
+        """Return a stable color for any directory name."""
+        if dir_name in cls.DIR_COLORS:
+            return cls.DIR_COLORS[dir_name]
+        idx = hash(dir_name) % len(cls._EXTRA_PALETTE)
+        return cls._EXTRA_PALETTE[idx]
 
     def __init__(self, project: SantaiProject, fullscreen: bool = False) -> None:
         super().__init__()
@@ -356,13 +377,18 @@ class GraphPanel(Static):
         self._render_width = render_width
         self._render_height = render_height
 
+        # Build a complete color map for every directory present in the graph
+        all_dirs = {n.directory for n in nodes}
+        dynamic_dir_colors = {d: self.get_dir_color(d) for d in all_dirs}
+        dynamic_dir_colors["other"] = self.DIR_COLORS["other"]
+
         # Render the force-directed graph
         result = render_graph(
             nodes=nodes,
             edges=edges,
             width=render_width,
             height=render_height,
-            dir_colors=self.DIR_COLORS,
+            dir_colors=dynamic_dir_colors,
             selected_id=self._selected_id,
             highlight_ids=self._highlight_ids,
             show_labels=True,
@@ -410,18 +436,23 @@ class GraphPanel(Static):
         # The graph visualization
         lines.append(result.markup)
 
-        # Legend
+        # Legend: known dirs first, then dynamic dirs alphabetically, unassigned last
         lines.append("")
         dirs_present = {n.directory for n in graph_data.nodes}
+        known_order = ["resources", "codebases", "history", "notes", "wiki"]
         legend_parts = []
-        for dir_name in ["resources", "codebases", "history", "notes", "wiki"]:
+        for dir_name in known_order:
             if dir_name in dirs_present:
-                color = self.DIR_COLORS.get(dir_name, self.DIR_COLORS["other"])
+                color = self.get_dir_color(dir_name)
                 legend_parts.append(f"[{color}]●[/{color}] {dir_name}")
-        for dir_name in dirs_present:
-            if dir_name not in ["resources", "codebases", "history", "notes", "wiki"]:
-                color = self.DIR_COLORS.get(dir_name, self.DIR_COLORS["other"])
-                legend_parts.append(f"[{color}]●[/{color}] {dir_name}")
+        for dir_name in sorted(
+            dirs_present - set(known_order) - {"unassigned", "other"}
+        ):
+            color = self.get_dir_color(dir_name)
+            legend_parts.append(f"[{color}]●[/{color}] {dir_name}")
+        if "unassigned" in dirs_present:
+            color = self.get_dir_color("unassigned")
+            legend_parts.append(f"[{color}]●[/{color}] unassigned")
         lines.append(" ".join(legend_parts))
 
         if graph_data.edges:
@@ -1356,8 +1387,6 @@ class GraphSearchScreen(ModalScreen):
         """Render the results list with selection highlight."""
         results_widget = self.query_one("#graph-search-results", Static)
 
-        dir_colors = GraphPanel.DIR_COLORS
-
         if not self._results:
             query = self.query_one("#graph-search-input", Input).value.strip()
             if query:
@@ -1368,7 +1397,7 @@ class GraphSearchScreen(ModalScreen):
 
         lines = []
         for i, node in enumerate(self._results):
-            color = dir_colors.get(node.directory, dir_colors.get("other", "#6b6560"))
+            color = GraphPanel.get_dir_color(node.directory)
             is_selected = i == self._selected_index
 
             # Selection indicator
@@ -1431,11 +1460,11 @@ class GraphFilterScreen(ModalScreen):
     ) -> None:
         super().__init__()
         self._project = project
-        # If no filter is active, all dirs are selected
-        if current_filter is None:
-            self._selected: set[str] = set(self.DIRS)
-        else:
-            self._selected = set(current_filter)
+        self._no_initial_filter = current_filter is None
+        # Temporary default; on_mount will expand to all available dirs if no filter
+        self._selected: set[str] = (
+            set(current_filter) if current_filter else set(self.DIRS)
+        )
         self._available_dirs: set[str] = set()
 
     def compose(self) -> ComposeResult:
@@ -1457,11 +1486,13 @@ class GraphFilterScreen(ModalScreen):
         self._dir_counts: dict[str, int] = {}
         for n in nodes:
             self._dir_counts[n.directory] = self._dir_counts.get(n.directory, 0) + 1
+        # When no filter was active, select everything (including dynamic dirs)
+        if self._no_initial_filter:
+            self._selected = set(self._available_dirs)
         self._update_display()
 
     def _update_display(self) -> None:
         body = self.query_one("#filter-body", Static)
-        dir_colors = GraphPanel.DIR_COLORS
 
         lines = []
         lines.append("")
@@ -1469,7 +1500,7 @@ class GraphFilterScreen(ModalScreen):
         lines.append("")
 
         for i, d in enumerate(self.DIRS, 1):
-            color = dir_colors.get(d, dir_colors.get("other", "#6b6560"))
+            color = GraphPanel.get_dir_color(d)
             count = self._dir_counts.get(d, 0)
             is_on = d in self._selected
             available = d in self._available_dirs
@@ -1486,10 +1517,12 @@ class GraphFilterScreen(ModalScreen):
 
             lines.append(f"  [{i}]{checkbox} {label}")
 
-        # Show any extra directories not in the standard list
-        extra_dirs = self._available_dirs - set(self.DIRS)
-        for d in sorted(extra_dirs):
-            color = dir_colors.get(d, dir_colors.get("other", "#6b6560"))
+        # Dynamic dirs: alphabetically, with "unassigned" at the end
+        extra_dirs = sorted(self._available_dirs - set(self.DIRS) - {"unassigned"})
+        for d in extra_dirs + (
+            ["unassigned"] if "unassigned" in self._available_dirs else []
+        ):
+            color = GraphPanel.get_dir_color(d)
             count = self._dir_counts.get(d, 0)
             is_on = d in self._selected
             if is_on:

--- a/src/santai_cli/tui/app.py
+++ b/src/santai_cli/tui/app.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable, Iterable
 from datetime import datetime
+from hashlib import md5
 from pathlib import Path
 from typing import Any
 
@@ -253,16 +254,17 @@ class GraphPanel(Static):
         "other": "#6b6560",  # warm gray fallback
     }
 
-    # Colors assigned round-robin (by hash) to dynamically discovered dirs
+    # Matches the web UI _extraDirPalette — same order so the same dir gets
+    # the same color in both surfaces.
     _EXTRA_PALETTE = [
-        "#e07b54",  # orange
-        "#54b8e0",  # sky blue
-        "#b054e0",  # purple
-        "#54e0a8",  # mint
-        "#e0c454",  # amber
-        "#c454e0",  # violet
-        "#54e07b",  # lime
-        "#e05480",  # rose
+        "#f97316",  # orange
+        "#22d3ee",  # cyan
+        "#d946ef",  # fuchsia
+        "#84cc16",  # lime
+        "#0f766e",  # dark teal
+        "#fb923c",  # peach-orange
+        "#a21caf",  # deep magenta
+        "#0e7490",  # dark cyan
     ]
 
     @classmethod
@@ -270,7 +272,9 @@ class GraphPanel(Static):
         """Return a stable color for any directory name."""
         if dir_name in cls.DIR_COLORS:
             return cls.DIR_COLORS[dir_name]
-        idx = hash(dir_name) % len(cls._EXTRA_PALETTE)
+        # Use MD5 for a stable cross-process hash (Python's built-in hash is
+        # randomized by PYTHONHASHSEED and changes every process restart).
+        idx = md5(dir_name.encode()).digest()[0] % len(cls._EXTRA_PALETTE)
         return cls._EXTRA_PALETTE[idx]
 
     def __init__(self, project: SantaiProject, fullscreen: bool = False) -> None:
@@ -1451,6 +1455,10 @@ class GraphFilterScreen(ModalScreen):
         Binding("3", "toggle_3", "history"),
         Binding("4", "toggle_4", "notes"),
         Binding("5", "toggle_5", "wiki"),
+        Binding("6", "toggle_6", "dir 6", show=False),
+        Binding("7", "toggle_7", "dir 7", show=False),
+        Binding("8", "toggle_8", "dir 8", show=False),
+        Binding("9", "toggle_9", "dir 9", show=False),
         Binding("a", "select_all", "All"),
         Binding("x", "clear_all", "None"),
     ]
@@ -1578,20 +1586,25 @@ class GraphFilterScreen(ModalScreen):
     def action_toggle_5(self) -> None:
         self._toggle_dir("wiki")
 
-    def on_key(self, event) -> None:
-        """Handle keys 6–9 to toggle dynamic (non-standard) directories."""
-        if not event.key.isdigit():
-            return
-        n = int(event.key)
-        if n < 6:
-            return
+    def _toggle_extra_dir(self, idx: int) -> None:
         extra_dirs = sorted(self._available_dirs - set(self.DIRS) - {"unassigned"})
         all_extra = extra_dirs + (
             ["unassigned"] if "unassigned" in self._available_dirs else []
         )
-        idx = n - 6
         if 0 <= idx < len(all_extra):
             self._toggle_dir(all_extra[idx])
+
+    def action_toggle_6(self) -> None:
+        self._toggle_extra_dir(0)
+
+    def action_toggle_7(self) -> None:
+        self._toggle_extra_dir(1)
+
+    def action_toggle_8(self) -> None:
+        self._toggle_extra_dir(2)
+
+    def action_toggle_9(self) -> None:
+        self._toggle_extra_dir(3)
 
     def action_select_all(self) -> None:
         self._selected = set(self.DIRS) | self._available_dirs

--- a/src/santai_cli/tui/app.py
+++ b/src/santai_cli/tui/app.py
@@ -399,8 +399,29 @@ class GraphPanel(Static):
         self._node_positions = result.node_positions
         self._node_map = result.node_map
 
-        # Build output
+        # Build output — legend and stats come FIRST so they are never clipped
+        # by the container height in the non-scrollable panel view.
         lines = []
+
+        # Legend: reflect exactly what is currently rendered (uses `nodes`, not graph_data)
+        dirs_present = {n.directory for n in nodes}
+        known_order = ["resources", "codebases", "history", "notes", "wiki"]
+        legend_parts = []
+        for dir_name in known_order:
+            if dir_name in dirs_present:
+                color = self.get_dir_color(dir_name)
+                label = dir_name[:12] + "…" if len(dir_name) > 13 else dir_name
+                legend_parts.append(f"[{color}]●[/{color}] {label}")
+        for dir_name in sorted(
+            dirs_present - set(known_order) - {"unassigned", "other"}
+        ):
+            color = self.get_dir_color(dir_name)
+            label = dir_name[:12] + "…" if len(dir_name) > 13 else dir_name
+            legend_parts.append(f"[{color}]●[/{color}] {label}")
+        if "unassigned" in dirs_present:
+            color = self.get_dir_color("unassigned")
+            legend_parts.append(f"[{color}]●[/{color}] unassigned")
+        lines.append(" ".join(legend_parts))
 
         # Stats header with search/filter indicators
         total_nodes = len(graph_data.nodes)
@@ -436,28 +457,9 @@ class GraphPanel(Static):
         # The graph visualization
         lines.append(result.markup)
 
-        # Legend: reflect exactly what is currently rendered (uses `nodes`, not graph_data)
-        lines.append("")
-        dirs_present = {n.directory for n in nodes}
-        known_order = ["resources", "codebases", "history", "notes", "wiki"]
-        legend_parts = []
-        for dir_name in known_order:
-            if dir_name in dirs_present:
-                color = self.get_dir_color(dir_name)
-                legend_parts.append(f"[{color}]●[/{color}] {dir_name}")
-        for dir_name in sorted(
-            dirs_present - set(known_order) - {"unassigned", "other"}
-        ):
-            color = self.get_dir_color(dir_name)
-            legend_parts.append(f"[{color}]●[/{color}] {dir_name}")
-        if "unassigned" in dirs_present:
-            color = self.get_dir_color("unassigned")
-            legend_parts.append(f"[{color}]●[/{color}] unassigned")
-        lines.append(" ".join(legend_parts))
-
         if graph_data.edges:
             lines.append(
-                "[dim]⬢ hub (5+)  ◆ connected (3+)  ● node"
+                "\n[dim]⬢ hub (5+)  ◆ connected (3+)  ● node"
                 "  ◈ match  ◉ selected  c=clear[/dim]"
             )
 

--- a/src/santai_cli/tui/app.py
+++ b/src/santai_cli/tui/app.py
@@ -436,9 +436,9 @@ class GraphPanel(Static):
         # The graph visualization
         lines.append(result.markup)
 
-        # Legend: known dirs first, then dynamic dirs alphabetically, unassigned last
+        # Legend: reflect exactly what is currently rendered (uses `nodes`, not graph_data)
         lines.append("")
-        dirs_present = {n.directory for n in graph_data.nodes}
+        dirs_present = {n.directory for n in nodes}
         known_order = ["resources", "codebases", "history", "notes", "wiki"]
         legend_parts = []
         for dir_name in known_order:

--- a/src/santai_cli/tui/app.py
+++ b/src/santai_cli/tui/app.py
@@ -1580,9 +1580,9 @@ class GraphFilterScreen(ModalScreen):
 
     def key_enter(self) -> None:
         """Apply the filter."""
-        all_dirs = set(self.DIRS) | self._available_dirs
-        if self._selected >= all_dirs or not self._selected:
-            # All selected or none selected = no filter
+        # Compare against available dirs only — standard dirs with no files
+        # are irrelevant and would prevent this check from ever being True.
+        if not self._selected or self._selected >= self._available_dirs:
             filter_dirs = None
         else:
             filter_dirs = set(self._selected)

--- a/src/santai_cli/tui/app.py
+++ b/src/santai_cli/tui/app.py
@@ -1520,10 +1520,13 @@ class GraphFilterScreen(ModalScreen):
             lines.append(f"  [{i}]{checkbox} {label}")
 
         # Dynamic dirs: alphabetically, with "unassigned" at the end
+        # Keys 6–9 are assigned to the first 4 extra dirs in order
         extra_dirs = sorted(self._available_dirs - set(self.DIRS) - {"unassigned"})
-        for d in extra_dirs + (
+        all_extra = extra_dirs + (
             ["unassigned"] if "unassigned" in self._available_dirs else []
-        ):
+        )
+        for idx, d in enumerate(all_extra):
+            key_hint = f"[{idx + 6}]" if idx < 4 else "   "
             color = GraphPanel.get_dir_color(d)
             count = self._dir_counts.get(d, 0)
             is_on = d in self._selected
@@ -1533,7 +1536,7 @@ class GraphFilterScreen(ModalScreen):
             else:
                 checkbox = "  ○"
                 label = f"[dim]{d}/ ({count} files)[/dim]"
-            lines.append(f"     {checkbox} {label}")
+            lines.append(f"  {key_hint}{checkbox} {label}")
 
         lines.append("")
 
@@ -1545,7 +1548,10 @@ class GraphFilterScreen(ModalScreen):
         total_count = sum(self._dir_counts.values())
         lines.append(f"  Showing: [bold]{selected_count}[/bold] of {total_count} files")
         lines.append("")
-        lines.append("  [dim]1-5 = toggle directory · a = all · x = none[/dim]")
+        extra_key_hint = " · 6-9 = extra dirs" if all_extra else ""
+        lines.append(
+            f"  [dim]1-5 = toggle directory{extra_key_hint} · a = all · x = none[/dim]"
+        )
         lines.append("  [dim]Enter = apply · Esc = cancel[/dim]")
 
         body.update("\n".join(lines))
@@ -1571,6 +1577,21 @@ class GraphFilterScreen(ModalScreen):
 
     def action_toggle_5(self) -> None:
         self._toggle_dir("wiki")
+
+    def on_key(self, event) -> None:
+        """Handle keys 6–9 to toggle dynamic (non-standard) directories."""
+        if not event.key.isdigit():
+            return
+        n = int(event.key)
+        if n < 6:
+            return
+        extra_dirs = sorted(self._available_dirs - set(self.DIRS) - {"unassigned"})
+        all_extra = extra_dirs + (
+            ["unassigned"] if "unassigned" in self._available_dirs else []
+        )
+        idx = n - 6
+        if 0 <= idx < len(all_extra):
+            self._toggle_dir(all_extra[idx])
 
     def action_select_all(self) -> None:
         self._selected = set(self.DIRS) | self._available_dirs

--- a/src/santai_cli/tui/app.py
+++ b/src/santai_cli/tui/app.py
@@ -2,7 +2,6 @@
 
 from collections.abc import Callable, Iterable
 from datetime import datetime
-from hashlib import md5
 from pathlib import Path
 from typing import Any
 
@@ -272,9 +271,16 @@ class GraphPanel(Static):
         """Return a stable color for any directory name."""
         if dir_name in cls.DIR_COLORS:
             return cls.DIR_COLORS[dir_name]
-        # Use MD5 for a stable cross-process hash (Python's built-in hash is
-        # randomized by PYTHONHASHSEED and changes every process restart).
-        idx = md5(dir_name.encode()).digest()[0] % len(cls._EXTRA_PALETTE)
+        # Replicate the web UI's Math.imul(31, h) polynomial hash so the same
+        # directory gets the same palette index (and therefore the same color)
+        # on both surfaces.
+        h = 0
+        for c in dir_name:
+            h_u32 = int(h) & 0xFFFFFFFF
+            prod = (31 * h_u32) & 0xFFFFFFFF
+            imul = prod if prod < 0x80000000 else prod - 0x100000000
+            h = imul + ord(c)
+        idx = abs(int(h)) % len(cls._EXTRA_PALETTE)
         return cls._EXTRA_PALETTE[idx]
 
     def __init__(self, project: SantaiProject, fullscreen: bool = False) -> None:
@@ -407,7 +413,7 @@ class GraphPanel(Static):
         # by the container height in the non-scrollable panel view.
         lines = []
 
-        # Legend: reflect exactly what is currently rendered (uses `nodes`, not graph_data)
+        # Legend: reflect exactly what is rendered (uses `nodes`, not graph_data)
         dirs_present = {n.directory for n in nodes}
         known_order = ["resources", "codebases", "history", "notes", "wiki"]
         legend_parts = []
@@ -1528,7 +1534,7 @@ class GraphFilterScreen(ModalScreen):
             lines.append(f"  [{i}]{checkbox} {label}")
 
         # Dynamic dirs: alphabetically, with "unassigned" at the end
-        # Keys 6–9 are assigned to the first 4 extra dirs in order
+        # Keys 6-9 are assigned to the first 4 extra dirs in order
         extra_dirs = sorted(self._available_dirs - set(self.DIRS) - {"unassigned"})
         all_extra = extra_dirs + (
             ["unassigned"] if "unassigned" in self._available_dirs else []

--- a/src/santai_cli/tui/graph_render.py
+++ b/src/santai_cli/tui/graph_render.py
@@ -467,7 +467,8 @@ def render_graph(
     dimmed_edge_color = "dim #2a2a2a"
     _default_colors = {
         "reference": "dim #444444",
-        "semantic": "dim #2d4a7a",  # indigo — visually distinct from reference gray
+        "semantic": "dim #2d4a7a",  # indigo
+        "name": "dim #2d5a3a",  # dark green — filename-pattern matches
     }
 
     for edge in edges:

--- a/src/santai_cli/tui/graph_render.py
+++ b/src/santai_cli/tui/graph_render.py
@@ -32,6 +32,7 @@ class GraphEdge:
 
     source: str
     target: str
+    edge_type: str = "reference"  # "reference" or "semantic"
 
 
 @dataclass
@@ -462,18 +463,23 @@ def render_graph(
         highlighted_edge_nodes.update(hl)
 
     # Draw edges — highlight edges connected to selected/highlighted nodes
-    default_edge_color = "dim #444444"
     highlight_edge_color = "bold #FFD700"  # gold for highlighted edges
     dimmed_edge_color = "dim #2a2a2a"
+    _default_colors = {
+        "reference": "dim #444444",
+        "semantic": "dim #2d4a7a",  # indigo — visually distinct from reference gray
+    }
 
     for edge in edges:
         if edge.source not in node_map or edge.target not in node_map:
             continue
         src = node_map[edge.source]
         tgt = node_map[edge.target]
+        default_color = _default_colors.get(
+            edge.edge_type, _default_colors["reference"]
+        )
 
         if highlighted_edge_nodes:
-            # If either endpoint is highlighted, use highlight color
             src_hl = edge.source in highlighted_edge_nodes
             tgt_hl = edge.target in highlighted_edge_nodes
             if src_hl or tgt_hl:
@@ -481,7 +487,7 @@ def render_graph(
             else:
                 canvas.draw_line(src.x, src.y, tgt.x, tgt.y, dimmed_edge_color)
         else:
-            canvas.draw_line(src.x, src.y, tgt.x, tgt.y, default_edge_color)
+            canvas.draw_line(src.x, src.y, tgt.x, tgt.y, default_color)
 
     # Draw nodes
     for node in layout_nodes:
@@ -601,6 +607,7 @@ def build_graph_from_project_data(
             GraphEdge(
                 source=edge.source,
                 target=edge.target,
+                edge_type=getattr(edge, "edge_type", "reference"),
             )
         )
 

--- a/src/santai_cli/tui/themes.py
+++ b/src/santai_cli/tui/themes.py
@@ -749,7 +749,7 @@ def _generate_css(c: ThemeColors) -> str:
     #theme-modal {{
         width: 60%;
         height: auto;
-        max-height: 70%;
+        max-height: 90%;
     }}
 
     #theme-modal-content {{

--- a/src/santai_cli/web/app.py
+++ b/src/santai_cli/web/app.py
@@ -273,6 +273,7 @@ def create_app(project: SantaiProject) -> FastAPI:
                     "source": edge.source,
                     "target": edge.target,
                     "link_text": edge.link_text,
+                    "edge_type": edge.edge_type,
                 }
                 for edge in graph.edges
             ],

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -7672,6 +7672,13 @@
         };
 
         // Normalize common plural/suffix variants so "cloud" and "clouds" count as one word
+        function _pluralize(w) {
+            if (w.endsWith('s')) return w;
+            if (w.length > 2 && w.endsWith('y') && !/[aeiou]/i.test(w[w.length - 2])) return w.slice(0, -1) + 'ies';
+            if (/(?:ch|sh|[xz])$/i.test(w)) return w + 'es';
+            return w + 's';
+        }
+
         function _stemWord(w) {
             if (w.length > 5 && w.endsWith('ies')) return w.slice(0, -3) + 'y';      // libraries→library
             if (w.length > 4 && /ches$|shes$|xes$|zes$/.test(w)) return w.slice(0, -2); // brushes→brush
@@ -7749,12 +7756,18 @@
             if (common.length) {
                 // Order by average filename position so title reads in natural word order
                 common.sort((a, b) => a.pos - b.pos || a.display.length - b.display.length || a.display.localeCompare(b.display));
-                return common.map(c => c.display).join(' ');
+                const words = common.map(c => c.display);
+                // Pluralize the last word when the cluster has multiple files
+                if (nodes.length > 1) words[words.length - 1] = _pluralize(words[words.length - 1]);
+                return words.join(' ');
             }
 
             // 2. Any top words at all, excluding requested words
             const top = _topWords(counts, originals, excludeWords, 2, positions);
-            if (top.length) return top.join(' ');
+            if (top.length) {
+                if (nodes.length > 1) top[top.length - 1] = _pluralize(top[top.length - 1]);
+                return top.join(' ');
+            }
 
             // 3. Shared directory (only if not falling back to avoid "notes" × N)
             const dirs = nodes.map(n => n.directory || '');

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -7704,12 +7704,14 @@
         }
 
         function _topWords(counts, originals, exclude = new Set(), limit = 2) {
-            return Object.entries(counts)
+            const words = Object.entries(counts)
                 .filter(([s]) => !exclude.has(s))
                 // Sort by count desc, then alpha for a stable tiebreak (avoids "first file wins")
                 .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
                 .slice(0, limit)
                 .map(([s]) => { const w = originals[s] || s; return w.charAt(0).toUpperCase() + w.slice(1); });
+            // Shorter word first → modifier before noun ("Public Libraries" not "Libraries Public")
+            return words.sort((a, b) => a.length - b.length || a.localeCompare(b));
         }
 
         function suggestClusterName(clusterId, excludeWords = new Set()) {
@@ -7736,7 +7738,12 @@
                 .filter(([s, c]) => c >= threshold && !excludeWords.has(s))
                 .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
                 .map(([s]) => display(s));
-            if (common.length) return common.slice(0, 2).join(' ');
+            if (common.length) {
+                const pair = common.slice(0, 2);
+                // Shorter word first → modifier before noun ("Public Libraries" not "Libraries Public")
+                pair.sort((a, b) => a.length - b.length || a.localeCompare(b));
+                return pair.join(' ');
+            }
 
             // 2. Any top words at all, excluding requested words
             const top = _topWords(counts, originals, excludeWords);

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -6060,10 +6060,18 @@
             other: '#94a3b8'        // Slate gray fallback
         };
 
-        // Extra palette for dynamically discovered directories (deterministic by name hash)
+        // Extra palette for dynamically discovered directories (deterministic by name hash).
+        // Colors chosen to be perceptually distinct from the 5 named dirs
+        // (blue, purple, red, yellow, green) and from each other.
         const _extraDirPalette = [
-            '#e07b54', '#54b8e0', '#b054e0', '#54e0a8',
-            '#e0c454', '#c454e0', '#54e07b', '#e05480'
+            '#f97316',  // orange
+            '#22d3ee',  // cyan
+            '#d946ef',  // fuchsia
+            '#84cc16',  // lime
+            '#0f766e',  // dark teal
+            '#fb923c',  // peach-orange
+            '#a21caf',  // deep magenta
+            '#0e7490'   // dark cyan
         ];
 
         function getDirColor(dirName) {

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -6086,7 +6086,7 @@
             // Deterministic hash so the same dir always gets the same color
             let h = 0;
             for (let i = 0; i < dirName.length; i++) {
-                h = Math.imul(31, h) + dirName.charCodeAt(i) | 0;
+                h = Math.imul(31, h) + dirName.charCodeAt(i);
             }
             return _extraDirPalette[Math.abs(h) % _extraDirPalette.length];
         }
@@ -6147,7 +6147,7 @@
                 const data = await response.json();
                 renderGraph(data);
                 lastGraphHash = hashGraphData(data);
-                updateEditStatus(); // show Restore Links button if deletions exist
+                updateEditStatus();
             } catch (error) {
                 console.error('Failed to load graph:', error);
                 document.getElementById('graph-stats').textContent = 'Failed to load graph';
@@ -8191,6 +8191,8 @@
                 }
             } else if (deleteMode) {
                 status.textContent = 'Click a link to delete it';
+            } else if (deletedLinks.size > 0) {
+                status.innerHTML = `<span style="opacity:0.6">${deletedLinks.size} link${deletedLinks.size === 1 ? '' : 's'} hidden — <a href="#" onclick="event.preventDefault();deletedLinks.clear();localStorage.removeItem('santai-deleted-links');if(window.lastGraphData)renderGraph(window.lastGraphData);updateEditStatus();" style="color:inherit;">restore</a></span>`;
             } else {
                 status.textContent = '';
             }

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -7685,37 +7685,43 @@
             const nodes = nodeIds.map(id => nodeMap.get(id)).filter(Boolean);
             const counts = {};    // stem → # files that contain it
             const originals = {}; // stem → best display word (shortest / most natural form)
+            const positions = {}; // stem → [normalized positions across filenames, for ordering]
             nodes.forEach(n => {
                 const base = n.name.replace(/\.[^.]+$/, '');
+                const tokens = base.split(/[\s\-_\.]+/).map(w => w.toLowerCase());
+                const tokenCount = tokens.length;
                 const seenStems = new Set(); // dedupe within one filename
-                base.split(/[\s\-_\.]+/)
-                    .map(w => w.toLowerCase())
-                    .filter(w => w.length > 2 && !_clusterStopWords.has(w) && /^[a-z]+$/.test(w))
-                    .forEach(w => {
-                        const s = _stemWord(w);
-                        if (seenStems.has(s)) return;
-                        seenStems.add(s);
-                        counts[s] = (counts[s] || 0) + 1;
-                        // Keep the shorter (more base) form as the display word
-                        if (!originals[s] || w.length < originals[s].length) originals[s] = w;
-                    });
+                tokens.forEach((w, idx) => {
+                    if (w.length <= 2 || _clusterStopWords.has(w) || !/^[a-z]+$/.test(w)) return;
+                    const s = _stemWord(w);
+                    if (seenStems.has(s)) return;
+                    seenStems.add(s);
+                    counts[s] = (counts[s] || 0) + 1;
+                    // Keep the shorter (more base) form as the display word
+                    if (!originals[s] || w.length < originals[s].length) originals[s] = w;
+                    // Track normalized position (0 = first token, 1 = last) for word ordering
+                    if (!positions[s]) positions[s] = [];
+                    positions[s].push(tokenCount > 1 ? idx / (tokenCount - 1) : 0);
+                });
             });
-            return { nodes, counts, originals };
+            return { nodes, counts, originals, positions };
         }
 
-        function _topWords(counts, originals, exclude = new Set(), limit = 2) {
-            const words = Object.entries(counts)
+        function _topWords(counts, originals, exclude = new Set(), limit = 2, positions = {}) {
+            const avgPos = s => { const ps = positions[s] || [0.5]; return ps.reduce((a, b) => a + b, 0) / ps.length; };
+            return Object.entries(counts)
                 .filter(([s]) => !exclude.has(s))
                 // Sort by count desc, then alpha for a stable tiebreak (avoids "first file wins")
                 .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
                 .slice(0, limit)
-                .map(([s]) => { const w = originals[s] || s; return w.charAt(0).toUpperCase() + w.slice(1); });
-            // Shorter word first → modifier before noun ("Public Libraries" not "Libraries Public")
-            return words.sort((a, b) => a.length - b.length || a.localeCompare(b));
+                .map(([s]) => { const w = originals[s] || s; return { display: w.charAt(0).toUpperCase() + w.slice(1), pos: avgPos(s) }; })
+                // Sort by average filename position so title reads in natural word order
+                .sort((a, b) => a.pos - b.pos || a.display.length - b.display.length || a.display.localeCompare(b.display))
+                .map(({ display }) => display);
         }
 
         function suggestClusterName(clusterId, excludeWords = new Set()) {
-            const { nodes, counts, originals } = _clusterFileWords(clusterId);
+            const { nodes, counts, originals, positions } = _clusterFileWords(clusterId);
             if (!nodes.length) return `Cluster ${clusterId + 1}`;
 
             const display = s => { const w = originals[s] || s; return w.charAt(0).toUpperCase() + w.slice(1); };
@@ -7734,19 +7740,20 @@
 
             // 1. Words appearing in at least 40% of files (threshold 1 for tiny clusters)
             const threshold = nodes.length <= 2 ? 1 : Math.ceil(nodes.length * 0.4);
+            const avgPos = s => { const ps = positions[s] || [0.5]; return ps.reduce((a, b) => a + b, 0) / ps.length; };
             const common = Object.entries(counts)
                 .filter(([s, c]) => c >= threshold && !excludeWords.has(s))
                 .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
-                .map(([s]) => display(s));
+                .slice(0, 2)
+                .map(([s]) => ({ display: display(s), pos: avgPos(s) }));
             if (common.length) {
-                const pair = common.slice(0, 2);
-                // Shorter word first → modifier before noun ("Public Libraries" not "Libraries Public")
-                pair.sort((a, b) => a.length - b.length || a.localeCompare(b));
-                return pair.join(' ');
+                // Order by average filename position so title reads in natural word order
+                common.sort((a, b) => a.pos - b.pos || a.display.length - b.display.length || a.display.localeCompare(b.display));
+                return common.map(c => c.display).join(' ');
             }
 
             // 2. Any top words at all, excluding requested words
-            const top = _topWords(counts, originals, excludeWords);
+            const top = _topWords(counts, originals, excludeWords, 2, positions);
             if (top.length) return top.join(' ');
 
             // 3. Shared directory (only if not falling back to avoid "notes" × N)

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -6205,7 +6205,8 @@
             let links = data.edges.map(e => ({
                 source: e.source,
                 target: e.target,
-                link_text: e.link_text
+                link_text: e.link_text,
+                edge_type: e.edge_type || 'reference'
             })).filter(e => {
                 if (!nodeMap.has(e.source) || !nodeMap.has(e.target)) return false;
                 const key = [e.source, e.target].sort().join('\0');
@@ -6443,14 +6444,18 @@
                 .attr('stdDeviation', '2.5')
                 .attr('flood-color', 'rgba(0,0,0,0.18)');
 
+            const _edgeStroke = { reference: '#cbd5e1', semantic: '#7aa2d4', name: '#84cc7a' };
+            const _edgeStrokeFor = d => d.isCustom ? '#cbd5e1' : (_edgeStroke[d.edge_type] || '#cbd5e1');
+
             const link = g.append('g')
                 .attr('class', 'links')
                 .selectAll('line')
                 .data(links)
                 .join('line')
                 .attr('class', d => 'graph-link' + (deleteMode ? ' graph-link-deletable' : ''))
-                .attr('stroke', '#cbd5e1')
+                .attr('stroke', d => _edgeStrokeFor(d))
                 .attr('stroke-width', 1.5)
+                .attr('stroke-dasharray', d => d.edge_type === 'name' ? '4 3' : null)
                 .attr('opacity', d => d.isSecondary ? 0.35 : 1)
                 .on('mouseover', function(event, d) {
                     if (deleteMode) {
@@ -6458,13 +6463,14 @@
                     } else {
                         d3.select(this).attr('stroke', '#3EB489').attr('stroke-width', 2.5);
                     }
-                    tooltip.innerHTML = `${d.source.name || d.source} → ${d.target.name || d.target}${d.isCustom ? ' (custom)' : ''}`;
+                    const typeLabel = d.isCustom ? 'custom' : (d.edge_type || 'reference');
+                    tooltip.innerHTML = `${d.source.name || d.source} → ${d.target.name || d.target} <span style="opacity:0.6">(${typeLabel})</span>`;
                     tooltip.style.left = event.clientX + 12 + 'px';
                     tooltip.style.top = event.clientY + 12 + 'px';
                     tooltip.classList.add('visible');
                 })
-                .on('mouseout', function() {
-                    d3.select(this).attr('stroke', '#cbd5e1').attr('stroke-width', 1.5);
+                .on('mouseout', function(event, d) {
+                    d3.select(this).attr('stroke', _edgeStrokeFor(d)).attr('stroke-width', 1.5);
                     tooltip.classList.remove('visible');
                 })
                 .on('click', function(event, d) {
@@ -6503,7 +6509,7 @@
                         d3.select(this).select('circle').attr('stroke', null).attr('stroke-width', null);
                     }
                     // Reset link colors (preserve opacity for secondary links)
-                    link.attr('stroke', '#cbd5e1').attr('stroke-width', 1.5)
+                    link.attr('stroke', d => _edgeStrokeFor(d)).attr('stroke-width', 1.5)
                         .attr('opacity', l => l.isSecondary ? 0.35 : 1);
                     tooltip.classList.remove('visible');
                 })

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -3831,6 +3831,12 @@
                                 Delete Link
                             </button>
                             <div class="graph-edit-status" id="graph-edit-status"></div>
+                            <button class="graph-edit-btn" id="restore-links-btn" onclick="clearDeletedLinks()" title="Restore all deleted links" style="display:none;">
+                                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+                                </svg>
+                                Restore Links
+                            </button>
                         </div>
                     </div>
                 </div>
@@ -6146,6 +6152,7 @@
                 const data = await response.json();
                 renderGraph(data);
                 lastGraphHash = hashGraphData(data);
+                updateEditStatus(); // show Restore Links button if deletions exist
             } catch (error) {
                 console.error('Failed to load graph:', error);
                 document.getElementById('graph-stats').textContent = 'Failed to load graph';
@@ -6211,6 +6218,7 @@
                 if (!nodeMap.has(e.source) || !nodeMap.has(e.target)) return false;
                 const key = [e.source, e.target].sort().join('\0');
                 if (seenEdgePairs.has(key)) return false;
+                if (deletedLinks.has(key)) return false;
                 seenEdgePairs.add(key);
                 return true;
             });
@@ -7571,6 +7579,8 @@
         let deleteMode = false;
         let selectedSourceNode = null;
         let customLinks = JSON.parse(localStorage.getItem('santai-custom-links') || '[]');
+        // Set of "source\0target" keys (sorted) for links the user has explicitly deleted
+        let deletedLinks = new Set(JSON.parse(localStorage.getItem('santai-deleted-links') || '[]'));
 
         // Graph filter state
         let activeDirectoryFilters = new Set(); // Empty means show all
@@ -8187,6 +8197,8 @@
             } else {
                 status.textContent = '';
             }
+            const restoreBtn = document.getElementById('restore-links-btn');
+            if (restoreBtn) restoreBtn.style.display = deletedLinks.size > 0 ? '' : 'none';
         }
 
         function updateGraphInteraction() {
@@ -8243,31 +8255,35 @@
             if (!deleteMode) return;
 
             event.stopPropagation();
-
-            // Hide tooltip since the link will be removed
             document.getElementById('graph-tooltip').classList.remove('visible');
 
-            // Find and remove the link
             const sourceId = d.source.id || d.source;
             const targetId = d.target.id || d.target;
+            const key = [sourceId, targetId].sort().join('\0');
 
-            // Check if it's a custom link
+            // Remove from custom links if present
             const customIndex = customLinks.findIndex(l =>
                 (l.source === sourceId && l.target === targetId) ||
                 (l.source === targetId && l.target === sourceId)
             );
-
             if (customIndex !== -1) {
                 customLinks.splice(customIndex, 1);
                 localStorage.setItem('santai-custom-links', JSON.stringify(customLinks));
-
-                if (window.lastGraphData) {
-                    renderGraph(window.lastGraphData);
-                }
-                showToast('Link deleted');
-            } else {
-                showToast('Cannot delete file-based links', true);
             }
+
+            // Always add to deleted set so the link stays hidden even if re-computed
+            deletedLinks.add(key);
+            localStorage.setItem('santai-deleted-links', JSON.stringify([...deletedLinks]));
+
+            if (window.lastGraphData) renderGraph(window.lastGraphData);
+            showToast('Link deleted');
+        }
+
+        function clearDeletedLinks() {
+            deletedLinks.clear();
+            localStorage.removeItem('santai-deleted-links');
+            if (window.lastGraphData) renderGraph(window.lastGraphData);
+            showToast('Deleted links restored');
         }
 
         function zoomGraph(factor) {

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -7690,7 +7690,7 @@
                 const seenStems = new Set(); // dedupe within one filename
                 base.split(/[\s\-_\.]+/)
                     .map(w => w.toLowerCase())
-                    .filter(w => w.length > 2 && !_clusterStopWords.has(w) && !/^\d+$/.test(w))
+                    .filter(w => w.length > 2 && !_clusterStopWords.has(w) && /^[a-z]+$/.test(w))
                     .forEach(w => {
                         const s = _stemWord(w);
                         if (seenStems.has(s)) return;

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -3795,26 +3795,6 @@
                         </div>
                         <div class="graph-legend">
                             <div id="graph-dir-legend">
-                                <div class="graph-legend-item" data-directory="resources" onclick="toggleDirectoryFilter('resources')">
-                                    <span class="graph-legend-color" style="background: #60a5fa;"></span>
-                                    <span>resources</span>
-                                </div>
-                                <div class="graph-legend-item" data-directory="codebases" onclick="toggleDirectoryFilter('codebases')">
-                                    <span class="graph-legend-color" style="background: #a855f7;"></span>
-                                    <span>codebases</span>
-                                </div>
-                                <div class="graph-legend-item" data-directory="history" onclick="toggleDirectoryFilter('history')">
-                                    <span class="graph-legend-color" style="background: #f87171;"></span>
-                                    <span>history</span>
-                                </div>
-                                <div class="graph-legend-item" data-directory="notes" onclick="toggleDirectoryFilter('notes')">
-                                    <span class="graph-legend-color" style="background: #fbbf24;"></span>
-                                    <span>notes</span>
-                                </div>
-                                <div class="graph-legend-item" data-directory="wiki" onclick="toggleDirectoryFilter('wiki')">
-                                    <span class="graph-legend-color" style="background: #34d399;"></span>
-                                    <span>wiki</span>
-                                </div>
                                 <button class="graph-cluster-clear-btn" id="dir-clear-btn" style="display:none;" onclick="clearDirectoryFilter()">Clear</button>
                             </div>
                             <div id="graph-cluster-legend" style="display:none;"></div>
@@ -6071,13 +6051,69 @@
 
         // Directory color mapping for graph - modern pastel palette
         const dirColors = {
-            resources: '#60a5fa',  // Blue
-            codebases: '#a855f7',  // Deep purple
-            history: '#f87171',    // Red
-            notes: '#fbbf24',      // Yellow (sticky note)
-            wiki: '#34d399',       // Emerald green
-            other: '#94a3b8'       // Slate gray
+            resources: '#60a5fa',   // Blue
+            codebases: '#a855f7',   // Deep purple
+            history: '#f87171',     // Red
+            notes: '#fbbf24',       // Yellow (sticky note)
+            wiki: '#34d399',        // Emerald green
+            unassigned: '#9b9ba8',  // Muted blue-gray (root-level files)
+            other: '#94a3b8'        // Slate gray fallback
         };
+
+        // Extra palette for dynamically discovered directories (deterministic by name hash)
+        const _extraDirPalette = [
+            '#e07b54', '#54b8e0', '#b054e0', '#54e0a8',
+            '#e0c454', '#c454e0', '#54e07b', '#e05480'
+        ];
+
+        function getDirColor(dirName) {
+            if (dirColors[dirName]) return dirColors[dirName];
+            // Deterministic hash so the same dir always gets the same color
+            let h = 0;
+            for (let i = 0; i < dirName.length; i++) {
+                h = Math.imul(31, h) + dirName.charCodeAt(i) | 0;
+            }
+            return _extraDirPalette[Math.abs(h) % _extraDirPalette.length];
+        }
+
+        // Rebuild the directory legend from actual graph data so dynamic/root-level
+        // folders appear automatically without any hardcoded HTML.
+        const _knownDirOrder = ['resources', 'codebases', 'history', 'notes', 'wiki'];
+
+        function updateDirLegend(data) {
+            const container = document.getElementById('graph-dir-legend');
+            if (!container) return;
+
+            const presentDirs = [...new Set(data.nodes.map(n => n.directory))];
+            const dynamic = presentDirs
+                .filter(d => !_knownDirOrder.includes(d) && d !== 'unassigned' && d !== 'other')
+                .sort();
+            const ordered = [
+                ..._knownDirOrder.filter(d => presentDirs.includes(d)),
+                ...dynamic,
+                ...(presentDirs.includes('unassigned') ? ['unassigned'] : [])
+            ];
+
+            // Preserve the Clear button (last child) while replacing legend items
+            const clearBtn = container.querySelector('#dir-clear-btn');
+            container.innerHTML = '';
+
+            ordered.forEach(dir => {
+                const color = getDirColor(dir);
+                const label = dir.length > 14 ? dir.slice(0, 13) + '…' : dir;
+                const item = document.createElement('div');
+                item.className = 'graph-legend-item' +
+                    (activeDirectoryFilters.has(dir) ? ' active' : '') +
+                    (activeDirectoryFilters.size > 0 && !activeDirectoryFilters.has(dir) ? ' dimmed' : '');
+                item.dataset.directory = dir;
+                item.title = dir;
+                item.onclick = () => toggleDirectoryFilter(dir);
+                item.innerHTML = `<span class="graph-legend-color" style="background:${color};"></span><span>${label}</span>`;
+                container.appendChild(item);
+            });
+
+            if (clearBtn) container.appendChild(clearBtn);
+        }
 
         // Track graph data to detect changes
         let lastGraphHash = null;
@@ -6225,6 +6261,9 @@
                 }
                 updateClusterLegend();
             }
+
+            // Rebuild dir legend so dynamic/root-level folders always appear
+            updateDirLegend(data);
 
             // Apply directory filter - identify primary nodes
             let primaryNodeIds = new Set();
@@ -6471,7 +6510,7 @@
                 .attr('r', 9)
                 .attr('fill', d => colorByCluster
                     ? (clusterColors[clusterMap.get(d.id)] || '#94a3b8')
-                    : (dirColors[d.directory] || dirColors.other))
+                    : getDirColor(d.directory))
                 .attr('opacity', d => d.isSecondary ? 0.35 : 1)
                 .attr('filter', 'url(#node-glow)');
 

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -3831,12 +3831,7 @@
                                 Delete Link
                             </button>
                             <div class="graph-edit-status" id="graph-edit-status"></div>
-                            <button class="graph-edit-btn" id="restore-links-btn" onclick="clearDeletedLinks()" title="Restore all deleted links" style="display:none;">
-                                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
-                                </svg>
-                                Restore Links
-                            </button>
+
                         </div>
                     </div>
                 </div>
@@ -6452,18 +6447,14 @@
                 .attr('stdDeviation', '2.5')
                 .attr('flood-color', 'rgba(0,0,0,0.18)');
 
-            const _edgeStroke = { reference: '#cbd5e1', semantic: '#7aa2d4', name: '#84cc7a' };
-            const _edgeStrokeFor = d => d.isCustom ? '#cbd5e1' : (_edgeStroke[d.edge_type] || '#cbd5e1');
-
             const link = g.append('g')
                 .attr('class', 'links')
                 .selectAll('line')
                 .data(links)
                 .join('line')
                 .attr('class', d => 'graph-link' + (deleteMode ? ' graph-link-deletable' : ''))
-                .attr('stroke', d => _edgeStrokeFor(d))
+                .attr('stroke', '#cbd5e1')
                 .attr('stroke-width', 1.5)
-                .attr('stroke-dasharray', d => d.edge_type === 'name' ? '4 3' : null)
                 .attr('opacity', d => d.isSecondary ? 0.35 : 1)
                 .on('mouseover', function(event, d) {
                     if (deleteMode) {
@@ -6471,14 +6462,13 @@
                     } else {
                         d3.select(this).attr('stroke', '#3EB489').attr('stroke-width', 2.5);
                     }
-                    const typeLabel = d.isCustom ? 'custom' : (d.edge_type || 'reference');
-                    tooltip.innerHTML = `${d.source.name || d.source} → ${d.target.name || d.target} <span style="opacity:0.6">(${typeLabel})</span>`;
+                    tooltip.innerHTML = `${d.source.name || d.source} → ${d.target.name || d.target}${d.isCustom ? ' (custom)' : ''}`;
                     tooltip.style.left = event.clientX + 12 + 'px';
                     tooltip.style.top = event.clientY + 12 + 'px';
                     tooltip.classList.add('visible');
                 })
-                .on('mouseout', function(event, d) {
-                    d3.select(this).attr('stroke', _edgeStrokeFor(d)).attr('stroke-width', 1.5);
+                .on('mouseout', function() {
+                    d3.select(this).attr('stroke', '#cbd5e1').attr('stroke-width', 1.5);
                     tooltip.classList.remove('visible');
                 })
                 .on('click', function(event, d) {
@@ -6517,7 +6507,7 @@
                         d3.select(this).select('circle').attr('stroke', null).attr('stroke-width', null);
                     }
                     // Reset link colors (preserve opacity for secondary links)
-                    link.attr('stroke', d => _edgeStrokeFor(d)).attr('stroke-width', 1.5)
+                    link.attr('stroke', '#cbd5e1').attr('stroke-width', 1.5)
                         .attr('opacity', l => l.isSecondary ? 0.35 : 1);
                     tooltip.classList.remove('visible');
                 })
@@ -8197,8 +8187,6 @@
             } else {
                 status.textContent = '';
             }
-            const restoreBtn = document.getElementById('restore-links-btn');
-            if (restoreBtn) restoreBtn.style.display = deletedLinks.size > 0 ? '' : 'none';
         }
 
         function updateGraphInteraction() {
@@ -8277,13 +8265,6 @@
 
             if (window.lastGraphData) renderGraph(window.lastGraphData);
             showToast('Link deleted');
-        }
-
-        function clearDeletedLinks() {
-            deletedLinks.clear();
-            localStorage.removeItem('santai-deleted-links');
-            if (window.lastGraphData) renderGraph(window.lastGraphData);
-            showToast('Deleted links restored');
         }
 
         function zoomGraph(factor) {

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -7665,32 +7665,52 @@
             sh:'Shell', bash:'Shell', sql:'SQL', r:'R'
         };
 
+        // Normalize common plural/suffix variants so "cloud" and "clouds" count as one word
+        function _stemWord(w) {
+            if (w.length > 5 && w.endsWith('ies')) return w.slice(0, -3) + 'y';      // libraries→library
+            if (w.length > 4 && /ches$|shes$|xes$|zes$/.test(w)) return w.slice(0, -2); // brushes→brush
+            if (w.length > 4 && w.endsWith('s') && !w.endsWith('ss')) return w.slice(0, -1); // clouds→cloud
+            return w;
+        }
+
         function _clusterFileWords(clusterId) {
             const nodeIds = clusterNodes.get(clusterId) || [];
             const nodeMap = window.lastFullNodeMap || new Map();
             const nodes = nodeIds.map(id => nodeMap.get(id)).filter(Boolean);
-            const counts = {};
+            const counts = {};    // stem → # files that contain it
+            const originals = {}; // stem → best display word (shortest / most natural form)
             nodes.forEach(n => {
-                const stem = n.name.replace(/\.[^.]+$/, '');
-                stem.split(/[\s\-_\.]+/)
+                const base = n.name.replace(/\.[^.]+$/, '');
+                const seenStems = new Set(); // dedupe within one filename
+                base.split(/[\s\-_\.]+/)
                     .map(w => w.toLowerCase())
                     .filter(w => w.length > 2 && !_clusterStopWords.has(w) && !/^\d+$/.test(w))
-                    .forEach(w => { counts[w] = (counts[w] || 0) + 1; });
+                    .forEach(w => {
+                        const s = _stemWord(w);
+                        if (seenStems.has(s)) return;
+                        seenStems.add(s);
+                        counts[s] = (counts[s] || 0) + 1;
+                        // Keep the shorter (more base) form as the display word
+                        if (!originals[s] || w.length < originals[s].length) originals[s] = w;
+                    });
             });
-            return { nodes, counts };
+            return { nodes, counts, originals };
         }
 
-        function _topWords(counts, exclude = new Set(), limit = 2) {
+        function _topWords(counts, originals, exclude = new Set(), limit = 2) {
             return Object.entries(counts)
-                .filter(([w]) => !exclude.has(w))
-                .sort((a, b) => b[1] - a[1])
+                .filter(([s]) => !exclude.has(s))
+                // Sort by count desc, then alpha for a stable tiebreak (avoids "first file wins")
+                .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
                 .slice(0, limit)
-                .map(([w]) => w.charAt(0).toUpperCase() + w.slice(1));
+                .map(([s]) => { const w = originals[s] || s; return w.charAt(0).toUpperCase() + w.slice(1); });
         }
 
         function suggestClusterName(clusterId, excludeWords = new Set()) {
-            const { nodes, counts } = _clusterFileWords(clusterId);
+            const { nodes, counts, originals } = _clusterFileWords(clusterId);
             if (!nodes.length) return `Cluster ${clusterId + 1}`;
+
+            const display = s => { const w = originals[s] || s; return w.charAt(0).toUpperCase() + w.slice(1); };
 
             // 0. Code-file detection — label by language when most files share an extension
             const extCounts = {};
@@ -7704,16 +7724,16 @@
                 return `${topLang[0]} Files`;
             }
 
-            // 1. Words appearing in at least half the files (lower bar for small clusters)
+            // 1. Words appearing in at least 40% of files (threshold 1 for tiny clusters)
             const threshold = nodes.length <= 2 ? 1 : Math.ceil(nodes.length * 0.4);
             const common = Object.entries(counts)
-                .filter(([w, c]) => c >= threshold && !excludeWords.has(w))
-                .sort((a, b) => b[1] - a[1])
-                .map(([w]) => w.charAt(0).toUpperCase() + w.slice(1));
+                .filter(([s, c]) => c >= threshold && !excludeWords.has(s))
+                .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+                .map(([s]) => display(s));
             if (common.length) return common.slice(0, 2).join(' ');
 
             // 2. Any top words at all, excluding requested words
-            const top = _topWords(counts, excludeWords);
+            const top = _topWords(counts, originals, excludeWords);
             if (top.length) return top.join(' ');
 
             // 3. Shared directory (only if not falling back to avoid "notes" × N)
@@ -7744,9 +7764,11 @@
             clusterNodes.forEach((nodeIds, cid) => { if (nodeIds.length > 1) ids.push(cid); });
             ids.sort((a, b) => a - b);
 
-            // First pass: assign initial names
+            // First pass: assign initial names (pre-compute fileWords to reuse in collision pass)
             const nameToIds = new Map();
+            const fileWordsCache = new Map();
             for (const cid of ids) {
+                fileWordsCache.set(cid, _clusterFileWords(cid));
                 const saved = clusterNames[getClusterKey(cid)];
                 if (saved) { clusterDisplayNames.set(cid, saved); continue; }
                 const name = suggestClusterName(cid);
@@ -7759,26 +7781,22 @@
             for (const [name, colliding] of nameToIds) {
                 if (colliding.length <= 1) continue;
 
-                // Gather all words from all colliding clusters
-                const allWordMaps = colliding.map(cid => _clusterFileWords(cid).counts);
-                const allWords = new Set(allWordMaps.flatMap(m => Object.keys(m)));
+                const wordData = colliding.map(cid => fileWordsCache.get(cid));
 
-                // Find words that distinguish each cluster (present in this cluster but not others)
+                // Find stems that distinguish each cluster (present in this one but not others)
                 colliding.forEach((cid, i) => {
-                    const mine = allWordMaps[i];
-                    const otherWords = new Set(
-                        allWordMaps.filter((_, j) => j !== i).flatMap(m => Object.keys(m))
+                    const { counts: mine, originals: myOrig } = wordData[i];
+                    const otherStems = new Set(
+                        wordData.filter((_, j) => j !== i).flatMap(d => Object.keys(d.counts))
                     );
                     const unique = Object.entries(mine)
-                        .filter(([w]) => !otherWords.has(w))
-                        .sort((a, b) => b[1] - a[1])
-                        .map(([w]) => w.charAt(0).toUpperCase() + w.slice(1));
+                        .filter(([s]) => !otherStems.has(s))
+                        .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+                        .map(([s]) => { const w = myOrig[s] || s; return w.charAt(0).toUpperCase() + w.slice(1); });
 
                     if (unique.length) {
-                        // Append the unique word to distinguish
                         clusterDisplayNames.set(cid, `${name} · ${unique[0]}`);
                     } else {
-                        // No unique words — fall back to numbered suffix
                         clusterDisplayNames.set(cid, `${name} ${i + 1}`);
                     }
                 });

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -2190,7 +2190,13 @@
         }
 
         .graph-filter-btn-clusters:hover {
-            background: rgba(0, 0, 0, 0.08);
+            background: linear-gradient(135deg,
+                rgba(255, 150, 100, 0.45) 0%,
+                rgba(255, 100, 150, 0.4) 50%,
+                rgba(150, 100, 255, 0.4) 100%
+            );
+            color: var(--text-primary);
+            transform: scale(1.02);
         }
 
         .graph-filter-btn-clusters.active {
@@ -3799,7 +3805,7 @@
                             </div>
                             <div id="graph-cluster-legend" style="display:none;"></div>
                             <button class="graph-cluster-clear-btn" id="cluster-clear-btn" style="display:none;" onclick="clearClusterFilter()">Clear</button>
-                            <button class="graph-filter-btn graph-filter-btn-clusters" id="cluster-mode-btn" onclick="toggleClusterMode()" style="display:none;">Clusters</button>
+                            <button class="graph-filter-btn graph-filter-btn-clusters" id="cluster-mode-btn" onclick="toggleClusterMode()" title="Color nodes by connected cluster" style="display:none;">Clusters</button>
                         </div>
                         <div class="graph-filter-controls">
                             <button class="graph-filter-btn active" data-filter="all" onclick="setConnectionFilter('all')">All</button>
@@ -7643,8 +7649,21 @@
             'the','a','an','and','or','of','in','on','at','to','for','with','by',
             'from','into','index','main','readme','untitled','file','new','doc',
             'docs','draft','copy','page','part','section','about','how','what',
-            'overview','summary','introduction','general','misc','other','stuff'
+            'overview','summary','introduction','general','misc','other','stuff',
+            // Generic essay/title structure words that don't identify the topic
+            'importance','important','impact','role','understanding','exploring',
+            'analysis','analyzing','benefits','challenges','guide','history',
+            'using','based','notes','note','topic','topics','review','report'
         ]);
+
+        // Map file extensions to human-readable language names
+        const _codeExtNames = {
+            cpp:'C++', cc:'C++', cxx:'C++', c:'C', h:'C/C++',
+            py:'Python', js:'JavaScript', ts:'TypeScript', jsx:'React', tsx:'React',
+            java:'Java', rb:'Ruby', go:'Go', rs:'Rust', cs:'C#',
+            php:'PHP', swift:'Swift', kt:'Kotlin', scala:'Scala',
+            sh:'Shell', bash:'Shell', sql:'SQL', r:'R'
+        };
 
         function _clusterFileWords(clusterId) {
             const nodeIds = clusterNodes.get(clusterId) || [];
@@ -7672,6 +7691,18 @@
         function suggestClusterName(clusterId, excludeWords = new Set()) {
             const { nodes, counts } = _clusterFileWords(clusterId);
             if (!nodes.length) return `Cluster ${clusterId + 1}`;
+
+            // 0. Code-file detection — label by language when most files share an extension
+            const extCounts = {};
+            nodes.forEach(n => {
+                const m = n.name.match(/\.([^.]+)$/);
+                const lang = m && _codeExtNames[m[1].toLowerCase()];
+                if (lang) extCounts[lang] = (extCounts[lang] || 0) + 1;
+            });
+            const topLang = Object.entries(extCounts).sort((a, b) => b[1] - a[1])[0];
+            if (topLang && topLang[1] >= Math.ceil(nodes.length * 0.6)) {
+                return `${topLang[0]} Files`;
+            }
 
             // 1. Words appearing in at least half the files (lower bar for small clusters)
             const threshold = nodes.length <= 2 ? 1 : Math.ceil(nodes.length * 0.4);


### PR DESCRIPTION
   ### Automatic edges
   - **Semantic edges (TF-IDF)**: files with similar content are automatically connected using cosine similarity on TF-IDF vectors. Uses smoothed IDF so small corpora (2–3 files) don't produce zero similarity.
   - **Name-based edges**: files sharing a meaningful filename token (e.g. `260_assign1.cpp`, `260_assign2.cpp`, `260_assign3.cpp` all share `assign`) are connected automatically, regardless of content.

   ### Dynamic legend
   - The web UI graph legend now rebuilds from live data on every render — newly added root-level folders appear automatically without hardcoding.
   - Root-level files (not inside a standard Santai dir) show as **Unassigned** in both the legend and graph.

   ### Smarter cluster labels
   - Label word order fixed: shorter word (modifier) appears before longer word (noun), giving "Public Libraries" instead of "Libraries Public"; generic title words (`importance`, `impact`, `role`, `analysis`, etc.) added to stop list so they don't dominate labels; files extensions inform titles; filename tokens now require purely alphabetic characters; plural stemming (`clouds` → `cloud`, `brushes` → `brush`) so related filenames count toward the same token.

   ### Link management
   - **Delete any link**: Delete Link mode now works on all edge types (reference, semantic, name), not just manually-added custom links. 

   ### Meta-file exclusion
   `AGENTS.md`, `CLAUDE.md`, `README.md`, `README.rst`, and `rumdl.toml` are excluded from the graph entirely.

   ### TUI fixes
   - Filter modal correctly includes dynamic (root-level) directories; keys `6`–`9` toggle the first four extra dirs.
   - Legend moved to top of panel so it is never clipped by container height.

   ## Test plan
   ### Semantic edges
   - [ ] Create two markdown files in `notes/` with clearly related content (e.g. both about the same topic). Reload the graph — a link should appear between them without any explicit references.
   - [ ] Create a third file on a completely unrelated topic — it should not be connected to the other two.

   ### Name-based edges
   - [ ] Add three files named `project_part1.md`, `project_part2.md`, `project_part3.md` — they should all be connected via the `project` token.
   - [ ] Confirm a file with a random-looking name (e.g. `8f4a2b9d.png`) does not create spurious name edges (purely alphanumeric tokens are rejected).

   ### Dynamic legend (web UI)
   - [ ] Create a new folder at the project root (not one of the 5 standard dirs) and add a file to it. Reload the web UI — the folder should appear in the graph legend with a distinct color.
   - [ ] Confirm `AGENTS.md`, `CLAUDE.md`, `README.md`, and `rumdl.toml` do not appear as nodes on the graph.
   - [ ] Files at the project root (not in any subdir) should appear as **unassigned** nodes.

   ### Cluster labels
   - [ ] Open the web UI, enable Clusters mode. Find a cluster of files whose names share a meaningful noun (e.g. "Public Libraries 1", "Public Libraries 2") — confirm the cluster label is accurate (e.g., "Libraries").

   ### Link deletion
   - [ ] Enter Delete Link mode and click a semantic or name edge (a link you didn't manually make) — it should disappear and stay gone after a graph refresh.
<img width="1918" height="1048" alt="Screenshot 2026-05-19 at 3 49 44 PM" src="https://github.com/user-attachments/assets/138474c0-0132-4d77-a03b-fbe9b194805d" />

   ### TUI filter modal
   - [ ] Open a project that has a root-level folder with files. Open the graph filter modal (`g` to get into the graph view, then `f`) — the extra folder should appear below the standard 5 dirs.
<img width="693" height="288" alt="Screenshot 2026-05-19 at 3 51 58 PM" src="https://github.com/user-attachments/assets/a2dc22f2-17e7-4635-bbee-7876f7aa010d" />

   - [ ] Press `6` to toggle that folder on/off — confirm the graph updates.
   - [ ] Confirm the legend at the top of the graph panel shows the extra folder's color dot.