### PR TITLE
fix: editable file tree, live markdown link maintenance, fullscreen graph improvements

### DIFF
--- a/src/santai_cli/core/project.py
+++ b/src/santai_cli/core/project.py
@@ -335,7 +335,7 @@ def get_notes(project: SantaiProject) -> list[NoteEntry]:
 # Patterns for detecting links in markdown files
 # Matches: [text](path) and [[wikilink]]
 MARKDOWN_LINK_PATTERN = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
-WIKILINK_PATTERN = re.compile(r"\[\[([^\]|]+)(?:\|[^\]]+)?\]\]")
+WIKILINK_PATTERN = re.compile(r"\[\[([^\]|]+)(?:\|([^\]]+))?\]\]")
 
 
 def _get_directory_name(file_path: Path, project_root: Path) -> str:

--- a/src/santai_cli/web/app.py
+++ b/src/santai_cli/web/app.py
@@ -16,6 +16,8 @@ from fastapi.templating import Jinja2Templates
 from pydantic import BaseModel
 
 from santai_cli.core.project import (
+    MARKDOWN_LINK_PATTERN,
+    WIKILINK_PATTERN,
     SantaiProject,
     get_directory_stats,
     get_file_graph,
@@ -127,6 +129,102 @@ def get_file_tree(
         tree.append(node)
 
     return tree
+
+
+def _update_markdown_links(root_dir: Path, old_abs: Path, new_abs: Path) -> None:
+    """Rewrite markdown links across the project after a file/folder move or rename.
+
+    Two cases are handled for every .md file found:
+    - Outside the moved item: any link that resolved to old_abs (or inside it) is
+      rewritten to point to the equivalent path under new_abs.
+    - Inside the moved item: outbound links whose targets didn't move are recomputed
+      from the file's new directory, and links whose targets also moved are left alone
+      (relative path within the subtree is unchanged).
+
+    Wikilinks ([[name]]) are not touched — they resolve by filename, not path.
+    """
+    for md_file in root_dir.rglob("*.md"):
+        if not md_file.is_file():
+            continue
+
+        # Work out where this file's links were authored from.
+        # If the file was inside the moved subtree its links were written relative
+        # to its OLD location; we need to resolve them from there.
+        if md_file == new_abs or (new_abs.is_dir() and md_file.is_relative_to(new_abs)):
+            suffix = md_file.relative_to(new_abs) if new_abs.is_dir() else Path(".")
+            link_base = (old_abs / suffix).parent
+            file_moved = True
+        else:
+            link_base = md_file.parent
+            file_moved = False
+
+        try:
+            content = md_file.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            continue
+
+        def _make_replacer(link_base: Path, md_file: Path, file_moved: bool):
+            def replacer(match: re.Match) -> str:
+                text = match.group(1)
+                target = match.group(2)
+
+                if target.startswith(("http://", "https://", "mailto:", "#")):
+                    return match.group(0)
+
+                fragment = ""
+                if "#" in target:
+                    target, frag = target.split("#", 1)
+                    fragment = "#" + frag
+                    if not target:
+                        return match.group(0)
+
+                resolved = (link_base / target).resolve()
+
+                if resolved == old_abs:
+                    new_target_abs = new_abs
+                elif resolved.is_relative_to(old_abs):
+                    new_target_abs = new_abs / resolved.relative_to(old_abs)
+                elif file_moved:
+                    # File moved but this link points outside the moved subtree —
+                    # recompute the relative path from the new file location.
+                    new_target_abs = resolved
+                else:
+                    return match.group(0)
+
+                new_rel = os.path.relpath(new_target_abs, md_file.parent).replace(
+                    "\\", "/"
+                )
+                return f"[{text}]({new_rel}{fragment})"
+
+            return replacer
+
+        new_content = MARKDOWN_LINK_PATTERN.sub(
+            _make_replacer(link_base, md_file, file_moved), content
+        )
+
+        # Also update wikilinks [[path]] — resolved from project root, not file dir.
+        def _wikilink_replacer(match: re.Match) -> str:
+            inner = match.group(1).strip()
+            display = match.group(2)
+            resolved = (root_dir / inner).resolve()
+            if resolved == old_abs:
+                new_target = str(new_abs.relative_to(root_dir)).replace("\\", "/")
+            elif resolved.is_relative_to(old_abs):
+                new_target_abs = new_abs / resolved.relative_to(old_abs)
+                new_target = str(new_target_abs.relative_to(root_dir)).replace(
+                    "\\", "/"
+                )
+            else:
+                return match.group(0)
+            return f"[[{new_target}|{display}]]" if display else f"[[{new_target}]]"
+
+        new_content = WIKILINK_PATTERN.sub(_wikilink_replacer, new_content)
+
+        if new_content != content:
+            try:
+                md_file.write_text(new_content, encoding="utf-8")
+            except OSError:
+                pass
 
 
 def create_app(project: SantaiProject) -> FastAPI:
@@ -406,7 +504,9 @@ def create_app(project: SantaiProject) -> FastAPI:
                 status_code=409, detail="A file with that name already exists"
             )
 
+        old_abs = target.resolve()
         target.rename(new_path)
+        _update_markdown_links(root_dir, old_abs, new_path.resolve())
         return {
             "message": "Renamed successfully",
             "path": str(new_path.relative_to(root_dir)),
@@ -483,6 +583,7 @@ def create_app(project: SantaiProject) -> FastAPI:
                 pass  # Not a subdirectory, OK to proceed
 
         shutil.move(str(source), str(new_path))
+        _update_markdown_links(root_dir, source, new_path)
         return {
             "message": "Moved successfully",
             "path": str(new_path.relative_to(root_dir)),

--- a/src/santai_cli/web/app.py
+++ b/src/santai_cli/web/app.py
@@ -457,24 +457,6 @@ def create_app(project: SantaiProject) -> FastAPI:
     @app.post("/api/files/move")
     async def move_file(req: MoveRequest) -> dict[str, str]:
         """Move a file or directory to a new location."""
-        # Protected top-level paths that cannot be moved
-        protected_paths = {
-            "codebases",
-            "history",
-            "notes",
-            "resources",
-            "wiki",
-            "AGENTS.md",
-            "CLAUDE.md",
-            "README.md",
-            "rumdl.toml",
-        }
-
-        if req.source_path in protected_paths:
-            raise HTTPException(
-                status_code=403, detail="Cannot move protected files or folders"
-            )
-
         source = safe_path(req.source_path)
         target_dir = safe_path(req.target_folder)
 

--- a/src/santai_cli/web/app.py
+++ b/src/santai_cli/web/app.py
@@ -1,5 +1,6 @@
 """FastAPI web application for Santai."""
 
+import logging
 import os
 import re
 import shutil
@@ -141,8 +142,61 @@ def _update_markdown_links(root_dir: Path, old_abs: Path, new_abs: Path) -> None
       from the file's new directory, and links whose targets also moved are left alone
       (relative path within the subtree is unchanged).
 
-    Wikilinks ([[name]]) are not touched — they resolve by filename, not path.
+    Only root-relative wikilinks are rewritten; filename-only wikilinks are left alone
+    since they resolve by lookup, not path.
     """
+
+    def _make_replacer(link_base: Path, md_file: Path, file_moved: bool):
+        def replacer(match: re.Match) -> str:
+            text = match.group(1)
+            target = match.group(2)
+
+            if target.startswith(("http://", "https://", "mailto:", "#")):
+                return match.group(0)
+
+            fragment = ""
+            if "#" in target:
+                target, frag = target.split("#", 1)
+                fragment = "#" + frag
+                if not target:
+                    return match.group(0)
+
+            resolved = (link_base / target).resolve()
+
+            if resolved == old_abs:
+                new_target_abs = new_abs
+            elif resolved.is_relative_to(old_abs):
+                new_target_abs = new_abs / resolved.relative_to(old_abs)
+            elif file_moved:
+                # File moved but this link points outside the moved subtree —
+                # recompute the relative path from the new file location.
+                new_target_abs = resolved
+            else:
+                return match.group(0)
+
+            try:
+                new_rel = os.path.relpath(new_target_abs, md_file.parent).replace(
+                    "\\", "/"
+                )
+            except ValueError:
+                return match.group(0)
+            return f"[{text}]({new_rel}{fragment})"
+
+        return replacer
+
+    def _wikilink_replacer(match: re.Match) -> str:
+        inner = match.group(1).strip()
+        display = match.group(2)
+        resolved = (root_dir / inner).resolve()
+        if resolved == old_abs:
+            new_target = str(new_abs.relative_to(root_dir)).replace("\\", "/")
+        elif resolved.is_relative_to(old_abs):
+            new_target_abs = new_abs / resolved.relative_to(old_abs)
+            new_target = str(new_target_abs.relative_to(root_dir)).replace("\\", "/")
+        else:
+            return match.group(0)
+        return f"[[{new_target}|{display}]]" if display else f"[[{new_target}]]"
+
     for md_file in root_dir.rglob("*.md"):
         if not md_file.is_file():
             continue
@@ -163,68 +217,19 @@ def _update_markdown_links(root_dir: Path, old_abs: Path, new_abs: Path) -> None
         except OSError:
             continue
 
-        def _make_replacer(link_base: Path, md_file: Path, file_moved: bool):
-            def replacer(match: re.Match) -> str:
-                text = match.group(1)
-                target = match.group(2)
-
-                if target.startswith(("http://", "https://", "mailto:", "#")):
-                    return match.group(0)
-
-                fragment = ""
-                if "#" in target:
-                    target, frag = target.split("#", 1)
-                    fragment = "#" + frag
-                    if not target:
-                        return match.group(0)
-
-                resolved = (link_base / target).resolve()
-
-                if resolved == old_abs:
-                    new_target_abs = new_abs
-                elif resolved.is_relative_to(old_abs):
-                    new_target_abs = new_abs / resolved.relative_to(old_abs)
-                elif file_moved:
-                    # File moved but this link points outside the moved subtree —
-                    # recompute the relative path from the new file location.
-                    new_target_abs = resolved
-                else:
-                    return match.group(0)
-
-                new_rel = os.path.relpath(new_target_abs, md_file.parent).replace(
-                    "\\", "/"
-                )
-                return f"[{text}]({new_rel}{fragment})"
-
-            return replacer
+        if old_abs.name not in content:
+            continue
 
         new_content = MARKDOWN_LINK_PATTERN.sub(
             _make_replacer(link_base, md_file, file_moved), content
         )
-
-        # Also update wikilinks [[path]] — resolved from project root, not file dir.
-        def _wikilink_replacer(match: re.Match) -> str:
-            inner = match.group(1).strip()
-            display = match.group(2)
-            resolved = (root_dir / inner).resolve()
-            if resolved == old_abs:
-                new_target = str(new_abs.relative_to(root_dir)).replace("\\", "/")
-            elif resolved.is_relative_to(old_abs):
-                new_target_abs = new_abs / resolved.relative_to(old_abs)
-                new_target = str(new_target_abs.relative_to(root_dir)).replace(
-                    "\\", "/"
-                )
-            else:
-                return match.group(0)
-            return f"[[{new_target}|{display}]]" if display else f"[[{new_target}]]"
-
         new_content = WIKILINK_PATTERN.sub(_wikilink_replacer, new_content)
 
         if new_content != content:
             try:
                 md_file.write_text(new_content, encoding="utf-8")
-            except OSError:
-                pass
+            except OSError as exc:
+                logging.warning("Failed to update links in %s: %s", md_file, exc)
 
 
 def create_app(project: SantaiProject) -> FastAPI:

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -4237,6 +4237,25 @@
             if (main) main.classList.remove('preview-open');
             document.body.classList.remove('preview-open');
             resizeGraphIfFullscreen();
+            // Re-center graph in non-fullscreen mode when preview closes.
+            // Reading clientWidth after the class removal forces a synchronous reflow so
+            // we get real dimensions before the first paint — no corner-flash.
+            if (!document.querySelector('.graph-panel.fullscreen') && window.currentSimulation && window.graphSvg && window.graphZoom) {
+                const container = document.querySelector('.graph-container');
+                const svg = d3.select('#graph-svg');
+                // clientWidth access forces layout; returns 0 if still hidden
+                if (container && svg && container.clientWidth > 0) {
+                    const svgW = +svg.attr('width') || 0;
+                    const svgH = +svg.attr('height') || 0;
+                    const dimensionsLost = svgW === 0 || svgH === 0;
+                    if (dimensionsLost) {
+                        svg.attr('width', container.clientWidth).attr('height', container.clientHeight);
+                        fitAllNodes(false);
+                    } else if (!window.graphUserHasMoved) {
+                        fitAllNodes(false);
+                    }
+                }
+            }
         }
 
         // File Preview Functions
@@ -6155,6 +6174,7 @@
         function renderGraph(data) {
             // Store data for re-rendering on resize/fullscreen
             window.lastGraphData = data;
+            window.graphUserHasMoved = false;
 
             const container = document.querySelector('.graph-container');
             const svg = d3.select('#graph-svg');
@@ -6330,6 +6350,7 @@
                 .scaleExtent([0.1, 4])
                 .on('zoom', (event) => {
                     g.attr('transform', event.transform);
+                    if (event.sourceEvent) window.graphUserHasMoved = true;
                 });
 
             svg.call(zoom);
@@ -6340,6 +6361,7 @@
 
             // Add double-click to reset zoom
             svg.on('dblclick.zoom', () => {
+                window.graphUserHasMoved = false;
                 fitAllNodes(true);
             });
 

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -4213,6 +4213,7 @@
         let lastClickedPath = null;    // anchor for shift-range selection
         let files = [];
         let previewPath = null;
+        let previewHistory = []; // paths navigated via markdown links, for back-button
         let previewReturnClusterId = null; // set when a file is opened from a cluster list
         function hasPreviewContent() {
             const header = document.getElementById('preview-file-header');
@@ -4234,7 +4235,12 @@
         }
 
         // File Preview Functions
-        async function openFilePreview(path) {
+        async function openFilePreview(path, historyMode = 'clear') {
+            if (historyMode === 'push') {
+                if (previewPath) previewHistory.push(previewPath);
+            } else if (historyMode === 'clear') {
+                previewHistory = [];
+            }
             if (document.body.classList.contains('graph-is-fullscreen')) {
                 toggleGraphFullscreen();
             }
@@ -4312,10 +4318,11 @@
                                     return;
                                 }
 
-                                // File exists - open in new tab
+                                // File exists - open preview and reveal in tree
                                 link.addEventListener('click', (e) => {
                                     e.preventDefault();
-                                    window.open(`/?preview=${encodeURIComponent(newPath)}`, '_blank');
+                                    openFilePreview(newPath, 'push');
+                                    revealInTree(newPath);
                                 });
                             } else if (href && (href.startsWith('http://') || href.startsWith('https://'))) {
                                 // External link - open in new window
@@ -4361,6 +4368,7 @@
 
         function resetPreviewState() {
             previewPath = null;
+            previewHistory = [];
             updateTreePreviewState();
             previewReturnClusterId = null;
             window.activeClusterId = null;
@@ -4979,6 +4987,18 @@
         function updateTreePreviewState() {
             document.querySelectorAll('#tree-view .tree-item').forEach(el => {
                 el.classList.toggle('tree-previewing', el.dataset.path === previewPath && !selectedItems.has(el.dataset.path));
+            });
+        }
+
+        function revealInTree(filePath) {
+            const parts = filePath.split('/');
+            for (let i = 1; i < parts.length; i++) {
+                expandedPaths.add(parts.slice(0, i).join('/'));
+            }
+            renderTree();
+            requestAnimationFrame(() => {
+                const el = document.querySelector('#tree-view .tree-item.tree-previewing');
+                if (el) el.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
             });
         }
 
@@ -8034,6 +8054,12 @@
         }
 
         function goBackFromPreview() {
+            if (previewHistory.length > 0) {
+                const previousPath = previewHistory.pop();
+                openFilePreview(previousPath, 'keep');
+                revealInTree(previousPath);
+                return;
+            }
             if (previewReturnClusterId !== null) {
                 const id = previewReturnClusterId;
                 previewReturnClusterId = null;

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -4799,17 +4799,14 @@
                 return;
             }
 
-            const protectedFilePaths = ['codebases', 'history', 'notes', 'resources', 'wiki', 'AGENTS.md', 'CLAUDE.md', 'README.md', 'rumdl.toml'];
             let html = '<div class="file-grid">';
             for (const item of items) {
-                const isProtected = protectedFilePaths.includes(item.path);
-                const canDrag = !isProtected;
                 html += `<div class="file-item"
                      data-path="${item.path}"
                      data-is-dir="${item.is_dir}"
                      data-name="${item.name}"
-                     ${canDrag ? 'draggable="true"' : ''}
-                     ${canDrag ? `ondragstart="handleDragStart(event, '${item.path}', '${item.name}', ${item.is_dir})"` : ''}
+                     draggable="true"
+                     ondragstart="handleDragStart(event, '${item.path}', '${item.name}', ${item.is_dir})"
                      ondragend="handleDragEnd(event)"
                      ${item.is_dir ? `ondragover="handleDragOver(event, '${item.path}', true)"` : ''}
                      ${item.is_dir ? 'ondragleave="handleDragLeave(event)"' : ''}
@@ -4824,8 +4821,7 @@
                         <div class="file-name">${item.name}</div>
                         <div class="file-meta">${item.is_dir ? 'Folder' : item.size_formatted}</div>
                     </div>`;
-                if (!isProtected) {
-                    html += `<div class="file-actions">
+                html += `<div class="file-actions">
                         <button class="file-action-btn edit-btn" onclick="event.stopPropagation(); editItem('${item.path}', '${item.name}')" title="Rename">
                             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                                 <path stroke-linecap="round" stroke-linejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931z" />
@@ -4837,7 +4833,6 @@
                             </svg>
                         </button>
                     </div>`;
-                }
                 html += `</div>`;
             }
             html += '</div>';
@@ -4956,15 +4951,8 @@
         }
 
         // Move item (drag and drop)
-        const protectedPaths = ['codebases', 'history', 'notes', 'resources', 'wiki', 'AGENTS.md', 'CLAUDE.md', 'README.md', 'rumdl.toml'];
         let draggedItems = null;    // array of { path, name, isDir } for current drag
         let currentDropGroup = null; // <li> currently highlighted as drop target
-
-        function isProtectedPath(path) {
-            // Only top-level names are protected — files inside (e.g. notes/my-note.md)
-            // are intentionally moveable; only the folder itself is locked.
-            return protectedPaths.includes(path);
-        }
 
         function getFlatVisibleTreeItems() {
             return Array.from(document.querySelectorAll('#tree-view .tree-item'));
@@ -5020,10 +5008,6 @@
         }
 
         function handleDragStart(event, path, name, isDir) {
-            if (isProtectedPath(path)) {
-                event.preventDefault();
-                return;
-            }
             // If this item is part of a multi-selection, drag all selected items
             if (selectedItems.size > 1 && selectedItems.has(path)) {
                 draggedItems = [];
@@ -5143,10 +5127,9 @@
             // Save items before async (draggedItems gets nulled by handleDragEnd)
             const items = draggedItems.slice();
 
-            // Filter to items that actually need to move: skip protected paths,
-            // items already in the target folder, and dirs being dropped into themselves
+            // Filter to items that actually need to move: skip items already in the
+            // target folder and dirs being dropped into themselves
             const moveable = items.filter(item =>
-                !isProtectedPath(item.path) &&
                 item.path.split('/').slice(0, -1).join('/') !== dropFolder &&
                 !(item.isDir && (dropFolder === item.path || dropFolder.startsWith(item.path + '/')))
             );
@@ -5729,12 +5712,8 @@
 
             let html = '<li>';
 
-            // Check if this is a protected path
-            const protectedPaths = ['codebases', 'history', 'notes', 'resources', 'wiki', 'AGENTS.md', 'CLAUDE.md', 'README.md', 'rumdl.toml'];
-            const isProtected = protectedPaths.includes(node.path);
-
             // Tree item
-            const canDrag = node.path && !isProtected;
+            const canDrag = !!node.path;
             const isSelected = selectedItems.has(node.path);
             const isPreviewing = !isSelected && node.path === previewPath;
             // Suppress folder-active green while a multi-selection is in progress
@@ -5765,9 +5744,9 @@
             }
             html += `<span class="tree-name">${displayName}</span>`;
 
-            // Action buttons (only for non-root and non-protected items) — rendered
+            // Action buttons (only for non-root items) — rendered
             // before the toggle so the chevron stays anchored at the far right.
-            if (node.path && !isProtected) {
+            if (node.path) {
                 html += `<span class="tree-actions">
                     <button class="tree-action-btn edit-btn" onclick="event.stopPropagation(); editItem('${node.path}', '${node.name}')" title="Rename">
                         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -4258,6 +4258,17 @@
             }
         }
 
+        // Collapse `..` segments in a slash-separated path string.
+        // e.g. "wiki/../notes/foo.md" → "notes/foo.md"
+        function normalizePath(p) {
+            const out = [];
+            for (const seg of p.split('/')) {
+                if (seg === '..') out.pop();
+                else if (seg !== '.') out.push(seg);
+            }
+            return out.join('/');
+        }
+
         // File Preview Functions
         async function openFilePreview(path, historyMode = 'clear') {
             if (historyMode === 'push') {
@@ -4318,7 +4329,7 @@
                                 // Resolve the path: try relative to current file's directory
                                 // first, then fall back to root-relative (for wikilinks).
                                 const currentDir = path.split('/').slice(0, -1).join('/');
-                                const relPath = currentDir ? `${currentDir}/${href}` : href;
+                                const relPath = normalizePath(currentDir ? `${currentDir}/${href}` : href);
                                 let resolvedPath = null;
 
                                 try {
@@ -4956,9 +4967,15 @@
             document.getElementById('rename-input').select();
         }
 
+        // Top-level folders that santai web depends on at startup
+        const SANTAI_DIRS = ['notes', 'wiki', 'resources', 'codebases', 'history'];
+
         // Delete item directly (from button)
         async function deleteItem(path, name, isDir) {
-            const msg = isDir
+            const isSantaiDir = isDir && SANTAI_DIRS.includes(path);
+            const msg = isSantaiDir
+                ? `Delete folder "${name}" and all its contents?\n\nWarning: "${name}" is a standard santai folder — deleting it may prevent santai web from launching.`
+                : isDir
                 ? `Delete folder "${name}" and all its contents?`
                 : `Delete "${name}"?`;
             if (!confirm(msg)) return;
@@ -5218,6 +5235,10 @@
             const newName = document.getElementById('rename-input').value.trim();
             if (!newName || !selectedItem) return;
 
+            if (SANTAI_DIRS.includes(selectedItem.path)) {
+                if (!confirm(`"${selectedItem.name}" is a standard santai folder — renaming it may prevent santai web from launching. Continue?`)) return;
+            }
+
             try {
                 const res = await fetch('/api/files/rename', {
                     method: 'POST',
@@ -5242,7 +5263,10 @@
         // Delete
         async function deleteSelected() {
             if (!selectedItem) return;
-            const deleteMsg = selectedItem.is_dir
+            const isSantaiDir = selectedItem.is_dir && SANTAI_DIRS.includes(selectedItem.path);
+            const deleteMsg = isSantaiDir
+                ? `Delete folder "${selectedItem.name}" and all its contents?\n\nWarning: "${selectedItem.name}" is a standard santai folder — deleting it may prevent santai web from launching.`
+                : selectedItem.is_dir
                 ? `Delete folder "${selectedItem.name}" and all its contents?`
                 : `Delete "${selectedItem.name}"?`;
             if (!confirm(deleteMsg)) return;
@@ -5759,7 +5783,7 @@
                          ondragover="handleDragOver(event, '${node.path}', ${node.is_dir})"
                          ondragleave="handleDragLeave(event)"
                          ondrop="handleDrop(event, '${node.path}', ${node.is_dir})"
-                         ${node.is_dir ? `onmouseenter="if(selectedItems.size>0)showFolderMoveTooltip(event,'${node.name.replace(/'/g, "\\'")}')" onmouseleave="hideFolderMoveTooltip()"` : ''}
+                         ${node.is_dir ? `onmouseenter="if(selectedItems.size>0&&draggedItems)showFolderMoveTooltip(event,'${node.name.replace(/&/g,'&amp;').replace(/"/g,'&quot;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/'/g,"\\'")}')" onmouseleave="hideFolderMoveTooltip()"` : ''}
                          onclick="handleTreeClick(event, '${node.path}', ${node.is_dir}, ${hasChildren})"
                          ondblclick="handleTreeDblClick(event, '${node.path}', ${node.is_dir})">`;
 
@@ -8439,7 +8463,8 @@
         const _legendObserver = new MutationObserver(() => updateFloatingLegend());
         _legendObserver.observe(document.body, { attributes: true, attributeFilter: ['class'] });
 
-        // Also hook into graph fullscreen toggle
+        // Wrap toggleGraphFullscreen so the floating legend stays in sync after every
+        // fullscreen toggle without modifying the original function definition.
         const _origToggleGraphFullscreen = toggleGraphFullscreen;
         toggleGraphFullscreen = function(animated = true) {
             _origToggleGraphFullscreen(animated);

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -4203,6 +4203,11 @@
          * passed through DOMPurify to prevent XSS from untrusted content.
          */
         function safeMarkdown(md) {
+            // Convert [[path]] and [[path|display]] to standard markdown links
+            // before marked sees the content, so they render as clickable <a> tags.
+            md = md.replace(/\[\[([^\]|]+)(?:\|([^\]]+))?\]\]/g, (_, path, text) =>
+                `[${text || path}](${path})`
+            );
             const raw = (typeof marked !== 'undefined') ? marked.parse(md) : md;
             return (typeof DOMPurify !== 'undefined') ? DOMPurify.sanitize(raw) : raw.replace(/<[^>]*>/g, '');
         }
@@ -4294,26 +4299,27 @@
                             const href = link.getAttribute('href');
                             // Check if it's a relative link (local file)
                             if (href && !href.startsWith('http://') && !href.startsWith('https://') && !href.startsWith('mailto:') && !href.startsWith('#')) {
-                                // Resolve the path relative to current file's directory
+                                // Resolve the path: try relative to current file's directory
+                                // first, then fall back to root-relative (for wikilinks).
                                 const currentDir = path.split('/').slice(0, -1).join('/');
-                                const newPath = currentDir ? `${currentDir}/${href}` : href;
+                                const relPath = currentDir ? `${currentDir}/${href}` : href;
+                                let resolvedPath = null;
 
-                                // Check if file exists
                                 try {
-                                    const checkRes = await fetch(`/api/files/content?path=${encodeURIComponent(newPath)}`);
-                                    if (!checkRes.ok) {
-                                        // File doesn't exist - disable link
-                                        link.style.color = 'var(--text-muted)';
-                                        link.style.textDecoration = 'line-through';
-                                        link.style.cursor = 'not-allowed';
-                                        link.title = 'File not found';
-                                        link.addEventListener('click', (e) => e.preventDefault());
-                                        return;
+                                    let checkRes = await fetch(`/api/files/content?path=${encodeURIComponent(relPath)}`);
+                                    if (checkRes.ok) {
+                                        resolvedPath = relPath;
+                                    } else if (currentDir) {
+                                        checkRes = await fetch(`/api/files/content?path=${encodeURIComponent(href)}`);
+                                        if (checkRes.ok) resolvedPath = href;
                                     }
-                                } catch {
-                                    // Error checking - disable link
+                                } catch { /* fall through to broken-link handling */ }
+
+                                if (!resolvedPath) {
                                     link.style.color = 'var(--text-muted)';
+                                    link.style.textDecoration = 'line-through';
                                     link.style.cursor = 'not-allowed';
+                                    link.title = 'File not found';
                                     link.addEventListener('click', (e) => e.preventDefault());
                                     return;
                                 }
@@ -4321,8 +4327,8 @@
                                 // File exists - open preview and reveal in tree
                                 link.addEventListener('click', (e) => {
                                     e.preventDefault();
-                                    openFilePreview(newPath, 'push');
-                                    revealInTree(newPath);
+                                    openFilePreview(resolvedPath, 'push');
+                                    revealInTree(resolvedPath);
                                 });
                             } else if (href && (href.startsWith('http://') || href.startsWith('https://'))) {
                                 // External link - open in new window

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -5092,7 +5092,7 @@
 
             const primary = draggedItems[0];
             const isNoOp = primary.path === dropFolder
-                || (draggedItems.length === 1 && primary.path.split('/').slice(0, -1).join('/') === dropFolder)
+                || draggedItems.every(item => item.path.split('/').slice(0, -1).join('/') === dropFolder)
                 || (draggedItems.length === 1 && primary.isDir && (dropFolder === primary.path || dropFolder.startsWith(primary.path + '/')));
 
             if (isNoOp) {
@@ -5143,9 +5143,13 @@
             // Save items before async (draggedItems gets nulled by handleDragEnd)
             const items = draggedItems.slice();
 
-            // Filter to moveable items — skip protected top-level paths so files
-            // inside locked folders (notes/*, wiki/*, etc.) still move correctly
-            const moveable = items.filter(item => !isProtectedPath(item.path));
+            // Filter to items that actually need to move: skip protected paths,
+            // items already in the target folder, and dirs being dropped into themselves
+            const moveable = items.filter(item =>
+                !isProtectedPath(item.path) &&
+                item.path.split('/').slice(0, -1).join('/') !== dropFolder &&
+                !(item.isDir && (dropFolder === item.path || dropFolder.startsWith(item.path + '/')))
+            );
             if (moveable.length === 0) return;
 
             if (moveable.length === 1) {

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -4419,8 +4419,18 @@
 
             const panel = document.getElementById('preview-panel');
             if (panel) panel.classList.remove('fullscreen');
+
+            // Capture and clear before state changes so hidePreviewPanel doesn't observe
+            // a stale flag, then restore graph fullscreen after the preview is gone.
+            const shouldRestoreGraph = _previewFullscreenRestoredGraph;
+            _previewFullscreenRestoredGraph = false;
+
             resetPreviewState();
             hidePreviewPanel();
+
+            if (shouldRestoreGraph) {
+                toggleGraphFullscreen(false);
+            }
         }
 
         function togglePreviewFullscreen() {
@@ -4449,7 +4459,7 @@
 
             if (!isFullscreen && _previewFullscreenRestoredGraph) {
                 _previewFullscreenRestoredGraph = false;
-                toggleGraphFullscreen();
+                toggleGraphFullscreen(false);
             }
 
             expandIcon.style.display = isFullscreen ? 'none' : 'block';
@@ -7487,7 +7497,7 @@
 
             if (!isFullscreen && _previewFullscreenRestoredGraph) {
                 _previewFullscreenRestoredGraph = false;
-                toggleGraphFullscreen();
+                toggleGraphFullscreen(false);
             }
 
             if (isFullscreen) {
@@ -8270,7 +8280,7 @@
         let _graphPanelNextSibling = null;
         let _previewFullscreenRestoredGraph = false;
 
-        function toggleGraphFullscreen() {
+        function toggleGraphFullscreen(animated = true) {
             const panel = document.querySelector('.graph-panel');
             const expandIcon = document.getElementById('fullscreen-icon-expand');
             const collapseIcon = document.getElementById('fullscreen-icon-collapse');
@@ -8327,7 +8337,7 @@
                     svg.attr('width', null).attr('height', null);
                     svg.attr('width', container.clientWidth).attr('height', container.clientHeight);
                 }
-                fitAllNodes(true);
+                fitAllNodes(animated);
             });
         }
 
@@ -8431,8 +8441,8 @@
 
         // Also hook into graph fullscreen toggle
         const _origToggleGraphFullscreen = toggleGraphFullscreen;
-        toggleGraphFullscreen = function() {
-            _origToggleGraphFullscreen();
+        toggleGraphFullscreen = function(animated = true) {
+            _origToggleGraphFullscreen(animated);
             setTimeout(updateFloatingLegend, 60);
             // Run again after the delayed renderGraph (300ms for exit) to clean up
             // orphaned floating legends created by the re-render.

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -5054,6 +5054,7 @@
         }
 
         function clearDropGroupHighlight() {
+            hideFolderMoveTooltip();
             if (currentDropGroup) {
                 currentDropGroup.classList.remove('drag-drop-target');
                 const svg = currentDropGroup.querySelector(':scope > .drag-group-svg');
@@ -5062,9 +5063,22 @@
             }
         }
 
+        function showFolderMoveTooltip(event, folderName) {
+            const tooltip = document.getElementById('folder-move-tooltip');
+            tooltip.textContent = `Move to ${folderName}`;
+            tooltip.style.left = (event.clientX + 12) + 'px';
+            tooltip.style.top = (event.clientY + 12) + 'px';
+            tooltip.classList.add('visible');
+        }
+
+        function hideFolderMoveTooltip() {
+            document.getElementById('folder-move-tooltip').classList.remove('visible');
+        }
+
         function handleDragEnd(event) {
             event.target.classList.remove('dragging');
             clearDropGroupHighlight();
+            hideFolderMoveTooltip();
             document.querySelectorAll('.drag-over').forEach(el => el.classList.remove('drag-over', 'invalid'));
             draggedItems = null;
         }
@@ -5087,6 +5101,9 @@
             }
 
             event.dataTransfer.dropEffect = 'move';
+
+            const folderName = dropFolder.split('/').pop() || 'root directory';
+            showFolderMoveTooltip(event, folderName);
 
             const treeItem = event.target.closest('#tree-view .tree-item');
             if (!treeItem) return;
@@ -5413,6 +5430,14 @@
             }
         }
 
+        // Clear tree drag state when drag leaves the tree panel
+        document.querySelector('.tree-container').addEventListener('dragleave', (e) => {
+            if (!draggedItems) return;
+            if (!e.currentTarget.contains(e.relatedTarget)) {
+                clearDropGroupHighlight();
+            }
+        });
+
         // Drag and drop (external files only - not internal moves)
         document.addEventListener('dragover', (e) => {
             e.preventDefault();
@@ -5719,6 +5744,7 @@
                          ondragover="handleDragOver(event, '${node.path}', ${node.is_dir})"
                          ondragleave="handleDragLeave(event)"
                          ondrop="handleDrop(event, '${node.path}', ${node.is_dir})"
+                         ${node.is_dir ? `onmouseenter="if(selectedItems.size>0)showFolderMoveTooltip(event,'${node.name.replace(/'/g, "\\'")}')" onmouseleave="hideFolderMoveTooltip()"` : ''}
                          onclick="handleTreeClick(event, '${node.path}', ${node.is_dir}, ${hasChildren})"
                          ondblclick="handleTreeDblClick(event, '${node.path}', ${node.is_dir})">`;
 
@@ -8423,5 +8449,6 @@
         setupScrollFade('.preview-content');
     </script>
     <div class="graph-tooltip" id="graph-tooltip"></div>
+    <div class="graph-tooltip" id="folder-move-tooltip"></div>
 </body>
 </html>

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -1024,7 +1024,7 @@
             display: none;
             align-items: center;
             justify-content: center;
-            z-index: 1001;
+            z-index: 1004;
         }
 
         .modal-overlay.show {

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -4265,9 +4265,6 @@
             } else if (historyMode === 'clear') {
                 previewHistory = [];
             }
-            if (document.body.classList.contains('graph-is-fullscreen')) {
-                toggleGraphFullscreen();
-            }
             previewPath = path;
             updateTreePreviewState();
             window.activeClusterId = null;


### PR DESCRIPTION
_Note: right now the `santai web` command only works when a project has the codebases, history, notes, resources, and wiki folders. Any changes made to the project structure during testing you might want to undo after so you can access your project later. Should be fixing this for the next CLI release._

Summary
  
This branch ships improvements to the web UI's file tree and drag-and-drop experience, as well as the graph's fullscreen view. 
1. Markdown link navigation reveals file location in tree. Clicking a relative markdown link now opens the file preview in-place (same window) instead of a new tab. The file tree automatically expands all parent folders and scrolls to highlight the file's location. Navigating back via the Back button returns to the file that contained the link — chained link traversal (A → B → C → Back → B → Back → A) is fully supported. Opening a file any other way (tree click, dashboard, graph) resets this history.
2. "Move to [folder]" tooltip on drag. Dragging a file over a folder in the tree now shows a floating tooltip with "Move to [folder name]" (or "Move to root directory" for the project root). The tooltip and marching-ants highlight are scoped to the tree — both disappear immediately when the drag exits the tree panel into the dashboard, preview pane, or any other area. The tooltip also appears on hover when items are multi-selected in the tree (Ctrl+click).
3. Correct no-op detection for multi-select drag. When dragging a mixed selection (files from different folders) onto a folder that already contains some of them, only the files that actually need to move are sent to the API. Files already in the target folder are silently skipped — no spurious "file already exists" error.
4. All folders and files are now editable. Removed the concept of locked/protected paths. notes, history, wiki, codebases, resources, AGENTS.md, CLAUDE.md, README.md, and rumdl.toml can now be renamed, moved, and deleted like any other item. The backend's 403 guard on the move endpoint is also removed.
5. Markdown links now stay valid when their target file is moved or renamed. Previously, any `[text](path)` would silently break as soon as the file it pointed to changed location — there was no way to recover without manually editing every file that referenced it. After this change, the move and rename API endpoints trigger a project-wide link rewrite immediately after the filesystem operation. 
6. Graph fullscreen preserved across file previews: Opening a file preview used to unconditionally exit graph fullscreen. Instant graph restore + Back/X restore fullscreen: When the user fullscreens a file preview from within graph fullscreen (which must temporarily exit graph fullscreen), dismissing the preview now restores graph fullscreen correctly in all three dismissal paths — collapse button, X button, and Back button.
  ---
Test Plan

Markdown link navigation
(For this it's easy to ask the chatbot to create 2 files, 1 that references the other)
- [x] Open a markdown file that contains a relative link to another file; click the link — preview opens in the same window, tree expands and highlights the linked file's location
- [x] Click Back — returns to the source file (not the dashboard); tree reveals that file
- [x] Click a file directly in the tree after link-navigating — Back no longer returns to the link chain (history is cleared)

Markdown link rename/relocation:
- [x] File A contains `[link](../notes/foo.md)`; rename foo.md to bar.md — link in A updates to ../notes/bar.md and is still clickable
- [x] File A links to notes/foo.md; move foo.md into history/ — link updates to point to history/foo.md

Unlocked folders
- [x] Rename one of notes, history, wiki, AGENTS.md, CLAUDE.md, etc. from the tree — rename succeeds
- [x] Drag notes or CLAUDE.md to another folder — move succeeds
- [x] Delete a previously-protected folder (notes, history, wiki, etc.) — delete succeeds

Move-to tooltip
<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/25cd224f-62df-4229-8b2c-9201c6895e4e" />
- [x] Drag a file over a folder in the tree — "Move to [folder name]" tooltip appears near cursor
- [x]  Drag over the project root — tooltip reads "Move to root directory"
- [x] Move cursor out of the tree while dragging (into preview panel or dashboard) — tooltip and marching ants both disappear

Multi-select drag no-op handling
- [x] Command+click one file from folder A and one from folder B; drag both onto folder A — only the file from B moves, success toast says "Moved _ to A" where _ is the file from folder B; no error shown

Graph fullscreen + file preview coexistence
- [x] Enter graph fullscreen. Click a graph node to open a file preview. Confirm the graph stays fullscreen and the preview appears as a right sidebar.
<img width="1470" height="803" alt="Screenshot 2026-05-20 at 11 22 28 AM" src="https://github.com/user-attachments/assets/427fb59f-9230-4b8a-8658-b337156ccee0" />

- [x] With the sidebar preview open in graph fullscreen, close the preview with X. Confirm the graph expands back to full width immediately
- [x] Enter graph fullscreen → click on a node to open a file preview (sidebar) → click the expand icon to fullscreen the preview. Confirm graph fullscreen exits cleanly. From that state, click the collapse icon to un-fullscreen the preview. Confirm the graph snaps back to fullscreen instantly