### PR TITLE
ci: hotfix opencode action to v1.15.6

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -32,7 +32,7 @@ jobs:
           persist-credentials: false
 
       - name: Run opencode
-        uses: anomalyco/opencode/github@d7a6e1daaf2271bcd0b611fbb27d4956806e475a  # v1.15.5
+        uses: anomalyco/opencode/github@b5f092837d009f26f8f5f1557743654af3b3424b  # v1.15.6
         env:
           ANTHROPIC_API_KEY: ${{ secrets.OPENCODE_GITHUB_KEY }}
         with:


### PR DESCRIPTION
## Summary

- Bump `anomalyco/opencode/github` from v1.15.5 → v1.15.6 on `main`.
- v1.15.5 ships a broken symlink at `packages/opencode/src/provider/sdk/copilot/AGENTS.md` (targets a missing `README.md`), which causes the runner to fail at the "Prepare all required actions" stage with `Could not find file '.../packages/opencode/src/provider/sdk/copilot/AGENTS.md'`. v1.15.6 removes that directory entirely.
- The same fix is on #117 (fix-opencode-workflow), but `issue_comment` workflows always run from the default branch — so #117 only takes effect after it merges. This hotfix unblocks `/opencode` on open PRs in the meantime.

Refs #116.

## Test plan

- [ ] Merge to `main`.
- [ ] On any open PR, comment `/opencode <something harmless>` and confirm the workflow run no longer errors at "Prepare all required actions".