### PR TITLE
feat: smart file placement

### DIFF
--- a/src/santai_cli/agents/HOW_TO_USE.md
+++ b/src/santai_cli/agents/HOW_TO_USE.md
@@ -50,7 +50,7 @@ history/ and notes/ to identify knowledge that should be captured..."
 ## Why This Works
 
 - **Direct use**: No code generation, just reference the markdown file
-- **Santai-aware**: Each agent understands the notes/resources/history directory structure
+- **Santai-aware**: Each agent understands the notes/media/history directory structure
 - **Composable**: Chain agents together (research -> documentation -> notes)
 - **Consistent**: Same agent definitions work across tools
 

--- a/src/santai_cli/agents/HOW_TO_USE.md
+++ b/src/santai_cli/agents/HOW_TO_USE.md
@@ -50,8 +50,8 @@ history/ and notes/ to identify knowledge that should be captured..."
 ## Why This Works
 
 - **Direct use**: No code generation, just reference the markdown file
-- **Santai-aware**: Each agent understands the santai directory structure
-- **Composable**: Chain agents together (research -> documentation)
+- **Santai-aware**: Each agent understands the notes/resources/history directory structure
+- **Composable**: Chain agents together (research -> documentation -> notes)
 - **Consistent**: Same agent definitions work across tools
 
 ## Adding New Agents

--- a/src/santai_cli/agents/README.md
+++ b/src/santai_cli/agents/README.md
@@ -6,6 +6,7 @@ This directory contains agent definitions purpose-built for Santai project workf
 
 ### Context Management
 
+- **[notes.md](notes.md)** - Curates the notes/ directory as the authoritative source of project knowledge
 - **[documentation.md](documentation.md)** - Creates and maintains documentation across all santai directories
 - **[summarizer.md](summarizer.md)** - Condenses project context into clear, actionable summaries
 - **[research.md](research.md)** - Investigates topics and gathers context for the project knowledge base

--- a/src/santai_cli/agents/documentation.md
+++ b/src/santai_cli/agents/documentation.md
@@ -13,7 +13,7 @@ You are a documentation specialist for Santai projects. Your job is to create, i
 Santai projects manage context through three core directories:
 
 - **notes/** — personal notes, summaries, AI research, documentation, how-to guides, tutorials, reference pages
-- **media/** — media files, images, audio, video, PDFs, templates, archives, binary data
+- **resources/** — media files, images, audio, video, PDFs, templates, archives, binary data
 - **history/** — logs, changelogs, versioned records (filename format: `YYYY-MM-DD-brief-description.md`)
 
 ## What You Document
@@ -40,7 +40,7 @@ Create structured notes that ground AI agents and solidify knowledge:
 - Update notes when the underlying knowledge changes
 
 ### Media Documentation
-Annotate binary and media files in `media/`:
+Annotate binary and media files in `resources/`:
 
 - Add companion `.md` files for PDFs, images, and archives describing their contents
 - Maintain an index when the collection grows large

--- a/src/santai_cli/agents/documentation.md
+++ b/src/santai_cli/agents/documentation.md
@@ -13,7 +13,7 @@ You are a documentation specialist for Santai projects. Your job is to create, i
 Santai projects manage context through three core directories:
 
 - **notes/** — personal notes, summaries, AI research, documentation, how-to guides, tutorials, reference pages
-- **resources/** — media files, images, audio, video, PDFs, templates, archives, binary data
+- **media/** — media files, images, audio, video, PDFs, templates, archives, binary data
 - **history/** — logs, changelogs, versioned records (filename format: `YYYY-MM-DD-brief-description.md`)
 
 ## What You Document
@@ -40,7 +40,7 @@ Create structured notes that ground AI agents and solidify knowledge:
 - Update notes when the underlying knowledge changes
 
 ### Media Documentation
-Annotate binary and media files in `resources/`:
+Annotate binary and media files in `media/`:
 
 - Add companion `.md` files for PDFs, images, and archives describing their contents
 - Maintain an index when the collection grows large

--- a/src/santai_cli/agents/documentation.md
+++ b/src/santai_cli/agents/documentation.md
@@ -12,9 +12,9 @@ You are a documentation specialist for Santai projects. Your job is to create, i
 
 Santai projects manage context through three core directories:
 
-- **media/** - Reference materials (markdown, PDFs, images, documents)
-- **history/** - Markdown documentation of major changes and decisions
-- **notes/** - General notes, scratch space, and quick thoughts
+- **notes/** — personal notes, summaries, AI research, documentation, how-to guides, tutorials, reference pages
+- **media/** — media files, images, audio, video, PDFs, templates, archives, binary data
+- **history/** — logs, changelogs, versioned records (filename format: `YYYY-MM-DD-brief-description.md`)
 
 ## What You Document
 
@@ -29,13 +29,21 @@ Write clear history entries that capture the narrative behind changes:
   - **Impact** - what this affects going forward
 - Git tracks granular changes; history/ captures the story and reasoning
 
-### Media Documentation
-Organize and annotate reference materials:
+### Notes
+Create structured notes that ground AI agents and solidify knowledge:
 
-- Add README.md files to media subdirectories explaining what's collected there
-- Annotate PDFs and images with companion .md files describing their contents
-- Maintain an index of available media when the collection grows large
-- Cross-reference related entries with `[[wikilinks]]` or standard markdown links
+- Write for an audience that includes both humans and AI agents
+- State key facts and decisions explicitly — don't assume prior context
+- Use clear headings and structure for easy reference
+- Cross-reference related notes with `[[wikilinks]]` or standard markdown links
+- Keep entries focused on one topic each
+- Update notes when the underlying knowledge changes
+
+### Media Documentation
+Annotate binary and media files in `media/`:
+
+- Add companion `.md` files for PDFs, images, and archives describing their contents
+- Maintain an index when the collection grows large
 
 ### Project-Level Documentation
 Maintain the project's top-level docs:
@@ -66,4 +74,5 @@ Maintain the project's top-level docs:
 - Fix broken cross-references between files
 - Add missing context that would help a new reader
 - Consolidate scattered information into the appropriate directory
+- Refine rough notes into polished reference entries when they contain key knowledge
 - Archive historical notes as history entries when appropriate

--- a/src/santai_cli/agents/linting.md
+++ b/src/santai_cli/agents/linting.md
@@ -13,7 +13,7 @@ You are a content quality specialist for Santai projects. Your job is to enforce
 Santai projects manage context through three core directories:
 
 - **notes/** — personal notes, summaries, AI research, documentation, how-to guides, tutorials, reference pages
-- **media/** — media files, images, audio, video, PDFs, templates, archives, binary data
+- **resources/** — media files, images, audio, video, PDFs, templates, archives, binary data
 - **history/** — logs, changelogs, versioned records (filename format: `YYYY-MM-DD-brief-description.md`)
 
 ## What You Lint
@@ -51,7 +51,7 @@ Santai projects manage context through three core directories:
 
 ## Linting Process
 
-1. **Scan** all files in the three santai directories (notes/, media/, history/)
+1. **Scan** all files in the three santai directories (notes/, resources/, history/)
 2. **Categorize** issues by severity:
    - **Error**: Broken links, invalid filenames, malformed content
    - **Warning**: Style inconsistencies, stale content, naming issues

--- a/src/santai_cli/agents/linting.md
+++ b/src/santai_cli/agents/linting.md
@@ -12,9 +12,9 @@ You are a content quality specialist for Santai projects. Your job is to enforce
 
 Santai projects manage context through three core directories:
 
-- **media/** - Reference materials (markdown, PDFs, images, documents)
-- **history/** - Markdown documentation of major changes and decisions
-- **notes/** - General notes, scratch space, and quick thoughts
+- **notes/** — personal notes, summaries, AI research, documentation, how-to guides, tutorials, reference pages
+- **media/** — media files, images, audio, video, PDFs, templates, archives, binary data
+- **history/** — logs, changelogs, versioned records (filename format: `YYYY-MM-DD-brief-description.md`)
 
 ## What You Lint
 
@@ -37,15 +37,21 @@ Santai projects manage context through three core directories:
 - Notes should have a clear title (H1 heading or first line)
 - Flag stale notes that haven't been updated in a long time
 
+### Notes Quality
+- Notes entries should be substantive (not empty or placeholder content)
+- Cross-references between files should resolve correctly
+- Key project knowledge should be clearly stated, not buried in prose
+- Flag notes that duplicate information already elsewhere
+
 ### Cross-Directory Consistency
 - Links between directories should resolve to existing files
 - No orphaned files that are unreferenced and appear abandoned
-- Consistent naming conventions across directories (kebab-case, snake_case, etc.)
+- Consistent naming conventions across directories (kebab-case preferred)
 - No duplicate content across directories
 
 ## Linting Process
 
-1. **Scan** all files in the santai directories
+1. **Scan** all files in the three santai directories (notes/, media/, history/)
 2. **Categorize** issues by severity:
    - **Error**: Broken links, invalid filenames, malformed content
    - **Warning**: Style inconsistencies, stale content, naming issues
@@ -61,7 +67,7 @@ When reporting issues, use this structure:
 ```
 ## directory/filename.md
 
-- [ERROR] Line 12: Broken link to `media/architecture.md` - file does not exist
+- [ERROR] Line 12: Broken link to `notes/architecture.md` - file does not exist
 - [WARN] Filename does not follow naming convention (expected kebab-case)
 - [INFO] Consider adding a summary section for quick scanning
 ```

--- a/src/santai_cli/agents/linting.md
+++ b/src/santai_cli/agents/linting.md
@@ -37,7 +37,7 @@ Santai projects manage context through three core directories:
 - Notes should have a clear title (H1 heading or first line)
 - Flag stale notes that haven't been updated in a long time
 
-### Notes Quality
+### Notes Substance
 - Notes entries should be substantive (not empty or placeholder content)
 - Cross-references between files should resolve correctly
 - Key project knowledge should be clearly stated, not buried in prose

--- a/src/santai_cli/agents/linting.md
+++ b/src/santai_cli/agents/linting.md
@@ -13,7 +13,7 @@ You are a content quality specialist for Santai projects. Your job is to enforce
 Santai projects manage context through three core directories:
 
 - **notes/** — personal notes, summaries, AI research, documentation, how-to guides, tutorials, reference pages
-- **resources/** — media files, images, audio, video, PDFs, templates, archives, binary data
+- **media/** — media files, images, audio, video, PDFs, templates, archives, binary data
 - **history/** — logs, changelogs, versioned records (filename format: `YYYY-MM-DD-brief-description.md`)
 
 ## What You Lint
@@ -51,7 +51,7 @@ Santai projects manage context through three core directories:
 
 ## Linting Process
 
-1. **Scan** all files in the three santai directories (notes/, resources/, history/)
+1. **Scan** all files in the three santai directories (notes/, media/, history/)
 2. **Categorize** issues by severity:
    - **Error**: Broken links, invalid filenames, malformed content
    - **Warning**: Style inconsistencies, stale content, naming issues

--- a/src/santai_cli/agents/notes.md
+++ b/src/santai_cli/agents/notes.md
@@ -13,7 +13,7 @@ You are a notes curator for Santai projects. Your job is to build and maintain t
 Santai projects manage context through three core directories:
 
 - **notes/** — personal notes, summaries, AI research, documentation, how-to guides, tutorials, reference pages
-- **media/** — media files, images, audio, video, PDFs, templates, archives, binary data
+- **resources/** — media files, images, audio, video, PDFs, templates, archives, binary data
 - **history/** — logs, changelogs, versioned records (filename format: `YYYY-MM-DD-brief-description.md`)
 
 ## The Notes Directory's Purpose
@@ -50,7 +50,7 @@ When an AI agent is given context from a santai project, well-structured notes/ 
 ## What Does NOT Belong in Notes
 
 - **Change logs** — those go in history/
-- **Media and binary files** — those go in media/
+- **Media and binary files** — those go in resources/
 - **Stale information** — if it's no longer true, update or remove it
 
 ## Note Page Structure

--- a/src/santai_cli/agents/notes.md
+++ b/src/santai_cli/agents/notes.md
@@ -1,0 +1,96 @@
+---
+description: Notes agent. Curates and maintains the notes directory as the authoritative source of project knowledge.
+mode: subagent
+permission:
+  edit: allow
+  bash: allow
+---
+
+You are a notes curator for Santai projects. Your job is to build and maintain the notes/ directory as the authoritative source of key project knowledge — the context that AI agents and team members need to work effectively.
+
+## Santai Project Structure
+
+Santai projects manage context through three core directories:
+
+- **notes/** — personal notes, summaries, AI research, documentation, how-to guides, tutorials, reference pages
+- **media/** — media files, images, audio, video, PDFs, templates, archives, binary data
+- **history/** — logs, changelogs, versioned records (filename format: `YYYY-MM-DD-brief-description.md`)
+
+## The Notes Directory's Purpose
+
+notes/ is the **single source of truth** for project knowledge that matters. Unlike history (which records what happened), notes captures **what is true right now** and **what you need to know** to work in this project.
+
+When an AI agent is given context from a santai project, well-structured notes/ entries should be the highest-signal content available.
+
+## What Belongs in Notes
+
+### Architecture & Design
+- System architecture and component relationships
+- Key design decisions and their rationale
+- Technology choices and why they were made
+- Constraints and trade-offs the project operates under
+
+### Conventions & Standards
+- Naming conventions, coding standards, file organization rules
+- Workflow processes (branching strategy, review process, release process)
+- Communication norms and terminology definitions
+
+### Domain Knowledge
+- Business rules and domain concepts
+- Glossary of project-specific terms
+- Stakeholder requirements and priorities
+- External dependencies and integration points
+
+### Operational Context
+- How to set up, build, deploy, and debug the project
+- Known issues and workarounds
+- Environment-specific configuration
+- Monitoring and alerting details
+
+## What Does NOT Belong in Notes
+
+- **Change logs** — those go in history/
+- **Media and binary files** — those go in media/
+- **Stale information** — if it's no longer true, update or remove it
+
+## Note Page Structure
+
+Each note page should follow this general structure:
+
+```markdown
+# Topic Title
+
+Brief summary of what this page covers and why it matters.
+
+## Key Points
+
+- The most important facts, stated directly
+- Decisions that have been made
+- Constraints that apply
+
+## Details
+
+Expanded explanation with context, examples, and reasoning.
+
+## Related
+
+- Links to related notes, history entries, or media files
+```
+
+## Curation Workflow
+
+1. **Identify** important knowledge scattered across conversations, history entries, or team members' heads
+2. **Extract** the core facts and decisions — strip away narrative, keep the substance
+3. **Structure** the knowledge as a clear, scannable note
+4. **Cross-reference** related pages using `[[wikilinks]]` or markdown links
+5. **Review** existing notes for accuracy — update or archive stale entries
+6. **Consolidate** overlapping notes into single authoritative entries
+
+## Maintenance Principles
+
+- **Current over comprehensive** — a small notes/ that's accurate beats a large one that's stale
+- **Explicit over implicit** — state things directly; AI agents can't read between the lines
+- **One topic per page** — makes content discoverable and linkable
+- **Update, don't append** — when facts change, update the page rather than adding "UPDATE:" notes
+- **Link to sources** — reference the history entry or media file that supports each claim
+- **Delete fearlessly** — if a note is no longer relevant, remove it; history/ has the record of what was

--- a/src/santai_cli/agents/notes.md
+++ b/src/santai_cli/agents/notes.md
@@ -13,7 +13,7 @@ You are a notes curator for Santai projects. Your job is to build and maintain t
 Santai projects manage context through three core directories:
 
 - **notes/** — personal notes, summaries, AI research, documentation, how-to guides, tutorials, reference pages
-- **resources/** — media files, images, audio, video, PDFs, templates, archives, binary data
+- **media/** — media files, images, audio, video, PDFs, templates, archives, binary data
 - **history/** — logs, changelogs, versioned records (filename format: `YYYY-MM-DD-brief-description.md`)
 
 ## The Notes Directory's Purpose
@@ -50,7 +50,7 @@ When an AI agent is given context from a santai project, well-structured notes/ 
 ## What Does NOT Belong in Notes
 
 - **Change logs** — those go in history/
-- **Media and binary files** — those go in resources/
+- **Media and binary files** — those go in media/
 - **Stale information** — if it's no longer true, update or remove it
 
 ## Note Page Structure

--- a/src/santai_cli/agents/research.md
+++ b/src/santai_cli/agents/research.md
@@ -14,7 +14,7 @@ You are a research specialist for Santai projects. Your job is to investigate to
 Santai projects manage context through three core directories:
 
 - **notes/** — personal notes, summaries, AI research, documentation, how-to guides, tutorials, reference pages
-- **resources/** — media files, images, audio, video, PDFs, templates, archives, binary data
+- **media/** — media files, images, audio, video, PDFs, templates, archives, binary data
 - **history/** — logs, changelogs, versioned records (filename format: `YYYY-MM-DD-brief-description.md`)
 
 ## What You Research
@@ -46,7 +46,7 @@ Santai projects manage context through three core directories:
 ## Research Process
 
 1. **Clarify the question** -- What specifically needs to be answered? What will the findings be used for?
-2. **Check existing context** -- Search the santai project first (notes/, resources/, history/) before looking externally
+2. **Check existing context** -- Search the santai project first (notes/, media/, history/) before looking externally
 3. **Gather sources** -- Collect relevant information from multiple sources
 4. **Evaluate credibility** -- Assess source reliability, recency, and authority
 5. **Synthesize findings** -- Combine information into coherent, structured output
@@ -83,7 +83,7 @@ Concrete next steps based on findings.
 
 ## Research Principles
 
-1. **Check internal context first** -- the santai project may already contain the answer in notes/, resources/, or history/
+1. **Check internal context first** -- the santai project may already contain the answer in notes/, media/, or history/
 2. **Multiple sources** -- validate information across sources; single-source findings should be flagged
 3. **Recency matters** -- note when information was published; prioritize current sources
 4. **Distinguish fact from opinion** -- be explicit about what is established vs. speculative
@@ -97,5 +97,5 @@ Research outputs naturally feed into the santai project:
 
 - **Definitive findings** and **reference materials** go in notes/
 - **Decision records** become history/ entries
-- **Media and binary files** collected go in resources/
+- **Media and binary files** collected go in media/
 - **In-progress investigation** lives in notes/ until complete

--- a/src/santai_cli/agents/research.md
+++ b/src/santai_cli/agents/research.md
@@ -13,9 +13,9 @@ You are a research specialist for Santai projects. Your job is to investigate to
 
 Santai projects manage context through three core directories:
 
-- **media/** - Reference materials (markdown, PDFs, images, documents)
-- **history/** - Markdown documentation of major changes and decisions
-- **notes/** - General notes, scratch space, and quick thoughts
+- **notes/** — personal notes, summaries, AI research, documentation, how-to guides, tutorials, reference pages
+- **media/** — media files, images, audio, video, PDFs, templates, archives, binary data
+- **history/** — logs, changelogs, versioned records (filename format: `YYYY-MM-DD-brief-description.md`)
 
 ## What You Research
 
@@ -46,7 +46,7 @@ Santai projects manage context through three core directories:
 ## Research Process
 
 1. **Clarify the question** -- What specifically needs to be answered? What will the findings be used for?
-2. **Check existing context** -- Search the santai project first (media/, history/, notes/) before looking externally
+2. **Check existing context** -- Search the santai project first (notes/, media/, history/) before looking externally
 3. **Gather sources** -- Collect relevant information from multiple sources
 4. **Evaluate credibility** -- Assess source reliability, recency, and authority
 5. **Synthesize findings** -- Combine information into coherent, structured output
@@ -83,7 +83,7 @@ Concrete next steps based on findings.
 
 ## Research Principles
 
-1. **Check internal context first** -- the santai project may already contain the answer in media/, history/, or notes/
+1. **Check internal context first** -- the santai project may already contain the answer in notes/, media/, or history/
 2. **Multiple sources** -- validate information across sources; single-source findings should be flagged
 3. **Recency matters** -- note when information was published; prioritize current sources
 4. **Distinguish fact from opinion** -- be explicit about what is established vs. speculative
@@ -95,6 +95,7 @@ Concrete next steps based on findings.
 
 Research outputs naturally feed into the santai project:
 
-- **Reference materials** collected go in media/
+- **Definitive findings** and **reference materials** go in notes/
 - **Decision records** become history/ entries
+- **Media and binary files** collected go in media/
 - **In-progress investigation** lives in notes/ until complete

--- a/src/santai_cli/agents/research.md
+++ b/src/santai_cli/agents/research.md
@@ -14,7 +14,7 @@ You are a research specialist for Santai projects. Your job is to investigate to
 Santai projects manage context through three core directories:
 
 - **notes/** — personal notes, summaries, AI research, documentation, how-to guides, tutorials, reference pages
-- **media/** — media files, images, audio, video, PDFs, templates, archives, binary data
+- **resources/** — media files, images, audio, video, PDFs, templates, archives, binary data
 - **history/** — logs, changelogs, versioned records (filename format: `YYYY-MM-DD-brief-description.md`)
 
 ## What You Research
@@ -46,7 +46,7 @@ Santai projects manage context through three core directories:
 ## Research Process
 
 1. **Clarify the question** -- What specifically needs to be answered? What will the findings be used for?
-2. **Check existing context** -- Search the santai project first (notes/, media/, history/) before looking externally
+2. **Check existing context** -- Search the santai project first (notes/, resources/, history/) before looking externally
 3. **Gather sources** -- Collect relevant information from multiple sources
 4. **Evaluate credibility** -- Assess source reliability, recency, and authority
 5. **Synthesize findings** -- Combine information into coherent, structured output
@@ -83,7 +83,7 @@ Concrete next steps based on findings.
 
 ## Research Principles
 
-1. **Check internal context first** -- the santai project may already contain the answer in notes/, media/, or history/
+1. **Check internal context first** -- the santai project may already contain the answer in notes/, resources/, or history/
 2. **Multiple sources** -- validate information across sources; single-source findings should be flagged
 3. **Recency matters** -- note when information was published; prioritize current sources
 4. **Distinguish fact from opinion** -- be explicit about what is established vs. speculative
@@ -97,5 +97,5 @@ Research outputs naturally feed into the santai project:
 
 - **Definitive findings** and **reference materials** go in notes/
 - **Decision records** become history/ entries
-- **Media and binary files** collected go in media/
+- **Media and binary files** collected go in resources/
 - **In-progress investigation** lives in notes/ until complete

--- a/src/santai_cli/agents/summarizer.md
+++ b/src/santai_cli/agents/summarizer.md
@@ -13,7 +13,7 @@ You are a summarization specialist for Santai projects. Your job is to distill c
 Santai projects manage context through three core directories:
 
 - **notes/** — personal notes, summaries, AI research, documentation, how-to guides, tutorials, reference pages
-- **resources/** — media files, images, audio, video, PDFs, templates, archives, binary data
+- **media/** — media files, images, audio, video, PDFs, templates, archives, binary data
 - **history/** — logs, changelogs, versioned records (filename format: `YYYY-MM-DD-brief-description.md`)
 
 ## What You Summarize
@@ -40,14 +40,14 @@ Scan notes/ and surface what's actionable:
 - Group related notes by topic
 
 ### Media Digests
-Summarize reference materials in resources/:
+Summarize reference materials in media/:
 - Produce abstracts for PDFs and long documents
 - Create an annotated index of available resources
 - Highlight which files are most relevant to current work
 
 ### Cross-Directory Synthesis
 Combine information from multiple directories:
-- "State of the project" reports drawing from notes/, resources/, and history/
+- "State of the project" reports drawing from notes/, media/, and history/
 - Topic-specific briefings pulling relevant content from wherever it lives
 - Onboarding summaries for new team members or AI agents
 

--- a/src/santai_cli/agents/summarizer.md
+++ b/src/santai_cli/agents/summarizer.md
@@ -13,7 +13,7 @@ You are a summarization specialist for Santai projects. Your job is to distill c
 Santai projects manage context through three core directories:
 
 - **notes/** — personal notes, summaries, AI research, documentation, how-to guides, tutorials, reference pages
-- **media/** — media files, images, audio, video, PDFs, templates, archives, binary data
+- **resources/** — media files, images, audio, video, PDFs, templates, archives, binary data
 - **history/** — logs, changelogs, versioned records (filename format: `YYYY-MM-DD-brief-description.md`)
 
 ## What You Summarize
@@ -40,14 +40,14 @@ Scan notes/ and surface what's actionable:
 - Group related notes by topic
 
 ### Media Digests
-Summarize reference materials in media/:
+Summarize reference materials in resources/:
 - Produce abstracts for PDFs and long documents
-- Create an annotated index of available media
+- Create an annotated index of available resources
 - Highlight which files are most relevant to current work
 
 ### Cross-Directory Synthesis
 Combine information from multiple directories:
-- "State of the project" reports drawing from notes/, media/, and history/
+- "State of the project" reports drawing from notes/, resources/, and history/
 - Topic-specific briefings pulling relevant content from wherever it lives
 - Onboarding summaries for new team members or AI agents
 

--- a/src/santai_cli/agents/summarizer.md
+++ b/src/santai_cli/agents/summarizer.md
@@ -12,17 +12,17 @@ You are a summarization specialist for Santai projects. Your job is to distill c
 
 Santai projects manage context through three core directories:
 
-- **media/** - Reference materials (markdown, PDFs, images, documents)
-- **history/** - Markdown documentation of major changes and decisions
-- **notes/** - General notes, scratch space, and quick thoughts
+- **notes/** — personal notes, summaries, AI research, documentation, how-to guides, tutorials, reference pages
+- **media/** — media files, images, audio, video, PDFs, templates, archives, binary data
+- **history/** — logs, changelogs, versioned records (filename format: `YYYY-MM-DD-brief-description.md`)
 
 ## What You Summarize
 
 ### Project Overview
 Produce a high-level summary of the entire santai project:
-- What the project is about (derived from README, AGENTS.md)
+- What the project is about (derived from README, AGENTS.md, notes/)
 - Current state and recent activity (from history/ and recent file modifications)
-- Key knowledge areas (from media/ and notes/ topics)
+- Key knowledge areas (from notes/ topics)
 - Active work and open threads (from notes/)
 
 ### History Summaries
@@ -34,19 +34,20 @@ Condense history/ entries into digestible timelines:
 
 ### Notes Triage
 Scan notes/ and surface what's actionable:
+- Identify notes that contain decisions or knowledge worth consolidating
 - Flag notes that are stale or no longer relevant
 - Extract action items and open questions
 - Group related notes by topic
 
 ### Media Digests
 Summarize reference materials in media/:
-- Produce abstracts for long documents
+- Produce abstracts for PDFs and long documents
 - Create an annotated index of available media
-- Highlight which media is most relevant to current work
+- Highlight which files are most relevant to current work
 
 ### Cross-Directory Synthesis
 Combine information from multiple directories:
-- "State of the project" reports drawing from all directories
+- "State of the project" reports drawing from notes/, media/, and history/
 - Topic-specific briefings pulling relevant content from wherever it lives
 - Onboarding summaries for new team members or AI agents
 

--- a/src/santai_cli/core/chat.py
+++ b/src/santai_cli/core/chat.py
@@ -7,10 +7,13 @@ Web interfaces.
 
 import asyncio
 import json
+import logging
 from collections.abc import AsyncGenerator
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
+
+logger = logging.getLogger(__name__)
 
 import anthropic
 import openai
@@ -528,7 +531,13 @@ async def _stream_openai_with_tools(
         stream = await client.chat.completions.create(**create_kwargs)  # type: ignore[arg-type]
     except Exception:
         # Some providers reject forced tool_choice — retry without it.
-        create_kwargs.pop("tool_choice", None)
+        dropped = create_kwargs.pop("tool_choice", None)
+        if dropped:
+            logger.warning(
+                "Provider rejected tool_choice=%r for model %s; retrying without constraint",
+                dropped,
+                model,
+            )
         stream = await client.chat.completions.create(**create_kwargs)  # type: ignore[arg-type]
 
     async for chunk in stream:

--- a/src/santai_cli/core/chat.py
+++ b/src/santai_cli/core/chat.py
@@ -161,6 +161,24 @@ TOOLS = [
             "required": ["source", "destination"],
         },
     },
+    {
+        "name": "answer",
+        "description": (
+            "Send a final response to the user. "
+            "Call this ONLY after ALL requested operations (file writes, moves, deletes) are fully complete. "
+            "Do not call it mid-task."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "content": {
+                    "type": "string",
+                    "description": "The response to send to the user",
+                },
+            },
+            "required": ["content"],
+        },
+    },
 ]
 
 TOOLS_OPENAI = [
@@ -330,53 +348,79 @@ async def stream_response(
         {"event": "file_written", "path": "..."}.
     """
     target_model = model or provider_config.model
-    max_tool_turns = 10
+    max_tool_turns = 20
 
-    for _ in range(max_tool_turns):
+    for iteration in range(max_tool_turns):
+        is_last = iteration == max_tool_turns - 1
+        # First turn: force any tool to prevent plain-text-only responses.
+        # Last turn: force answer() so the loop always terminates with a reply.
+        if is_last:
+            force_tool: bool | str = "answer"
+        elif iteration == 0:
+            force_tool = True
+        else:
+            force_tool = False
+
         if provider == "anthropic":
             text, tool_calls = await _stream_anthropic_with_tools(
-                session, provider_config.api_key, target_model
-            )
-        elif provider == "openai":
-            text, tool_calls = await _stream_openai_with_tools(
-                session, provider_config.api_key, target_model, provider_config.base_url
+                session, provider_config.api_key, target_model, force_tool=force_tool
             )
         else:
             text, tool_calls = await _stream_openai_with_tools(
-                session, provider_config.api_key, target_model, provider_config.base_url
+                session,
+                provider_config.api_key,
+                target_model,
+                provider_config.base_url,
+                force_tool=force_tool,
             )
 
+        # Fallback: provider ignored forced tool_choice and returned plain text.
         if not tool_calls:
             if text:
                 yield text
             break
 
         results = []
+        answer_content: str | None = None
+
         for tool_call in tool_calls:
-            tool_name = tool_call.get("name", "unknown")
-            yield {"event": "tool_call", "name": tool_name}
-            result = execute_tool(tool_call, session.project_root)
-            results.append((tool_name, tool_call, result))
             tool_name = tool_call.get("name", "")
-            if tool_name in ("write_file", "move"):
+            if tool_name == "answer":
                 try:
-                    args = json.loads(tool_call.get("arguments", "{}"))
+                    args = json.loads(tool_call.get("arguments", "{}") or "{}")
                 except json.JSONDecodeError:
                     args = {}
-                path = (
-                    args.get("destination")
-                    if tool_name == "move"
-                    else args.get("filepath")
-                )
-                if path:
-                    yield {"event": "file_written", "path": path}
+                answer_content = args.get("content", "")
+                results.append((tool_name, tool_call, json.dumps({"success": True})))
+            else:
+                yield {"event": "tool_call", "name": tool_name}
+                result = execute_tool(tool_call, session.project_root)
+                results.append((tool_name, tool_call, result))
+                if tool_name in ("write_file", "move"):
+                    try:
+                        args = json.loads(tool_call.get("arguments", "{}"))
+                    except json.JSONDecodeError:
+                        args = {}
+                    path = (
+                        args.get("destination")
+                        if tool_name == "move"
+                        else args.get("filepath")
+                    )
+                    if path:
+                        yield {"event": "file_written", "path": path}
+
         session.add_tool_turn(tool_calls, results)
+
+        if answer_content is not None:
+            yield answer_content
+            break
 
 
 async def _stream_anthropic_with_tools(
     session: ChatSession,
     api_key: str,
     model: str,
+    force_tool: bool | str = False,
 ) -> tuple[str, list[dict[str, Any]]]:
     """Stream from Anthropic API with tool support.
 
@@ -394,6 +438,10 @@ async def _stream_anthropic_with_tools(
     }
     if session.system_prompt:
         kwargs["system"] = session.system_prompt
+    if force_tool is True:
+        kwargs["tool_choice"] = {"type": "any"}
+    elif isinstance(force_tool, str):
+        kwargs["tool_choice"] = {"type": "tool", "name": force_tool}
 
     pending_tool: dict[str, Any] | None = None
 
@@ -430,6 +478,7 @@ async def _stream_openai_with_tools(
     api_key: str,
     model: str,
     base_url: str | None = None,
+    force_tool: bool | str = False,
 ) -> tuple[str, list[dict[str, Any]]]:
     """Stream from OpenAI API with tool support.
 
@@ -466,7 +515,21 @@ async def _stream_openai_with_tools(
         create_kwargs["max_tokens"] = _max_tokens_for_model(model)
     if model in _DISABLE_THINKING_MODELS:
         create_kwargs["extra_body"] = {"thinking": {"type": "disabled"}}
-    stream = await client.chat.completions.create(**create_kwargs)  # type: ignore[arg-type]
+    # Force tool use when requested (skip for models known to not support it).
+    if model not in _NO_SYSTEM_ROLE_MODELS:
+        if force_tool is True:
+            create_kwargs["tool_choice"] = "required"
+        elif isinstance(force_tool, str):
+            create_kwargs["tool_choice"] = {
+                "type": "function",
+                "function": {"name": force_tool},
+            }
+    try:
+        stream = await client.chat.completions.create(**create_kwargs)  # type: ignore[arg-type]
+    except Exception:
+        # Some providers reject forced tool_choice — retry without it.
+        create_kwargs.pop("tool_choice", None)
+        stream = await client.chat.completions.create(**create_kwargs)  # type: ignore[arg-type]
 
     async for chunk in stream:
         if chunk.choices and chunk.choices[0].delta:

--- a/src/santai_cli/core/chat.py
+++ b/src/santai_cli/core/chat.py
@@ -798,7 +798,8 @@ async def get_response(
     """
     chunks: list[str] = []
     async for chunk in stream_response(session, provider, provider_config, model):
-        chunks.append(chunk)
+        if isinstance(chunk, str):
+            chunks.append(chunk)
     return "".join(chunks)
 
 

--- a/src/santai_cli/core/project.py
+++ b/src/santai_cli/core/project.py
@@ -11,6 +11,15 @@ from pathlib import Path
 # but not enforced — projects are free to add, rename, or omit them.
 SANTAI_DIRS = ["media", "history", "notes"]
 
+# Single source of truth for what each folder is for.
+# Consumed by both the smart-place AI prompt (app.py) and the chat system
+# prompt (repo_context.py) so they never drift.
+SANTAI_FOLDER_DESCRIPTIONS: dict[str, str] = {
+    "notes": "personal notes, summaries, AI research, documentation, how-to guides, tutorials, reference pages",
+    "media": "media files, images, audio, video, PDFs, templates, archives, binary data",
+    "history": "logs, changelogs, versioned records",
+}
+
 
 @dataclass
 class HistoryEntry:

--- a/src/santai_cli/core/repo_context.py
+++ b/src/santai_cli/core/repo_context.py
@@ -8,7 +8,7 @@ of all files and content in the repository.
 from dataclasses import dataclass
 from pathlib import Path
 
-from santai_cli.core.project import SantaiProject
+from santai_cli.core.project import SANTAI_FOLDER_DESCRIPTIONS, SantaiProject
 
 
 @dataclass
@@ -130,9 +130,9 @@ def build_repo_context_prompt(context: RepoContext) -> str:
             "",
             "## File Organization",
             "This project organizes files into three knowledge-base folders:",
-            "- **notes/** — personal notes, summaries, AI research, documentation, how-to guides, tutorials, reference pages",
-            "- **media/** — media files, images, audio, video, PDFs, templates, archives, binary data",
-            "- **history/** — logs, changelogs, versioned records (use `YYYY-MM-DD-brief-description.md` format)",
+            f"- **notes/** — {SANTAI_FOLDER_DESCRIPTIONS['notes']}",
+            f"- **media/** — {SANTAI_FOLDER_DESCRIPTIONS['media']}",
+            f"- **history/** — {SANTAI_FOLDER_DESCRIPTIONS['history']} (use `YYYY-MM-DD-brief-description.md` format)",
             "",
             "**When writing files:**",
             "- Always place files under one of these three folders (e.g. `notes/my-summary.md`, not just `my-summary.md`)",
@@ -141,8 +141,8 @@ def build_repo_context_prompt(context: RepoContext) -> str:
             "- Keep the original extension when moving or referencing existing files",
             "",
             "## Important Guidelines",
-            "- IMPORTANT: You MUST call at least one tool every turn. Never respond with plain text alone.",
-            "- IMPORTANT: Use answer() to deliver text to the user — it is the ONLY way your response reaches them. Call it once, after all other operations are complete.",
+            "- IMPORTANT: Call at least one tool per turn. If you have nothing to look up or write, call answer() directly.",
+            "- IMPORTANT: Use answer() to deliver your response. Call it once, after all other operations are complete.",
             "- IMPORTANT: For ANY content you generate (haiku, poem, story, list, summary, code, plan, etc.): ALWAYS call write_file() first to save it under notes/, then call answer() with the content and a brief note that it was saved.",
             "- You can see the file tree above, but you do NOT have the file contents in context.",
             "- IMPORTANT: Whenever a user asks a question that could be answered by a file in this project (notes/, media/, history/, or any other file), you MUST call read_file to read the relevant file(s) before answering. Never answer knowledge-base questions from memory — always fetch fresh content with the tool.",

--- a/src/santai_cli/core/repo_context.py
+++ b/src/santai_cli/core/repo_context.py
@@ -59,31 +59,31 @@ def _build_file_tree(root: Path, max_depth: int = 4) -> str:
     return "\n".join(lines)
 
 
-def _get_media_summary(project: SantaiProject) -> str:
-    """Get a summary of media files in the project.
-
-    Args:
-        project: The Santai project.
-
-    Returns:
-        Summary string of media.
-    """
-    media_path = project.media_path
-
+def _get_resources_summary(project: SantaiProject) -> str:
+    """Get a summary of media files and recent notes in the project."""
     summary_parts = []
 
+    media_path = project.root / "media"
     if media_path.is_dir():
         files = [f for f in media_path.rglob("*") if f.is_file()]
         if files:
             summary_parts.append(f"Media ({len(files)} files):")
             for f in sorted(files)[:20]:
-                rel = f.relative_to(media_path)
-                summary_parts.append(f"  - {rel}")
+                summary_parts.append(f"  - {f.relative_to(media_path)}")
+
+    # Legacy resources/ support while migration is in progress
+    resources_path = project.resources_path
+    if resources_path.is_dir():
+        files = [f for f in resources_path.rglob("*") if f.is_file()]
+        if files:
+            summary_parts.append(f"Media ({len(files)} files):")
+            for f in sorted(files)[:20]:
+                summary_parts.append(f"  - {f.relative_to(resources_path)}")
 
     if not summary_parts:
         return ""
 
-    return f"## Media Summary\n\n{'=' * 40}\n\n" + "\n".join(summary_parts)
+    return f"## Media & Resources\n\n{'=' * 40}\n\n" + "\n".join(summary_parts)
 
 
 def build_repo_context(project: SantaiProject) -> RepoContext:
@@ -103,7 +103,7 @@ def build_repo_context(project: SantaiProject) -> RepoContext:
     return RepoContext(
         project=project,
         file_tree=_build_file_tree(project.root),
-        media_summary=_get_media_summary(project),
+        media_summary=_get_resources_summary(project),
     )
 
 
@@ -137,9 +137,21 @@ def build_repo_context_prompt(context: RepoContext) -> str:
     sections.extend(
         [
             "",
+            "## File Organization",
+            "This project organizes files into three knowledge-base folders:",
+            "- **notes/** — personal notes, summaries, AI research, documentation, how-to guides, tutorials, reference pages",
+            "- **media/** — media files, images, audio, video, PDFs, templates, archives, binary data",
+            "- **history/** — logs, changelogs, versioned records (use `YYYY-MM-DD-brief-description.md` format)",
+            "",
+            "**When writing files:**",
+            "- Always place files under one of these three folders (e.g. `notes/my-summary.md`, not just `my-summary.md`)",
+            "- Choose descriptive, lowercase, hyphenated filenames that reflect the content",
+            "- **Proactively expand context**: when a conversation produces knowledge worth preserving — a summary, a research finding, meeting notes, a decision — write it to `notes/` without waiting to be asked",
+            "- Keep the original extension when moving or referencing existing files",
+            "",
             "## Important Guidelines",
             "- You can see the file tree above, but you do NOT have the file contents in context.",
-            "- IMPORTANT: Whenever a user asks a question that could be answered by a file in this project (notes, media, history, or any other file), you MUST call read_file to read the relevant file(s) before answering. Never answer knowledge-base questions from memory — always fetch fresh content with the tool.",
+            "- IMPORTANT: Whenever a user asks a question that could be answered by a file in this project (notes/, media/, history/, or any other file), you MUST call read_file to read the relevant file(s) before answering. Never answer knowledge-base questions from memory — always fetch fresh content with the tool.",
             "- If multiple files might be relevant, read each one before responding.",
             "- Use [[wikilinks]] or markdown links when referencing project files.",
             "- IMPORTANT: If a read_file result includes 'truncated: true', the file was cut off. Acknowledge this to the user rather than treating the partial content as complete.",

--- a/src/santai_cli/core/repo_context.py
+++ b/src/santai_cli/core/repo_context.py
@@ -60,18 +60,9 @@ def _build_file_tree(root: Path, max_depth: int = 4) -> str:
 
 
 def _get_resources_summary(project: SantaiProject) -> str:
-    """Get a summary of media files and recent notes in the project."""
+    """Get a summary of resources files and recent notes in the project."""
     summary_parts = []
 
-    media_path = project.root / "media"
-    if media_path.is_dir():
-        files = [f for f in media_path.rglob("*") if f.is_file()]
-        if files:
-            summary_parts.append(f"Media ({len(files)} files):")
-            for f in sorted(files)[:20]:
-                summary_parts.append(f"  - {f.relative_to(media_path)}")
-
-    # Legacy resources/ support while migration is in progress
     resources_path = project.resources_path
     if resources_path.is_dir():
         files = [f for f in resources_path.rglob("*") if f.is_file()]
@@ -140,7 +131,7 @@ def build_repo_context_prompt(context: RepoContext) -> str:
             "## File Organization",
             "This project organizes files into three knowledge-base folders:",
             "- **notes/** — personal notes, summaries, AI research, documentation, how-to guides, tutorials, reference pages",
-            "- **media/** — media files, images, audio, video, PDFs, templates, archives, binary data",
+            "- **resources/** — media files, images, audio, video, PDFs, templates, archives, binary data",
             "- **history/** — logs, changelogs, versioned records (use `YYYY-MM-DD-brief-description.md` format)",
             "",
             "**When writing files:**",
@@ -151,7 +142,7 @@ def build_repo_context_prompt(context: RepoContext) -> str:
             "",
             "## Important Guidelines",
             "- You can see the file tree above, but you do NOT have the file contents in context.",
-            "- IMPORTANT: Whenever a user asks a question that could be answered by a file in this project (notes/, media/, history/, or any other file), you MUST call read_file to read the relevant file(s) before answering. Never answer knowledge-base questions from memory — always fetch fresh content with the tool.",
+            "- IMPORTANT: Whenever a user asks a question that could be answered by a file in this project (notes/, resources/, history/, or any other file), you MUST call read_file to read the relevant file(s) before answering. Never answer knowledge-base questions from memory — always fetch fresh content with the tool.",
             "- If multiple files might be relevant, read each one before responding.",
             "- Use [[wikilinks]] or markdown links when referencing project files.",
             "- IMPORTANT: If a read_file result includes 'truncated: true', the file was cut off. Acknowledge this to the user rather than treating the partial content as complete.",

--- a/src/santai_cli/core/repo_context.py
+++ b/src/santai_cli/core/repo_context.py
@@ -63,13 +63,13 @@ def _get_resources_summary(project: SantaiProject) -> str:
     """Get a summary of resources files and recent notes in the project."""
     summary_parts = []
 
-    resources_path = project.resources_path
-    if resources_path.is_dir():
-        files = [f for f in resources_path.rglob("*") if f.is_file()]
+    media_path = project.media_path
+    if media_path.is_dir():
+        files = [f for f in media_path.rglob("*") if f.is_file()]
         if files:
             summary_parts.append(f"Media ({len(files)} files):")
             for f in sorted(files)[:20]:
-                summary_parts.append(f"  - {f.relative_to(resources_path)}")
+                summary_parts.append(f"  - {f.relative_to(media_path)}")
 
     if not summary_parts:
         return ""
@@ -131,21 +131,25 @@ def build_repo_context_prompt(context: RepoContext) -> str:
             "## File Organization",
             "This project organizes files into three knowledge-base folders:",
             "- **notes/** — personal notes, summaries, AI research, documentation, how-to guides, tutorials, reference pages",
-            "- **resources/** — media files, images, audio, video, PDFs, templates, archives, binary data",
+            "- **media/** — media files, images, audio, video, PDFs, templates, archives, binary data",
             "- **history/** — logs, changelogs, versioned records (use `YYYY-MM-DD-brief-description.md` format)",
             "",
             "**When writing files:**",
             "- Always place files under one of these three folders (e.g. `notes/my-summary.md`, not just `my-summary.md`)",
             "- Choose descriptive, lowercase, hyphenated filenames that reflect the content",
-            "- **Proactively expand context**: when a conversation produces knowledge worth preserving — a summary, a research finding, meeting notes, a decision — write it to `notes/` without waiting to be asked",
+            "- **ALWAYS save generated content to a file**: any content you create — poems, haikus, lists, summaries, code, stories, research, decisions — MUST be written to `notes/` using write_file in addition to displaying it in chat. Do this automatically, without being asked.",
             "- Keep the original extension when moving or referencing existing files",
             "",
             "## Important Guidelines",
+            "- IMPORTANT: You MUST call at least one tool every turn. Never respond with plain text alone.",
+            "- IMPORTANT: Use answer() to deliver text to the user — it is the ONLY way your response reaches them. Call it once, after all other operations are complete.",
+            "- IMPORTANT: For ANY content you generate (haiku, poem, story, list, summary, code, plan, etc.): ALWAYS call write_file() first to save it under notes/, then call answer() with the content and a brief note that it was saved.",
             "- You can see the file tree above, but you do NOT have the file contents in context.",
-            "- IMPORTANT: Whenever a user asks a question that could be answered by a file in this project (notes/, resources/, history/, or any other file), you MUST call read_file to read the relevant file(s) before answering. Never answer knowledge-base questions from memory — always fetch fresh content with the tool.",
+            "- IMPORTANT: Whenever a user asks a question that could be answered by a file in this project (notes/, media/, history/, or any other file), you MUST call read_file to read the relevant file(s) before answering. Never answer knowledge-base questions from memory — always fetch fresh content with the tool.",
             "- If multiple files might be relevant, read each one before responding.",
             "- Use [[wikilinks]] or markdown links when referencing project files.",
             "- IMPORTANT: If a read_file result includes 'truncated: true', the file was cut off. Acknowledge this to the user rather than treating the partial content as complete.",
+            "- IMPORTANT: For multi-step requests (e.g. 'delete X and write Y'): complete EVERY step before calling answer(). Do not call answer() after only the first step.",
         ]
     )
 
@@ -153,7 +157,9 @@ def build_repo_context_prompt(context: RepoContext) -> str:
         [
             "",
             "## Available Tools",
-            "You have access to the following tools. WHEN THE USER ASKS YOU TO CREATE OR WRITE A FILE, YOU MUST USE THE write_file TOOL - DO NOT JUST TELL THEM HOW TO DO IT:",
+            "",
+            "- **answer**: Send your final response to the user. REQUIRED to produce any output — call once, after all other work is done.",
+            "  Arguments: content (string)",
             "",
             "- **write_file**: Write content to a file. Creates directories as needed.",
             "  Arguments: filepath (string), content (string)",
@@ -174,11 +180,8 @@ def build_repo_context_prompt(context: RepoContext) -> str:
             "- **remove_file**: Remove a file.",
             "  Arguments: filepath (string)",
             "",
-            "- **remove_dir**: Remove a directory. If empty, deletes immediately. If non-empty, the tool returns a CONFIRM_REQUIRED message — show only that message to the user (do not add any preamble or narration), then wait for confirmation before calling again with confirmed=true.",
+            "- **remove_dir**: Remove a directory. If empty, deletes immediately. If non-empty, the tool returns a CONFIRM_REQUIRED message — relay it exactly to the user, then call again with confirmed=true after they confirm.",
             "  Arguments: path (string), confirmed (boolean, optional)",
-            "",
-            "IMPORTANT: When the user asks you to create, write, or edit a file, use the write_file tool - do not describe how to do it or suggest commands.",
-            "IMPORTANT: For remove_dir, call the tool first without narrating — do not say you are about to delete anything. Let the tool result determine what to say.",
         ]
     )
 

--- a/src/santai_cli/core/repo_context.py
+++ b/src/santai_cli/core/repo_context.py
@@ -60,7 +60,7 @@ def _build_file_tree(root: Path, max_depth: int = 4) -> str:
 
 
 def _get_media_summary(project: SantaiProject) -> str:
-    """Get a summary of resources files and recent notes in the project."""
+    """Get a summary of media files in the project."""
     summary_parts = []
 
     media_path = project.media_path
@@ -143,7 +143,7 @@ def build_repo_context_prompt(context: RepoContext) -> str:
             "## Important Guidelines",
             "- IMPORTANT: Call at least one tool per turn. If you have nothing to look up or write, call answer() directly.",
             "- IMPORTANT: Use answer() to deliver your response. Call it once, after all other operations are complete.",
-            "- IMPORTANT: For ANY content you generate (haiku, poem, story, list, summary, code, plan, etc.): ALWAYS call write_file() first to save it under notes/, then call answer() with the content and a brief note that it was saved.",
+            "- IMPORTANT: For substantial content you create at the user's request (poems, stories, code, multi-paragraph summaries, plans, research notes): ALWAYS call write_file() first to save it under notes/, then call answer() with the content and a brief note that it was saved. Short answers, factual responses, and conversational replies do NOT need to be written to a file.",
             "- You can see the file tree above, but you do NOT have the file contents in context.",
             "- IMPORTANT: Whenever a user asks a question that could be answered by a file in this project (notes/, media/, history/, or any other file), you MUST call read_file to read the relevant file(s) before answering. Never answer knowledge-base questions from memory — always fetch fresh content with the tool.",
             "- If multiple files might be relevant, read each one before responding.",

--- a/src/santai_cli/core/repo_context.py
+++ b/src/santai_cli/core/repo_context.py
@@ -59,7 +59,7 @@ def _build_file_tree(root: Path, max_depth: int = 4) -> str:
     return "\n".join(lines)
 
 
-def _get_resources_summary(project: SantaiProject) -> str:
+def _get_media_summary(project: SantaiProject) -> str:
     """Get a summary of resources files and recent notes in the project."""
     summary_parts = []
 
@@ -74,7 +74,7 @@ def _get_resources_summary(project: SantaiProject) -> str:
     if not summary_parts:
         return ""
 
-    return f"## Media & Resources\n\n{'=' * 40}\n\n" + "\n".join(summary_parts)
+    return f"## Media\n\n{'=' * 40}\n\n" + "\n".join(summary_parts)
 
 
 def build_repo_context(project: SantaiProject) -> RepoContext:
@@ -94,7 +94,7 @@ def build_repo_context(project: SantaiProject) -> RepoContext:
     return RepoContext(
         project=project,
         file_tree=_build_file_tree(project.root),
-        media_summary=_get_resources_summary(project),
+        media_summary=_get_media_summary(project),
     )
 
 

--- a/src/santai_cli/web/app.py
+++ b/src/santai_cli/web/app.py
@@ -683,6 +683,13 @@ def create_app(project: SantaiProject) -> FastAPI:
             "path": str(new_dir.relative_to(root_dir)),
         }
 
+    @app.post("/api/files/mkdirp")
+    async def make_directory_recursive(path: str = Query(...)) -> dict[str, str]:
+        """Create a directory and all parent directories (no-op if it already exists)."""
+        dir_path = safe_path(path)
+        dir_path.mkdir(parents=True, exist_ok=True)
+        return {"path": str(dir_path.relative_to(root_dir))}
+
     @app.post("/api/files/touch")
     async def touch_file(req: TouchRequest) -> dict[str, str]:
         """Create a new empty file."""

--- a/src/santai_cli/web/app.py
+++ b/src/santai_cli/web/app.py
@@ -349,7 +349,12 @@ async def _suggest_file_placement(
                 else:
                     continue
 
-                parsed = _json.loads(text)
+                # Models sometimes wrap the JSON in a ```json fence or prepend text.
+                # Pull out the first {...} object before parsing.
+                m = re.search(r"\{.*\}", text, re.DOTALL)
+                if not m:
+                    continue
+                parsed = _json.loads(m.group())
                 path = parsed.get("path", "")
                 if (
                     isinstance(path, str)

--- a/src/santai_cli/web/app.py
+++ b/src/santai_cli/web/app.py
@@ -611,7 +611,10 @@ def create_app(project: SantaiProject) -> FastAPI:
             safe_path(str(file_path.relative_to(root_dir)))
 
         if file_path.exists():
-            raise HTTPException(status_code=409, detail="File already exists")
+            raise HTTPException(
+                status_code=409,
+                detail=f"'{file_path.name}' already exists — upload aborted",
+            )
 
         with open(file_path, "wb") as f:
             content = await file.read()

--- a/src/santai_cli/web/app.py
+++ b/src/santai_cli/web/app.py
@@ -71,6 +71,11 @@ class SettingsRequest(BaseModel):
     openai_api_key: str | None = None
 
 
+class SmartPlaceRequest(BaseModel):
+    filename: str
+    content: str = ""
+
+
 def format_size(size_bytes: int | float) -> str:
     """Format bytes as human-readable size."""
     for unit in ["B", "KB", "MB", "GB"]:
@@ -230,6 +235,143 @@ def _update_markdown_links(root_dir: Path, old_abs: Path, new_abs: Path) -> None
                 md_file.write_text(new_content, encoding="utf-8")
             except OSError as exc:
                 logging.warning("Failed to update links in %s: %s", md_file, exc)
+
+
+_MEDIA_EXTS: frozenset[str] = frozenset(
+    {
+        "png",
+        "jpg",
+        "jpeg",
+        "gif",
+        "svg",
+        "webp",
+        "ico",
+        "bmp",
+        "tiff",
+        "pdf",
+        "zip",
+        "tar",
+        "gz",
+        "mp3",
+        "m4a",
+        "wav",
+        "flac",
+        "aac",
+        "ogg",
+        "wma",
+        "mp4",
+        "mov",
+        "avi",
+        "mkv",
+        "wmv",
+        "flv",
+        "webm",
+        "psd",
+        "ai",
+        "eps",
+        "sketch",
+    }
+)
+
+_SMART_PLACE_ALLOWED = re.compile(r"^(notes|media|history)/[^/]")
+
+_SMART_PLACE_FOLDER_LIST = (
+    "- notes/ → personal notes, summaries, AI research, documentation, how-to guides, tutorials, reference pages\n"
+    "- media/ → media, images, audio, video, PDFs, templates, archives, binary files\n"
+    "- history/ → logs, changelogs, versioned records"
+)
+
+
+async def _suggest_file_placement(
+    filename: str,
+    content: str,
+    project_root: Path,
+) -> dict[str, str]:
+    """AI-driven file placement into notes/, media/, or history/."""
+    import json as _json
+
+    from santai_cli.core.config import load_config
+
+    is_folder = content.startswith("Folder containing:")
+    ext = (
+        filename.rsplit(".", 1)[-1].lower()
+        if ("." in filename and not is_folder)
+        else ""
+    )
+    slug = re.sub(r"[^\w.-]", "-", filename.lower())
+
+    config = load_config(project_root)
+
+    if config.has_any_provider:
+        if is_folder:
+            system_prompt = (
+                f"You are a file organization assistant. Folders belong in one of:\n{_SMART_PLACE_FOLDER_LIST}\n\n"
+                "Place the FOLDER based on what it contains. Path must end with the folder name.\n"
+                'Respond ONLY with valid JSON. Example: {"path":"notes/my-folder","reasoning":"..."}'
+            )
+        else:
+            system_prompt = (
+                f"You are a file organization assistant. Files belong in one of:\n{_SMART_PLACE_FOLDER_LIST}\n\n"
+                "CRITICAL: Keep the EXACT original file extension.\n"
+                'Respond ONLY with valid JSON. Example: {"path":"notes/my-file.md","reasoning":"..."}'
+            )
+        user_content = f"File name: {filename}\n\nContent preview:\n{content[:2000]}"
+
+        for provider_name, provider_config in config.providers.items():
+            try:
+                if provider_name == "anthropic":
+                    import anthropic as _anthropic
+
+                    client = _anthropic.AsyncAnthropic(api_key=provider_config.api_key)
+                    response = await client.messages.create(
+                        model=provider_config.model,
+                        max_tokens=150,
+                        system=system_prompt,
+                        messages=[{"role": "user", "content": user_content}],
+                    )
+                    text = response.content[0].text.strip()
+                elif provider_name == "openai":
+                    import openai as _openai
+
+                    kw: dict = {"api_key": provider_config.api_key}
+                    if provider_config.base_url:
+                        kw["base_url"] = provider_config.base_url
+                    client = _openai.AsyncOpenAI(**kw)
+                    resp = await client.chat.completions.create(
+                        model=provider_config.model,
+                        max_tokens=150,
+                        temperature=0,
+                        messages=[
+                            {"role": "system", "content": system_prompt},
+                            {"role": "user", "content": user_content},
+                        ],
+                    )
+                    text = (resp.choices[0].message.content or "").strip()
+                else:
+                    continue
+
+                parsed = _json.loads(text)
+                path = parsed.get("path", "")
+                if (
+                    isinstance(path, str)
+                    and _SMART_PLACE_ALLOWED.match(path)
+                    and ".." not in path
+                ):
+                    if not is_folder and ext:
+                        suggested_ext = (
+                            path.rsplit(".", 1)[-1].lower()
+                            if "." in Path(path).name
+                            else ""
+                        )
+                        if suggested_ext != ext:
+                            path = re.sub(r"\.[^.]+$", f".{ext}", path)
+                    return {"path": path, "reasoning": parsed.get("reasoning", "")}
+            except Exception:
+                continue
+
+    if ext in _MEDIA_EXTS:
+        return {"path": f"media/{slug}", "reasoning": "Media file"}
+    return {"path": f"notes/{slug}", "reasoning": "Default to notes"}
 
 
 def create_app(project: SantaiProject) -> FastAPI:
@@ -438,10 +580,7 @@ def create_app(project: SantaiProject) -> FastAPI:
         within the folder is preserved and parent directories are created.
         """
         target_dir = safe_path(path)
-        if not target_dir.is_dir():
-            raise HTTPException(
-                status_code=400, detail="Target path is not a directory"
-            )
+        target_dir.mkdir(parents=True, exist_ok=True)
 
         if not file.filename:
             raise HTTPException(status_code=400, detail="No filename provided")
@@ -1072,6 +1211,15 @@ def create_app(project: SantaiProject) -> FastAPI:
         profiles = get_agent_profiles()
         agents = [{"name": name, "description": desc} for name, desc in profiles]
         return {"agents": agents}
+
+    @app.post("/api/chat/smart-place")
+    async def chat_smart_place(req: SmartPlaceRequest) -> dict[str, str]:
+        """Suggest a folder placement path for a file using AI classification.
+
+        Returns {"path": "notes/filename.md", "reasoning": "..."}.
+        Falls back to extension-based rules if the AI is unavailable.
+        """
+        return await _suggest_file_placement(req.filename, req.content, project.root)
 
     @app.post("/api/chat")
     async def chat_send(req: ChatRequest) -> StreamingResponse:

--- a/src/santai_cli/web/app.py
+++ b/src/santai_cli/web/app.py
@@ -683,6 +683,11 @@ def create_app(project: SantaiProject) -> FastAPI:
             "path": str(new_dir.relative_to(root_dir)),
         }
 
+    @app.get("/api/files/exists")
+    async def path_exists(path: str = Query(...)) -> dict[str, bool]:
+        """Return whether a path exists within the project."""
+        return {"exists": safe_path(path).exists()}
+
     @app.post("/api/files/mkdirp")
     async def make_directory_recursive(path: str = Query(...)) -> dict[str, Any]:
         """Create a directory and all parent directories (no-op if it already exists)."""

--- a/src/santai_cli/web/app.py
+++ b/src/santai_cli/web/app.py
@@ -273,11 +273,11 @@ _MEDIA_EXTS: frozenset[str] = frozenset(
     }
 )
 
-_SMART_PLACE_ALLOWED = re.compile(r"^(notes|media|history)/[^/]")
+_SMART_PLACE_ALLOWED = re.compile(r"^(notes|resources|history)/[^/]")
 
 _SMART_PLACE_FOLDER_LIST = (
     "- notes/ → personal notes, summaries, AI research, documentation, how-to guides, tutorials, reference pages\n"
-    "- media/ → media, images, audio, video, PDFs, templates, archives, binary files\n"
+    "- resources/ → media, images, audio, video, PDFs, templates, archives, binary files\n"
     "- history/ → logs, changelogs, versioned records"
 )
 
@@ -287,7 +287,7 @@ async def _suggest_file_placement(
     content: str,
     project_root: Path,
 ) -> dict[str, str]:
-    """AI-driven file placement into notes/, media/, or history/."""
+    """AI-driven file placement into notes/, resources/, or history/."""
     import json as _json
 
     from santai_cli.core.config import load_config
@@ -370,7 +370,7 @@ async def _suggest_file_placement(
                 continue
 
     if ext in _MEDIA_EXTS:
-        return {"path": f"media/{slug}", "reasoning": "Media file"}
+        return {"path": f"resources/{slug}", "reasoning": "Media file"}
     if is_folder:
         # Scan the file manifest to detect media-dominant folders
         manifest_text = content.replace("Folder containing:", "").strip()
@@ -383,7 +383,7 @@ async def _suggest_file_placement(
             )
             if media_count / len(names) > 0.5:
                 return {
-                    "path": f"media/{slug}",
+                    "path": f"resources/{slug}",
                     "reasoning": "Folder containing mostly media files",
                 }
     return {"path": f"notes/{slug}", "reasoning": "Default to notes"}

--- a/src/santai_cli/web/app.py
+++ b/src/santai_cli/web/app.py
@@ -273,11 +273,11 @@ _MEDIA_EXTS: frozenset[str] = frozenset(
     }
 )
 
-_SMART_PLACE_ALLOWED = re.compile(r"^(notes|resources|history)/[^/]")
+_SMART_PLACE_ALLOWED = re.compile(r"^(notes|media|history)/[^/]")
 
 _SMART_PLACE_FOLDER_LIST = (
     "- notes/ → personal notes, summaries, AI research, documentation, how-to guides, tutorials, reference pages\n"
-    "- resources/ → media, images, audio, video, PDFs, templates, archives, binary files\n"
+    "- media/ → media files, images, audio, video, PDFs, templates, archives, binary files\n"
     "- history/ → logs, changelogs, versioned records"
 )
 
@@ -287,7 +287,7 @@ async def _suggest_file_placement(
     content: str,
     project_root: Path,
 ) -> dict[str, str]:
-    """AI-driven file placement into notes/, resources/, or history/."""
+    """AI-driven file placement into notes/, media/, or history/."""
     import json as _json
 
     from santai_cli.core.config import load_config
@@ -364,15 +364,17 @@ async def _suggest_file_placement(
                             else ""
                         )
                         if suggested_ext != ext:
-                            path = re.sub(r"\.[^.]+$", f".{ext}", path)
+                            new_path, n = re.subn(r"\.[^.]+$", f".{ext}", path)
+                            path = new_path if n else f"{path}.{ext}"
                     return {"path": path, "reasoning": parsed.get("reasoning", "")}
             except Exception:
                 continue
 
     if ext in _MEDIA_EXTS:
-        return {"path": f"resources/{slug}", "reasoning": "Media file"}
+        return {"path": f"media/{slug}", "reasoning": "Media file"}
     if is_folder:
-        # Scan the file manifest to detect media-dominant folders
+        # Scan the file manifest to detect media-dominant folders.
+        # Empty manifests fall through to the notes/ default.
         manifest_text = content.replace("Folder containing:", "").strip()
         names = [n.strip() for n in manifest_text.split(",") if n.strip()]
         if names:
@@ -383,7 +385,7 @@ async def _suggest_file_placement(
             )
             if media_count / len(names) > 0.5:
                 return {
-                    "path": f"resources/{slug}",
+                    "path": f"media/{slug}",
                     "reasoning": "Folder containing mostly media files",
                 }
     return {"path": f"notes/{slug}", "reasoning": "Default to notes"}
@@ -607,9 +609,10 @@ def create_app(project: SantaiProject) -> FastAPI:
             file_path.parent.mkdir(parents=True, exist_ok=True)
         else:
             file_path = target_dir / file.filename
-            if file_path.exists():
-                raise HTTPException(status_code=409, detail="File already exists")
             safe_path(str(file_path.relative_to(root_dir)))
+
+        if file_path.exists():
+            raise HTTPException(status_code=409, detail="File already exists")
 
         with open(file_path, "wb") as f:
             content = await file.read()

--- a/src/santai_cli/web/app.py
+++ b/src/santai_cli/web/app.py
@@ -684,11 +684,12 @@ def create_app(project: SantaiProject) -> FastAPI:
         }
 
     @app.post("/api/files/mkdirp")
-    async def make_directory_recursive(path: str = Query(...)) -> dict[str, str]:
+    async def make_directory_recursive(path: str = Query(...)) -> dict[str, Any]:
         """Create a directory and all parent directories (no-op if it already exists)."""
         dir_path = safe_path(path)
+        was_new = not dir_path.exists()
         dir_path.mkdir(parents=True, exist_ok=True)
-        return {"path": str(dir_path.relative_to(root_dir))}
+        return {"path": str(dir_path.relative_to(root_dir)), "created": was_new}
 
     @app.post("/api/files/touch")
     async def touch_file(req: TouchRequest) -> dict[str, str]:

--- a/src/santai_cli/web/app.py
+++ b/src/santai_cli/web/app.py
@@ -371,6 +371,21 @@ async def _suggest_file_placement(
 
     if ext in _MEDIA_EXTS:
         return {"path": f"media/{slug}", "reasoning": "Media file"}
+    if is_folder:
+        # Scan the file manifest to detect media-dominant folders
+        manifest_text = content.replace("Folder containing:", "").strip()
+        names = [n.strip() for n in manifest_text.split(",") if n.strip()]
+        if names:
+            media_count = sum(
+                1
+                for n in names
+                if "." in n and n.rsplit(".", 1)[-1].lower() in _MEDIA_EXTS
+            )
+            if media_count / len(names) > 0.5:
+                return {
+                    "path": f"media/{slug}",
+                    "reasoning": "Folder containing mostly media files",
+                }
     return {"path": f"notes/{slug}", "reasoning": "Default to notes"}
 
 

--- a/src/santai_cli/web/app.py
+++ b/src/santai_cli/web/app.py
@@ -18,6 +18,7 @@ from pydantic import BaseModel
 
 from santai_cli.core.project import (
     MARKDOWN_LINK_PATTERN,
+    SANTAI_FOLDER_DESCRIPTIONS,
     WIKILINK_PATTERN,
     SantaiProject,
     get_directory_stats,
@@ -275,10 +276,8 @@ _MEDIA_EXTS: frozenset[str] = frozenset(
 
 _SMART_PLACE_ALLOWED = re.compile(r"^(notes|media|history)/[^/]")
 
-_SMART_PLACE_FOLDER_LIST = (
-    "- notes/ → personal notes, summaries, AI research, documentation, how-to guides, tutorials, reference pages\n"
-    "- media/ → media files, images, audio, video, PDFs, templates, archives, binary files\n"
-    "- history/ → logs, changelogs, versioned records"
+_SMART_PLACE_FOLDER_LIST = "\n".join(
+    f"- {folder}/ → {desc}" for folder, desc in SANTAI_FOLDER_DESCRIPTIONS.items()
 )
 
 

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -5452,7 +5452,12 @@
             }
 
             loadFiles(currentPath);
-            loadTree();
+            await loadTree();
+            // Reveal the uploaded folder in the tree (no file preview — it's a directory).
+            const revealFolder = currentPath === ''
+                ? (smartFolderPath || folderName)
+                : (currentPath ? `${currentPath}/${folderName}` : folderName);
+            revealInTree(revealFolder);
         }
 
         function toggleUploadMenu(e) {
@@ -5512,20 +5517,29 @@
         async function handleFileSelect(event) {
             const files = event.target.files;
             const placements = [];
+            let lastUploadedPath = null;
             for (const file of files) {
                 if (currentPath === '') {
                     const preview = await readTextPreview(file);
                     const smartPath = await callSmartPlace(file.name, preview);
                     await uploadFile(file, smartPath);
-                    if (smartPath) placements.push({ name: file.name, dest: smartPath });
+                    if (smartPath) {
+                        placements.push({ name: file.name, dest: smartPath });
+                        lastUploadedPath = smartPath;
+                    }
                 } else {
                     await uploadFile(file);
+                    lastUploadedPath = currentPath ? `${currentPath}/${file.name}` : file.name;
                 }
             }
             event.target.value = '';
             appendSortNotification(placements);
             loadFiles(currentPath);
-            loadTree();
+            await loadTree();
+            if (lastUploadedPath) {
+                if (files.length === 1) openFilePreview(lastUploadedPath);
+                revealInTree(lastUploadedPath);
+            }
         }
 
 
@@ -5606,6 +5620,8 @@
             const dropState = { count: 0, capped: false };
             const smartSort = targetFolder === '';
             const sortedPlacements = [];
+            let firstSuccessPath = null; // first successfully uploaded path for reveal/preview
+            let droppedIsFolder = false; // true if the dropped item was a directory
 
             for (const entry of entries) {
                 const collected = await collectEntryFiles(entry, '', dropState);
@@ -5624,10 +5640,14 @@
                         const res = await fetch(url, { method: 'POST', body: formData });
                         if (!res.ok) { const err = await res.json(); throw new Error(err.detail); }
                         succeeded++;
-                        if (smartPath) sortedPlacements.push({ name: file.name, dest: smartPath });
+                        if (smartPath) {
+                            sortedPlacements.push({ name: file.name, dest: smartPath });
+                            firstSuccessPath = firstSuccessPath || smartPath;
+                        }
                     } catch { failed++; }
 
                 } else if (smartSort && entry.isDirectory) {
+                    droppedIsFolder = true;
                     const folderName = entry.name;
                     const sampleNames = collected.slice(0, 30).map(({ file: f }) => f.name).join(', ');
                     const smartFolderPath = await callSmartPlace(folderName, `Folder containing: ${sampleNames}`);
@@ -5645,9 +5665,13 @@
                             succeeded++;
                         } catch { failed++; }
                     }
-                    if (smartFolderPath) sortedPlacements.push({ name: folderName + '/', dest: smartFolderPath + '/' });
+                    if (smartFolderPath) {
+                        sortedPlacements.push({ name: folderName + '/', dest: smartFolderPath + '/' });
+                        firstSuccessPath = firstSuccessPath || smartFolderPath;
+                    }
 
                 } else {
+                    droppedIsFolder = droppedIsFolder || entry.isDirectory;
                     for (const { file, relPath } of collected) {
                         try {
                             const formData = new FormData();
@@ -5658,6 +5682,11 @@
                             const res = await fetch(url, { method: 'POST', body: formData });
                             if (!res.ok) { const err = await res.json(); throw new Error(err.detail); }
                             succeeded++;
+                            if (!firstSuccessPath) {
+                                firstSuccessPath = targetFolder
+                                    ? `${targetFolder}/${relPath.includes('/') ? relPath : file.name}`
+                                    : (relPath || file.name);
+                            }
                         } catch { failed++; }
                     }
                 }
@@ -5667,7 +5696,12 @@
             if (failed > 0) showToast(`${failed} file${failed !== 1 ? 's' : ''} failed`, true);
             if (dropState.capped) showToast(`Folder too large — only first ${_MAX_UPLOAD_FILES} files uploaded`, true);
             loadFiles(currentPath);
-            loadTree();
+            await loadTree();
+            if (firstSuccessPath) {
+                const isSingleFile = succeeded === 1 && !droppedIsFolder;
+                if (isSingleFile) openFilePreview(firstSuccessPath);
+                revealInTree(firstSuccessPath);
+            }
         }
 
         // Drag and drop (external files only - not internal moves)

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -5396,10 +5396,42 @@
             }
         });
 
+        // Read up to maxChars of text from a file (returns '' for binary/large files).
+        function readTextPreview(file, maxChars = 2000) {
+            if (file.size > 500_000) return Promise.resolve('');
+            return new Promise(resolve => {
+                const reader = new FileReader();
+                reader.onload = e => resolve((e.target.result || '').slice(0, maxChars));
+                reader.onerror = () => resolve('');
+                reader.readAsText(file);
+            });
+        }
+
+        // Ask the backend to suggest a placement path for a file or folder.
+        // Returns a path like "notes/my-file.md" or null on failure.
+        async function callSmartPlace(filename, content) {
+            try {
+                const res = await fetch('/api/chat/smart-place', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ filename, content })
+                });
+                if (!res.ok) return null;
+                const data = await res.json();
+                return data.path || null;
+            } catch { return null; }
+        }
+
         async function handleFileSelect(event) {
             const files = event.target.files;
             for (const file of files) {
-                await uploadFile(file);
+                if (currentPath === '') {
+                    const preview = await readTextPreview(file);
+                    const smartPath = await callSmartPlace(file.name, preview);
+                    await uploadFile(file, smartPath);
+                } else {
+                    await uploadFile(file);
+                }
             }
             event.target.value = '';
             loadFiles(currentPath);
@@ -5440,15 +5472,19 @@
             return results;
         }
 
-        async function uploadFile(file) {
+        // overrideRelPath: full relative path from root (e.g. "notes/my-file.md") produced
+        // by smart placement. When set, uploads to root with that relative path so parent
+        // directories are created automatically.
+        async function uploadFile(file, overrideRelPath = null) {
             const formData = new FormData();
             formData.append('file', file);
 
+            const url = overrideRelPath
+                ? `/api/files?path=&relative_path=${encodeURIComponent(overrideRelPath)}`
+                : `/api/files?path=${encodeURIComponent(currentPath)}`;
+
             try {
-                const res = await fetch(`/api/files?path=${encodeURIComponent(currentPath)}`, {
-                    method: 'POST',
-                    body: formData
-                });
+                const res = await fetch(url, { method: 'POST', body: formData });
 
                 if (!res.ok) {
                     const err = await res.json();
@@ -5496,21 +5532,68 @@
 
                 let succeeded = 0, failed = 0;
                 const dropState = { count: 0, capped: false };
+                const smartSort = currentPath === '';
+
                 for (const entry of entries) {
                     const collected = await collectEntryFiles(entry, '', dropState);
-                    for (const { file, relPath } of collected) {
+
+                    if (smartSort && entry.isFile) {
+                        // Single file at root: AI-classify and route to correct folder
+                        const { file } = collected[0] || {};
+                        if (!file) continue;
+                        const preview = await readTextPreview(file);
+                        const smartPath = await callSmartPlace(file.name, preview);
                         try {
                             const formData = new FormData();
                             formData.append('file', file);
-                            const url = relPath.includes('/')
-                                ? `/api/files?path=${encodeURIComponent(currentPath)}&relative_path=${encodeURIComponent(relPath)}`
-                                : `/api/files?path=${encodeURIComponent(currentPath)}`;
+                            const url = smartPath
+                                ? `/api/files?path=&relative_path=${encodeURIComponent(smartPath)}`
+                                : `/api/files?path=`;
                             const res = await fetch(url, { method: 'POST', body: formData });
                             if (!res.ok) { const err = await res.json(); throw new Error(err.detail); }
                             succeeded++;
                         } catch { failed++; }
+
+                    } else if (smartSort && entry.isDirectory) {
+                        // Folder at root: classify by contents, preserve internal structure
+                        const folderName = entry.name;
+                        const sampleNames = collected.slice(0, 30).map(({ file: f }) => f.name).join(', ');
+                        const smartFolderPath = await callSmartPlace(folderName, `Folder containing: ${sampleNames}`);
+                        // smartFolderPath = e.g. "notes/my-project"; base dir = "notes"
+                        const baseDir = smartFolderPath ? smartFolderPath.split('/')[0] : '';
+
+                        for (const { file, relPath } of collected) {
+                            // relPath already includes folderName (e.g. "my-project/src/main.py")
+                            const uploadPath = baseDir ? `${baseDir}/${relPath}` : relPath;
+                            try {
+                                const formData = new FormData();
+                                formData.append('file', file);
+                                const res = await fetch(
+                                    `/api/files?path=&relative_path=${encodeURIComponent(uploadPath)}`,
+                                    { method: 'POST', body: formData }
+                                );
+                                if (!res.ok) { const err = await res.json(); throw new Error(err.detail); }
+                                succeeded++;
+                            } catch { failed++; }
+                        }
+
+                    } else {
+                        // Non-root drop: respect the user's chosen folder
+                        for (const { file, relPath } of collected) {
+                            try {
+                                const formData = new FormData();
+                                formData.append('file', file);
+                                const url = relPath.includes('/')
+                                    ? `/api/files?path=${encodeURIComponent(currentPath)}&relative_path=${encodeURIComponent(relPath)}`
+                                    : `/api/files?path=${encodeURIComponent(currentPath)}`;
+                                const res = await fetch(url, { method: 'POST', body: formData });
+                                if (!res.ok) { const err = await res.json(); throw new Error(err.detail); }
+                                succeeded++;
+                            } catch { failed++; }
+                        }
                     }
                 }
+
                 if (succeeded > 0) showToast(`Uploaded ${succeeded} file${succeeded !== 1 ? 's' : ''}`);
                 if (failed > 0) showToast(`${failed} file${failed !== 1 ? 's' : ''} failed`, true);
                 if (dropState.capped) showToast(`Folder too large — only first ${_MAX_UPLOAD_FILES} files uploaded`, true);

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -5410,32 +5410,41 @@
             const smartFolderPath = await callSmartPlace(folderName, `Folder containing: ${sampleNames}`);
             const baseDir = smartFolderPath ? smartFolderPath.split('/')[0] : '';
 
-            const results = await Promise.allSettled(batch.map(file => {
+            // Abort immediately if destination folder already exists.
+            const destPath = smartFolderPath || folderName;
+            if (await checkExists(destPath)) {
+                showToast(`'${folderName}' already exists — upload aborted`, true);
+                return;
+            }
+
+            let succeeded = 0;
+            const dupNames = [];
+            for (const file of batch) {
                 const relPath = file.webkitRelativePath;
                 const uploadPath = baseDir ? `${baseDir}/${relPath}` : relPath;
                 const formData = new FormData();
                 formData.append('file', file);
-                return fetch(
-                    `/api/files?path=&relative_path=${encodeURIComponent(uploadPath)}`,
-                    { method: 'POST', body: formData }
-                ).then(async res => {
+                try {
+                    const res = await fetch(
+                        `/api/files?path=&relative_path=${encodeURIComponent(uploadPath)}`,
+                        { method: 'POST', body: formData }
+                    );
                     if (!res.ok) { const err = await res.json(); throw new Error(err.detail); }
-                });
-            }));
+                    succeeded++;
+                } catch (err) {
+                    if (isDuplicateError(err)) dupNames.push(file.name);
+                    else showToast(err.message, true);
+                }
+            }
 
-            const succeeded = results.filter(r => r.status === 'fulfilled').length;
-            const failed = results.filter(r => r.status === 'rejected').length;
-            const dest = smartFolderPath ? smartFolderPath + '/' : folderName + '/';
-            if (succeeded > 0) showToast(`Uploaded ${succeeded} file${succeeded !== 1 ? 's' : ''}`);
-            if (failed > 0) showToast(`${failed} file${failed !== 1 ? 's' : ''} failed`, true);
             if (capped) showToast(`Folder too large — only first ${_MAX_UPLOAD_FILES} files uploaded`, true);
-            if (smartFolderPath) appendSortNotification([{ name: folderName + '/', dest }]);
+            showUploadSummaryToast(dupNames, succeeded, 'file');
+            const dest = smartFolderPath ? smartFolderPath + '/' : folderName + '/';
+            if (succeeded > 0 && smartFolderPath) appendSortNotification([{ name: folderName + '/', dest }]);
 
             loadFiles(currentPath);
             await loadTree();
-            // Reveal the uploaded folder in the tree (no file preview — it's a directory).
-            const revealFolder = smartFolderPath || folderName;
-            revealInTree(revealFolder);
+            if (succeeded > 0) revealInTree(smartFolderPath || folderName);
         }
 
         function toggleUploadMenu(e) {
@@ -5479,6 +5488,37 @@
             } catch { return null; }
         }
 
+        function isDuplicateError(err) {
+            return err.message && err.message.includes('already exists');
+        }
+
+        async function checkExists(path) {
+            try {
+                const r = await fetch(`/api/files/exists?path=${encodeURIComponent(path)}`);
+                return (await r.json()).exists === true;
+            } catch { return false; }
+        }
+
+        // Single unified toast for upload results.
+        // dupNames: array of item names that were duplicates
+        // uploadedCount: number of items that succeeded
+        // itemLabel: 'file' or 'folder'
+        function showUploadSummaryToast(dupNames, uploadedCount, itemLabel) {
+            const dups = dupNames.length;
+            if (dups === 0 && uploadedCount === 0) return;
+            if (dups === 0) {
+                showToast(`Uploaded ${uploadedCount} ${itemLabel}${uploadedCount !== 1 ? 's' : ''}`);
+            } else if (uploadedCount === 0) {
+                if (dups === 1) {
+                    showToast(`'${dupNames[0]}' already exists — upload aborted`, true);
+                } else {
+                    showToast(`${dups} duplicate${dups !== 1 ? 's' : ''} found — upload aborted`, true);
+                }
+            } else {
+                showToast(`${dups} duplicate${dups !== 1 ? 's' : ''} found, ${uploadedCount} ${itemLabel}${uploadedCount !== 1 ? 's' : ''} uploaded`);
+            }
+        }
+
         // Show smart-sort results as a bot message (hides suggestion chips automatically).
         function appendSortNotification(placements) {
             if (!placements.length) return;
@@ -5498,7 +5538,8 @@
             const files = event.target.files;
             const placements = [];
             let lastUploadedPath = null;
-            let succeeded = 0, failed = 0;
+            let succeeded = 0;
+            const dupNames = [];
             // Always smart sort — the button is not a folder-specific drop target.
             for (const file of files) {
                 try {
@@ -5511,13 +5552,13 @@
                     }
                     succeeded++;
                 } catch (err) {
-                    failed++;
-                    showToast(err.message, true);
+                    if (isDuplicateError(err)) dupNames.push(file.name);
+                    else showToast(err.message, true);
                 }
             }
             event.target.value = '';
-            if (succeeded > 0) showToast(`Uploaded ${succeeded} file${succeeded !== 1 ? 's' : ''}`);
-            appendSortNotification(placements);
+            showUploadSummaryToast(dupNames, succeeded, 'file');
+            if (succeeded > 0) appendSortNotification(placements);
             loadFiles(currentPath);
             await loadTree();
             if (lastUploadedPath) {
@@ -5601,15 +5642,16 @@
                 .map(item => item.webkitGetAsEntry?.())
                 .filter(Boolean);
 
-            let succeeded = 0, failed = 0;
+            let succeeded = 0;
+            const dupNames = []; // duplicate item names collected across all entries
             const dropState = { count: 0, capped: false };
             const smartSort = targetFolder === '';
             const sortedPlacements = [];
-            let firstSuccessPath = null; // first successfully uploaded path for reveal/preview
-            let droppedIsFolder = false; // true if the dropped item was a directory
+            let firstSuccessPath = null;
+            let droppedIsFolder = false;
 
             for (const entry of entries) {
-                dropState.emptyDirs = []; // reset per-entry so we can apply the right prefix
+                dropState.emptyDirs = [];
                 const collected = await collectEntryFiles(entry, '', dropState);
 
                 if (smartSort && entry.isFile) {
@@ -5630,7 +5672,10 @@
                             sortedPlacements.push({ name: file.name, dest: smartPath });
                             firstSuccessPath = firstSuccessPath || smartPath;
                         }
-                    } catch(err) { failed++; showToast(err.message, true); }
+                    } catch(err) {
+                        if (isDuplicateError(err)) dupNames.push(file.name);
+                        else showToast(err.message, true);
+                    }
 
                 } else if (smartSort && entry.isDirectory) {
                     droppedIsFolder = true;
@@ -5638,6 +5683,11 @@
                     const sampleNames = collected.slice(0, 30).map(({ file: f }) => f.name).join(', ');
                     const smartFolderPath = await callSmartPlace(folderName, `Folder containing: ${sampleNames}`);
                     const baseDir = smartFolderPath ? smartFolderPath.split('/')[0] : '';
+                    const destPath = smartFolderPath || folderName;
+                    if (await checkExists(destPath)) {
+                        dupNames.push(folderName);
+                        continue;
+                    }
                     const prevSucceeded = succeeded;
                     for (const { file, relPath } of collected) {
                         const uploadPath = baseDir ? `${baseDir}/${relPath}` : relPath;
@@ -5650,7 +5700,10 @@
                             );
                             if (!res.ok) { const err = await res.json(); throw new Error(err.detail); }
                             succeeded++;
-                        } catch(err) { failed++; showToast(err.message, true); }
+                        } catch(err) {
+                            if (isDuplicateError(err)) dupNames.push(file.name);
+                            else showToast(err.message, true);
+                        }
                     }
                     let emptyDirsCreated = 0;
                     for (const emptyDir of dropState.emptyDirs) {
@@ -5667,7 +5720,14 @@
                     }
 
                 } else {
-                    droppedIsFolder = droppedIsFolder || entry.isDirectory;
+                    if (entry.isDirectory) {
+                        droppedIsFolder = true;
+                        const destPath = targetFolder ? `${targetFolder}/${entry.name}` : entry.name;
+                        if (await checkExists(destPath)) {
+                            dupNames.push(entry.name);
+                            continue;
+                        }
+                    }
                     for (const { file, relPath } of collected) {
                         try {
                             const formData = new FormData();
@@ -5683,7 +5743,10 @@
                                     ? `${targetFolder}/${relPath.includes('/') ? relPath : file.name}`
                                     : (relPath || file.name);
                             }
-                        } catch(err) { failed++; showToast(err.message, true); }
+                        } catch(err) {
+                            if (isDuplicateError(err)) dupNames.push(file.name);
+                            else showToast(err.message, true);
+                        }
                     }
                     for (const emptyDir of dropState.emptyDirs) {
                         const mkPath = targetFolder
@@ -5697,8 +5760,12 @@
                     }
                 }
             }
+            // uploadedCount: for folder drops use folder count (sortedPlacements), else file count
+            const isSmartFolderDrop = droppedIsFolder && sortedPlacements.length > 0;
+            const itemLabel = (droppedIsFolder && (sortedPlacements.length > 0 || dupNames.length > 0)) ? 'folder' : 'file';
+            const uploadedCount = isSmartFolderDrop ? sortedPlacements.length : succeeded;
             appendSortNotification(sortedPlacements);
-            if (succeeded > 0) showToast(`Uploaded ${succeeded} file${succeeded !== 1 ? 's' : ''}`);
+            showUploadSummaryToast(dupNames, uploadedCount, itemLabel);
             if (dropState.capped) showToast(`Folder too large — only first ${_MAX_UPLOAD_FILES} files uploaded`, true);
             loadFiles(currentPath);
             await loadTree();

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -1802,7 +1802,7 @@
         .toast {
             position: fixed;
             bottom: 32px;
-            left: calc(50% + 140px);
+            left: 50%;
             transform: translateX(-50%) translateY(20px);
             opacity: 0;
             background: rgba(255, 255, 255, 0.95);
@@ -1814,6 +1814,9 @@
             z-index: 1002;
             box-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
             transition: transform 0.4s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+            max-width: min(480px, calc(100vw - 48px));
+            text-align: center;
+            word-break: break-word;
         }
 
         .toast.show {
@@ -1824,10 +1827,6 @@
         .toast.error {
             border-color: #ef4444;
             background: rgba(254, 242, 242, 0.95);
-        }
-
-        .toast.preview-open {
-            left: calc(50% - 60px);
         }
 
         /* Hidden file input */

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -4835,13 +4835,13 @@
                      data-is-dir="${item.is_dir}"
                      data-name="${item.name}"
                      draggable="true"
-                     ondragstart="handleDragStart(event, '${item.path}', '${item.name}', ${item.is_dir})"
+                     ondragstart="handleDragStart(event, '${escAttr(item.path)}', '${escAttr(item.name)}', ${item.is_dir})"
                      ondragend="handleDragEnd(event)"
-                     ${item.is_dir ? `ondragover="handleDragOver(event, '${item.path}', true)"` : ''}
+                     ${item.is_dir ? `ondragover="handleDragOver(event, '${escAttr(item.path)}', true)"` : ''}
                      ${item.is_dir ? 'ondragleave="handleDragLeave(event)"' : ''}
-                     ${item.is_dir ? `ondrop="handleDrop(event, '${item.path}', true)"` : ''}
+                     ${item.is_dir ? `ondrop="handleDrop(event, '${escAttr(item.path)}', true)"` : ''}
                      onclick="selectItem(this, event)"
-                     ondblclick="openItem('${item.path}', ${item.is_dir})"
+                     ondblclick="openItem('${escAttr(item.path)}', ${item.is_dir})"
                      oncontextmenu="showContextMenu(event, this)">
                     <div class="file-icon ${item.is_dir ? 'folder' : 'file'}">
                         ${item.is_dir ? folderIcon : getFileIcon(item.name)}
@@ -4851,12 +4851,12 @@
                         <div class="file-meta">${item.is_dir ? 'Folder' : item.size_formatted}</div>
                     </div>`;
                 html += `<div class="file-actions">
-                        <button class="file-action-btn edit-btn" onclick="event.stopPropagation(); editItem('${item.path}', '${item.name}')" title="Rename">
+                        <button class="file-action-btn edit-btn" onclick="event.stopPropagation(); editItem('${escAttr(item.path)}', '${escAttr(item.name)}')" title="Rename">
                             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                                 <path stroke-linecap="round" stroke-linejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931z" />
                             </svg>
                         </button>
-                        <button class="file-action-btn delete-btn" onclick="event.stopPropagation(); deleteItem('${item.path}', '${item.name}', ${item.is_dir})" title="Delete">
+                        <button class="file-action-btn delete-btn" onclick="event.stopPropagation(); deleteItem('${escAttr(item.path)}', '${escAttr(item.name)}', ${item.is_dir})" title="Delete">
                             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                                 <path stroke-linecap="round" stroke-linejoin="round" d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0" />
                             </svg>
@@ -5936,6 +5936,20 @@
             });
         });
 
+        // Escape a value for use as a JS string literal inside a single-quoted
+        // argument inside an HTML double-quoted attribute (e.g. onclick="fn('...')").
+        function escAttr(s) {
+            return String(s)
+                .replace(/\\/g, '\\\\')
+                .replace(/'/g, "\\'")
+                .replace(/&/g, '&amp;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;')
+                .replace(/"/g, '&quot;')
+                .replace(/\n/g, '\\n')
+                .replace(/\r/g, '\\r');
+        }
+
         // Toast
         function showToast(message, isError = false) {
             const toast = document.getElementById('toast');
@@ -6071,14 +6085,14 @@
                          data-path="${node.path}"
                          data-is-dir="${node.is_dir}"
                          ${canDrag ? 'draggable="true"' : ''}
-                         ${canDrag ? `ondragstart="handleDragStart(event, '${node.path}', '${node.name}', ${node.is_dir})"` : ''}
+                         ${canDrag ? `ondragstart="handleDragStart(event, '${escAttr(node.path)}', '${escAttr(node.name)}', ${node.is_dir})"` : ''}
                          ondragend="handleDragEnd(event)"
-                         ondragover="handleDragOver(event, '${node.path}', ${node.is_dir})"
+                         ondragover="handleDragOver(event, '${escAttr(node.path)}', ${node.is_dir})"
                          ondragleave="handleDragLeave(event)"
-                         ondrop="handleDrop(event, '${node.path}', ${node.is_dir})"
-                         ${node.is_dir ? `onmouseenter="if(selectedItems.size>0&&draggedItems)showFolderMoveTooltip(event,'${node.name.replace(/&/g,'&amp;').replace(/"/g,'&quot;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/'/g,"\\'")}')" onmouseleave="hideFolderMoveTooltip()"` : ''}
-                         onclick="handleTreeClick(event, '${node.path}', ${node.is_dir}, ${hasChildren})"
-                         ondblclick="handleTreeDblClick(event, '${node.path}', ${node.is_dir})">`;
+                         ondrop="handleDrop(event, '${escAttr(node.path)}', ${node.is_dir})"
+                         ${node.is_dir ? `onmouseenter="if(selectedItems.size>0&&draggedItems)showFolderMoveTooltip(event,'${escAttr(node.name)}')" onmouseleave="hideFolderMoveTooltip()"` : ''}
+                         onclick="handleTreeClick(event, '${escAttr(node.path)}', ${node.is_dir}, ${hasChildren})"
+                         ondblclick="handleTreeDblClick(event, '${escAttr(node.path)}', ${node.is_dir})">`;
 
             // Icon
             html += `<span class="tree-icon ${node.is_dir ? 'folder' : 'file'}">
@@ -6097,12 +6111,12 @@
             // before the toggle so the chevron stays anchored at the far right.
             if (node.path) {
                 html += `<span class="tree-actions">
-                    <button class="tree-action-btn edit-btn" onclick="event.stopPropagation(); editItem('${node.path}', '${node.name}')" title="Rename">
+                    <button class="tree-action-btn edit-btn" onclick="event.stopPropagation(); editItem('${escAttr(node.path)}', '${escAttr(node.name)}')" title="Rename">
                         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                             <path stroke-linecap="round" stroke-linejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931z" />
                         </svg>
                     </button>
-                    <button class="tree-action-btn delete-btn" onclick="event.stopPropagation(); deleteItem('${node.path}', '${node.name}', ${node.is_dir})" title="Delete">
+                    <button class="tree-action-btn delete-btn" onclick="event.stopPropagation(); deleteItem('${escAttr(node.path)}', '${escAttr(node.name)}', ${node.is_dir})" title="Delete">
                         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                             <path stroke-linecap="round" stroke-linejoin="round" d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0" />
                         </svg>
@@ -6112,7 +6126,7 @@
 
             // Toggle chevron last so it stays anchored at the far right
             html += `<span class="tree-toggle${isExpanded ? ' expanded' : ''}${!hasChildren ? ' hidden' : ''}"
-                          onclick="toggleTreeNode(event, '${node.path}')">${chevronIcon}</span>`;
+                          onclick="toggleTreeNode(event, '${escAttr(node.path)}')">${chevronIcon}</span>`;
 
             html += '</div>';
 

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -5530,6 +5530,7 @@
         // is preserved as the first path segment).
         // _state = { count, capped } shared across recursive calls to enforce the cap.
         async function collectEntryFiles(entry, relPrefix, _state = { count: 0, capped: false }) {
+            if (!_state.emptyDirs) _state.emptyDirs = [];
             const results = [];
             if (_state.capped) return results;
             if (entry.isFile) {
@@ -5542,18 +5543,24 @@
             } else if (entry.isDirectory) {
                 const dirPath = relPrefix + entry.name + '/';
                 const reader = entry.createReader();
-                // readEntries may return results in batches — keep calling until empty.
+                // Collect ALL children across batches first so we can detect empty dirs.
+                const allChildren = [];
                 let batch;
                 do {
                     batch = await new Promise((resolve, reject) =>
                         reader.readEntries(resolve, reject)
                     );
-                    for (const child of batch) {
+                    allChildren.push(...batch);
+                } while (batch.length > 0);
+                if (allChildren.length === 0) {
+                    _state.emptyDirs.push(dirPath);
+                } else {
+                    for (const child of allChildren) {
                         if (_state.capped) break;
                         const children = await collectEntryFiles(child, dirPath, _state);
                         results.push(...children);
                     }
-                } while (batch.length > 0 && !_state.capped);
+                }
             }
             return results;
         }
@@ -5599,6 +5606,7 @@
             let droppedIsFolder = false; // true if the dropped item was a directory
 
             for (const entry of entries) {
+                dropState.emptyDirs = []; // reset per-entry so we can apply the right prefix
                 const collected = await collectEntryFiles(entry, '', dropState);
 
                 if (smartSort && entry.isFile) {
@@ -5640,6 +5648,10 @@
                             succeeded++;
                         } catch(err) { failed++; showToast(err.message, true); }
                     }
+                    for (const emptyDir of dropState.emptyDirs) {
+                        const mkPath = (baseDir ? `${baseDir}/` : '') + emptyDir.replace(/\/$/, '');
+                        try { await fetch(`/api/files/mkdirp?path=${encodeURIComponent(mkPath)}`, { method: 'POST' }); } catch {}
+                    }
                     if (smartFolderPath) {
                         sortedPlacements.push({ name: folderName + '/', dest: smartFolderPath + '/' });
                         firstSuccessPath = firstSuccessPath || smartFolderPath;
@@ -5663,6 +5675,12 @@
                                     : (relPath || file.name);
                             }
                         } catch(err) { failed++; showToast(err.message, true); }
+                    }
+                    for (const emptyDir of dropState.emptyDirs) {
+                        const mkPath = targetFolder
+                            ? `${targetFolder}/${emptyDir.replace(/\/$/, '')}`
+                            : emptyDir.replace(/\/$/, '');
+                        try { await fetch(`/api/files/mkdirp?path=${encodeURIComponent(mkPath)}`, { method: 'POST' }); } catch {}
                     }
                 }
             }

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -3094,6 +3094,21 @@
         }
         .chat-file-pill a:hover { text-decoration: underline; }
 
+        .chat-sort-notification {
+            padding: 4px 10px 4px 9px;
+            margin: 3px 0 5px;
+            font-size: 11.5px;
+            color: var(--text-muted, #6b7280);
+            border-left: 2px solid #16a34a;
+            border-radius: 0 4px 4px 0;
+            line-height: 1.6;
+        }
+        .chat-sort-notification code {
+            font-family: monospace;
+            font-size: 11px;
+            color: #16a34a;
+        }
+
         .chat-msg {
             padding: 10px 14px;
             border-radius: 18px;
@@ -5361,22 +5376,54 @@
             if (files.length === 0) return;
             const capped = files.length > _MAX_UPLOAD_FILES;
             const batch = capped ? files.slice(0, _MAX_UPLOAD_FILES) : files;
-            const results = await Promise.allSettled(batch.map(file => {
-                const relPath = file.webkitRelativePath;
-                const formData = new FormData();
-                formData.append('file', file);
-                const url = relPath
-                    ? `/api/files?path=${encodeURIComponent(currentPath)}&relative_path=${encodeURIComponent(relPath)}`
-                    : `/api/files?path=${encodeURIComponent(currentPath)}`;
-                return fetch(url, { method: 'POST', body: formData }).then(async res => {
-                    if (!res.ok) { const err = await res.json(); throw new Error(err.detail); }
-                });
-            }));
-            const succeeded = results.filter(r => r.status === 'fulfilled').length;
-            const failed = results.filter(r => r.status === 'rejected').length;
-            if (succeeded > 0) showToast(`Uploaded ${succeeded} file${succeeded !== 1 ? 's' : ''}`);
-            if (failed > 0) showToast(`${failed} file${failed !== 1 ? 's' : ''} failed`, true);
-            if (capped) showToast(`Folder too large — only first ${_MAX_UPLOAD_FILES} files uploaded`, true);
+
+            if (currentPath === '') {
+                // Smart sort: classify the folder as a unit then route everything under the chosen base dir
+                const folderName = batch[0]?.webkitRelativePath.split('/')[0] || '';
+                const sampleNames = batch.slice(0, 30).map(f => f.name).join(', ');
+                const smartFolderPath = await callSmartPlace(folderName, `Folder containing: ${sampleNames}`);
+                const baseDir = smartFolderPath ? smartFolderPath.split('/')[0] : '';
+
+                const results = await Promise.allSettled(batch.map(file => {
+                    const relPath = file.webkitRelativePath;
+                    const uploadPath = baseDir ? `${baseDir}/${relPath}` : relPath;
+                    const formData = new FormData();
+                    formData.append('file', file);
+                    return fetch(
+                        `/api/files?path=&relative_path=${encodeURIComponent(uploadPath)}`,
+                        { method: 'POST', body: formData }
+                    ).then(async res => {
+                        if (!res.ok) { const err = await res.json(); throw new Error(err.detail); }
+                    });
+                }));
+
+                const succeeded = results.filter(r => r.status === 'fulfilled').length;
+                const failed = results.filter(r => r.status === 'rejected').length;
+                const dest = smartFolderPath ? smartFolderPath + '/' : folderName + '/';
+                if (succeeded > 0) showToast(`Uploaded ${folderName}/ → ${dest}`);
+                if (failed > 0) showToast(`${failed} file${failed !== 1 ? 's' : ''} failed`, true);
+                if (capped) showToast(`Folder too large — only first ${_MAX_UPLOAD_FILES} files uploaded`, true);
+                if (smartFolderPath) appendSortNotification([{ name: folderName + '/', dest }]);
+            } else {
+                // Non-root: respect the user's chosen folder
+                const results = await Promise.allSettled(batch.map(file => {
+                    const relPath = file.webkitRelativePath;
+                    const formData = new FormData();
+                    formData.append('file', file);
+                    const url = relPath
+                        ? `/api/files?path=${encodeURIComponent(currentPath)}&relative_path=${encodeURIComponent(relPath)}`
+                        : `/api/files?path=${encodeURIComponent(currentPath)}`;
+                    return fetch(url, { method: 'POST', body: formData }).then(async res => {
+                        if (!res.ok) { const err = await res.json(); throw new Error(err.detail); }
+                    });
+                }));
+                const succeeded = results.filter(r => r.status === 'fulfilled').length;
+                const failed = results.filter(r => r.status === 'rejected').length;
+                if (succeeded > 0) showToast(`Uploaded ${succeeded} file${succeeded !== 1 ? 's' : ''}`);
+                if (failed > 0) showToast(`${failed} file${failed !== 1 ? 's' : ''} failed`, true);
+                if (capped) showToast(`Folder too large — only first ${_MAX_UPLOAD_FILES} files uploaded`, true);
+            }
+
             loadFiles(currentPath);
             loadTree();
         }
@@ -5422,18 +5469,54 @@
             } catch { return null; }
         }
 
+        // Insert a quiet notification row into the chat panel showing smart-sort results.
+        function appendSortNotification(placements) {
+            const msgs = document.getElementById('chat-messages');
+            if (!msgs || !placements.length) return;
+            const note = document.createElement('div');
+            note.className = 'chat-sort-notification';
+            if (placements.length === 1) {
+                const p = placements[0];
+                const nameCode = document.createElement('code');
+                nameCode.textContent = p.name;
+                const destCode = document.createElement('code');
+                destCode.textContent = p.dest;
+                note.append('Sorted ', nameCode, ' → ', destCode);
+            } else {
+                const byFolder = {};
+                for (const p of placements) {
+                    const folder = p.dest.split('/')[0];
+                    byFolder[folder] = (byFolder[folder] || 0) + 1;
+                }
+                note.append(`Sorted ${placements.length} files → `);
+                let first = true;
+                for (const [f, n] of Object.entries(byFolder)) {
+                    if (!first) note.append(', ');
+                    const fc = document.createElement('code');
+                    fc.textContent = f + '/';
+                    note.append(fc, ` (${n})`);
+                    first = false;
+                }
+            }
+            msgs.appendChild(note);
+            msgs.scrollTop = msgs.scrollHeight;
+        }
+
         async function handleFileSelect(event) {
             const files = event.target.files;
+            const placements = [];
             for (const file of files) {
                 if (currentPath === '') {
                     const preview = await readTextPreview(file);
                     const smartPath = await callSmartPlace(file.name, preview);
                     await uploadFile(file, smartPath);
+                    if (smartPath) placements.push({ name: file.name, dest: smartPath });
                 } else {
                     await uploadFile(file);
                 }
             }
             event.target.value = '';
+            appendSortNotification(placements);
             loadFiles(currentPath);
             loadTree();
         }
@@ -5491,7 +5574,7 @@
                     throw new Error(err.detail || 'Upload failed');
                 }
 
-                showToast(`Uploaded ${file.name}`);
+                showToast(overrideRelPath ? `Uploaded → ${overrideRelPath}` : `Uploaded ${file.name}`);
             } catch (err) {
                 showToast(err.message, true);
             }
@@ -5533,6 +5616,7 @@
                 let succeeded = 0, failed = 0;
                 const dropState = { count: 0, capped: false };
                 const smartSort = currentPath === '';
+                const sortedPlacements = [];
 
                 for (const entry of entries) {
                     const collected = await collectEntryFiles(entry, '', dropState);
@@ -5552,6 +5636,7 @@
                             const res = await fetch(url, { method: 'POST', body: formData });
                             if (!res.ok) { const err = await res.json(); throw new Error(err.detail); }
                             succeeded++;
+                            if (smartPath) sortedPlacements.push({ name: file.name, dest: smartPath });
                         } catch { failed++; }
 
                     } else if (smartSort && entry.isDirectory) {
@@ -5576,6 +5661,7 @@
                                 succeeded++;
                             } catch { failed++; }
                         }
+                        if (smartFolderPath) sortedPlacements.push({ name: folderName + '/', dest: smartFolderPath + '/' });
 
                     } else {
                         // Non-root drop: respect the user's chosen folder
@@ -5593,6 +5679,7 @@
                         }
                     }
                 }
+                appendSortNotification(sortedPlacements);
 
                 if (succeeded > 0) showToast(`Uploaded ${succeeded} file${succeeded !== 1 ? 's' : ''}`);
                 if (failed > 0) showToast(`${failed} file${failed !== 1 ? 's' : ''} failed`, true);

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -3094,21 +3094,6 @@
         }
         .chat-file-pill a:hover { text-decoration: underline; }
 
-        .chat-sort-notification {
-            padding: 4px 10px 4px 9px;
-            margin: 3px 0 5px;
-            font-size: 11.5px;
-            color: var(--text-muted, #6b7280);
-            border-left: 2px solid #16a34a;
-            border-radius: 0 4px 4px 0;
-            line-height: 1.6;
-        }
-        .chat-sort-notification code {
-            font-family: monospace;
-            font-size: 11px;
-            color: #16a34a;
-        }
-
         .chat-msg {
             padding: 10px 14px;
             border-radius: 18px;
@@ -5469,37 +5454,26 @@
             } catch { return null; }
         }
 
-        // Insert a quiet notification row into the chat panel showing smart-sort results.
+        // Show smart-sort results as a bot message (hides suggestion chips automatically).
         function appendSortNotification(placements) {
-            const msgs = document.getElementById('chat-messages');
-            if (!msgs || !placements.length) return;
-            const note = document.createElement('div');
-            note.className = 'chat-sort-notification';
+            if (!placements.length) return;
+            let md;
             if (placements.length === 1) {
                 const p = placements[0];
-                const nameCode = document.createElement('code');
-                nameCode.textContent = p.name;
-                const destCode = document.createElement('code');
-                destCode.textContent = p.dest;
-                note.append('Sorted ', nameCode, ' → ', destCode);
+                md = `Sorted \`${p.name}\` → \`${p.dest}\``;
+            } else if (placements.length <= 6) {
+                const lines = placements.map(p => `- \`${p.name}\` → \`${p.dest}\``);
+                md = `Sorted ${placements.length} files:\n${lines.join('\n')}`;
             } else {
                 const byFolder = {};
                 for (const p of placements) {
                     const folder = p.dest.split('/')[0];
                     byFolder[folder] = (byFolder[folder] || 0) + 1;
                 }
-                note.append(`Sorted ${placements.length} files → `);
-                let first = true;
-                for (const [f, n] of Object.entries(byFolder)) {
-                    if (!first) note.append(', ');
-                    const fc = document.createElement('code');
-                    fc.textContent = f + '/';
-                    note.append(fc, ` (${n})`);
-                    first = false;
-                }
+                const parts = Object.entries(byFolder).map(([f, n]) => `\`${f}/\` (${n})`);
+                md = `Sorted ${placements.length} files → ${parts.join(', ')}`;
             }
-            msgs.appendChild(note);
-            msgs.scrollTop = msgs.scrollHeight;
+            appendChatMessage('assistant', md);
         }
 
         async function handleFileSelect(event) {

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -5501,7 +5501,10 @@
             if (!placements.length) return;
             const n = placements.length;
             const label = n === 1 ? 'Uploaded 1 file:' : `Uploaded ${n} files:`;
-            const lines = placements.map(p => `- ${p.dest}`);
+            // Escape markdown special chars in paths so a filename like
+            // "[evil](javascript:...)" can't become a clickable link.
+            const escapeMd = s => s.replace(/[[\]()]/g, '\\$&');
+            const lines = placements.map(p => `- ${escapeMd(p.dest)}`);
             const md = `${label}\n\n${lines.join('\n')}`;
             appendChatMessage('assistant', md);
         }

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -5518,21 +5518,29 @@
             const files = event.target.files;
             const placements = [];
             let lastUploadedPath = null;
+            let succeeded = 0, failed = 0;
             for (const file of files) {
-                if (currentPath === '') {
-                    const preview = await readTextPreview(file);
-                    const smartPath = await callSmartPlace(file.name, preview);
-                    await uploadFile(file, smartPath);
-                    if (smartPath) {
-                        placements.push({ name: file.name, dest: smartPath });
-                        lastUploadedPath = smartPath;
+                try {
+                    if (currentPath === '') {
+                        const preview = await readTextPreview(file);
+                        const smartPath = await callSmartPlace(file.name, preview);
+                        await uploadFile(file, smartPath);
+                        if (smartPath) {
+                            placements.push({ name: file.name, dest: smartPath });
+                            lastUploadedPath = smartPath;
+                        }
+                    } else {
+                        await uploadFile(file);
+                        lastUploadedPath = currentPath ? `${currentPath}/${file.name}` : file.name;
                     }
-                } else {
-                    await uploadFile(file);
-                    lastUploadedPath = currentPath ? `${currentPath}/${file.name}` : file.name;
+                    succeeded++;
+                } catch (err) {
+                    failed++;
+                    showToast(err.message, true);
                 }
             }
             event.target.value = '';
+            if (succeeded > 0) showToast(`Uploaded ${succeeded} file${succeeded !== 1 ? 's' : ''}`);
             appendSortNotification(placements);
             loadFiles(currentPath);
             await loadTree();
@@ -5587,17 +5595,10 @@
                 ? `/api/files?path=&relative_path=${encodeURIComponent(overrideRelPath)}`
                 : `/api/files?path=${encodeURIComponent(currentPath)}`;
 
-            try {
-                const res = await fetch(url, { method: 'POST', body: formData });
-
-                if (!res.ok) {
-                    const err = await res.json();
-                    throw new Error(err.detail || 'Upload failed');
-                }
-
-                showToast(overrideRelPath ? `Uploaded → ${overrideRelPath}` : `Uploaded ${file.name}`);
-            } catch (err) {
-                showToast(err.message, true);
+            const res = await fetch(url, { method: 'POST', body: formData });
+            if (!res.ok) {
+                const err = await res.json();
+                throw new Error(err.detail || 'Upload failed');
             }
         }
 

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -5483,7 +5483,9 @@
         function appendSortNotification(placements) {
             if (!placements.length) return;
             const n = placements.length;
-            const label = n === 1 ? 'Uploaded 1 file:' : `Uploaded ${n} files:`;
+            const label = n === 1
+                ? `Uploaded 1 ${placements[0].name.endsWith('/') ? 'folder' : 'file'}:`
+                : `Uploaded ${n} items:`;
             // Escape markdown special chars in paths so a filename like
             // "[evil](javascript:...)" can't become a clickable link.
             const escapeMd = s => s.replace(/[[\]()]/g, '\\$&');
@@ -5636,6 +5638,7 @@
                     const sampleNames = collected.slice(0, 30).map(({ file: f }) => f.name).join(', ');
                     const smartFolderPath = await callSmartPlace(folderName, `Folder containing: ${sampleNames}`);
                     const baseDir = smartFolderPath ? smartFolderPath.split('/')[0] : '';
+                    const prevSucceeded = succeeded;
                     for (const { file, relPath } of collected) {
                         const uploadPath = baseDir ? `${baseDir}/${relPath}` : relPath;
                         try {
@@ -5649,11 +5652,16 @@
                             succeeded++;
                         } catch(err) { failed++; showToast(err.message, true); }
                     }
+                    let emptyDirsCreated = 0;
                     for (const emptyDir of dropState.emptyDirs) {
                         const mkPath = (baseDir ? `${baseDir}/` : '') + emptyDir.replace(/\/$/, '');
-                        try { await fetch(`/api/files/mkdirp?path=${encodeURIComponent(mkPath)}`, { method: 'POST' }); } catch {}
+                        try {
+                            const r = await fetch(`/api/files/mkdirp?path=${encodeURIComponent(mkPath)}`, { method: 'POST' });
+                            const data = await r.json();
+                            if (data.created) emptyDirsCreated++;
+                        } catch {}
                     }
-                    if (smartFolderPath) {
+                    if (smartFolderPath && (succeeded > prevSucceeded || emptyDirsCreated > 0)) {
                         sortedPlacements.push({ name: folderName + '/', dest: smartFolderPath + '/' });
                         firstSuccessPath = firstSuccessPath || smartFolderPath;
                     }
@@ -5681,7 +5689,11 @@
                         const mkPath = targetFolder
                             ? `${targetFolder}/${emptyDir.replace(/\/$/, '')}`
                             : emptyDir.replace(/\/$/, '');
-                        try { await fetch(`/api/files/mkdirp?path=${encodeURIComponent(mkPath)}`, { method: 'POST' }); } catch {}
+                        try {
+                            const r = await fetch(`/api/files/mkdirp?path=${encodeURIComponent(mkPath)}`, { method: 'POST' });
+                            const data = await r.json();
+                            if (data.created && !firstSuccessPath) firstSuccessPath = mkPath;
+                        } catch {}
                     }
                 }
             }

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -5404,59 +5404,37 @@
             const capped = files.length > _MAX_UPLOAD_FILES;
             const batch = capped ? files.slice(0, _MAX_UPLOAD_FILES) : files;
 
-            if (currentPath === '') {
-                // Smart sort: classify the folder as a unit then route everything under the chosen base dir
-                const folderName = batch[0]?.webkitRelativePath.split('/')[0] || '';
-                const sampleNames = batch.slice(0, 30).map(f => f.name).join(', ');
-                const smartFolderPath = await callSmartPlace(folderName, `Folder containing: ${sampleNames}`);
-                const baseDir = smartFolderPath ? smartFolderPath.split('/')[0] : '';
+            // Always smart sort — the button is not a folder-specific drop target.
+            const folderName = batch[0]?.webkitRelativePath.split('/')[0] || '';
+            const sampleNames = batch.slice(0, 30).map(f => f.name).join(', ');
+            const smartFolderPath = await callSmartPlace(folderName, `Folder containing: ${sampleNames}`);
+            const baseDir = smartFolderPath ? smartFolderPath.split('/')[0] : '';
 
-                const results = await Promise.allSettled(batch.map(file => {
-                    const relPath = file.webkitRelativePath;
-                    const uploadPath = baseDir ? `${baseDir}/${relPath}` : relPath;
-                    const formData = new FormData();
-                    formData.append('file', file);
-                    return fetch(
-                        `/api/files?path=&relative_path=${encodeURIComponent(uploadPath)}`,
-                        { method: 'POST', body: formData }
-                    ).then(async res => {
-                        if (!res.ok) { const err = await res.json(); throw new Error(err.detail); }
-                    });
-                }));
+            const results = await Promise.allSettled(batch.map(file => {
+                const relPath = file.webkitRelativePath;
+                const uploadPath = baseDir ? `${baseDir}/${relPath}` : relPath;
+                const formData = new FormData();
+                formData.append('file', file);
+                return fetch(
+                    `/api/files?path=&relative_path=${encodeURIComponent(uploadPath)}`,
+                    { method: 'POST', body: formData }
+                ).then(async res => {
+                    if (!res.ok) { const err = await res.json(); throw new Error(err.detail); }
+                });
+            }));
 
-                const succeeded = results.filter(r => r.status === 'fulfilled').length;
-                const failed = results.filter(r => r.status === 'rejected').length;
-                const dest = smartFolderPath ? smartFolderPath + '/' : folderName + '/';
-                if (succeeded > 0) showToast(`Uploaded ${folderName}/ → ${dest}`);
-                if (failed > 0) showToast(`${failed} file${failed !== 1 ? 's' : ''} failed`, true);
-                if (capped) showToast(`Folder too large — only first ${_MAX_UPLOAD_FILES} files uploaded`, true);
-                if (smartFolderPath) appendSortNotification([{ name: folderName + '/', dest }]);
-            } else {
-                // Non-root: respect the user's chosen folder
-                const results = await Promise.allSettled(batch.map(file => {
-                    const relPath = file.webkitRelativePath;
-                    const formData = new FormData();
-                    formData.append('file', file);
-                    const url = relPath
-                        ? `/api/files?path=${encodeURIComponent(currentPath)}&relative_path=${encodeURIComponent(relPath)}`
-                        : `/api/files?path=${encodeURIComponent(currentPath)}`;
-                    return fetch(url, { method: 'POST', body: formData }).then(async res => {
-                        if (!res.ok) { const err = await res.json(); throw new Error(err.detail); }
-                    });
-                }));
-                const succeeded = results.filter(r => r.status === 'fulfilled').length;
-                const failed = results.filter(r => r.status === 'rejected').length;
-                if (succeeded > 0) showToast(`Uploaded ${succeeded} file${succeeded !== 1 ? 's' : ''}`);
-                if (failed > 0) showToast(`${failed} file${failed !== 1 ? 's' : ''} failed`, true);
-                if (capped) showToast(`Folder too large — only first ${_MAX_UPLOAD_FILES} files uploaded`, true);
-            }
+            const succeeded = results.filter(r => r.status === 'fulfilled').length;
+            const failed = results.filter(r => r.status === 'rejected').length;
+            const dest = smartFolderPath ? smartFolderPath + '/' : folderName + '/';
+            if (succeeded > 0) showToast(`Uploaded ${succeeded} file${succeeded !== 1 ? 's' : ''}`);
+            if (failed > 0) showToast(`${failed} file${failed !== 1 ? 's' : ''} failed`, true);
+            if (capped) showToast(`Folder too large — only first ${_MAX_UPLOAD_FILES} files uploaded`, true);
+            if (smartFolderPath) appendSortNotification([{ name: folderName + '/', dest }]);
 
             loadFiles(currentPath);
             await loadTree();
             // Reveal the uploaded folder in the tree (no file preview — it's a directory).
-            const revealFolder = currentPath === ''
-                ? (smartFolderPath || folderName)
-                : (currentPath ? `${currentPath}/${folderName}` : folderName);
+            const revealFolder = smartFolderPath || folderName;
             revealInTree(revealFolder);
         }
 
@@ -5519,19 +5497,15 @@
             const placements = [];
             let lastUploadedPath = null;
             let succeeded = 0, failed = 0;
+            // Always smart sort — the button is not a folder-specific drop target.
             for (const file of files) {
                 try {
-                    if (currentPath === '') {
-                        const preview = await readTextPreview(file);
-                        const smartPath = await callSmartPlace(file.name, preview);
-                        await uploadFile(file, smartPath);
-                        if (smartPath) {
-                            placements.push({ name: file.name, dest: smartPath });
-                            lastUploadedPath = smartPath;
-                        }
-                    } else {
-                        await uploadFile(file);
-                        lastUploadedPath = currentPath ? `${currentPath}/${file.name}` : file.name;
+                    const preview = await readTextPreview(file);
+                    const smartPath = await callSmartPlace(file.name, preview);
+                    await uploadFile(file, smartPath);
+                    if (smartPath) {
+                        placements.push({ name: file.name, dest: smartPath });
+                        lastUploadedPath = smartPath;
                     }
                     succeeded++;
                 } catch (err) {

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -5619,7 +5619,7 @@
                             sortedPlacements.push({ name: file.name, dest: smartPath });
                             firstSuccessPath = firstSuccessPath || smartPath;
                         }
-                    } catch { failed++; }
+                    } catch(err) { failed++; showToast(err.message, true); }
 
                 } else if (smartSort && entry.isDirectory) {
                     droppedIsFolder = true;
@@ -5638,7 +5638,7 @@
                             );
                             if (!res.ok) { const err = await res.json(); throw new Error(err.detail); }
                             succeeded++;
-                        } catch { failed++; }
+                        } catch(err) { failed++; showToast(err.message, true); }
                     }
                     if (smartFolderPath) {
                         sortedPlacements.push({ name: folderName + '/', dest: smartFolderPath + '/' });
@@ -5662,13 +5662,12 @@
                                     ? `${targetFolder}/${relPath.includes('/') ? relPath : file.name}`
                                     : (relPath || file.name);
                             }
-                        } catch { failed++; }
+                        } catch(err) { failed++; showToast(err.message, true); }
                     }
                 }
             }
             appendSortNotification(sortedPlacements);
             if (succeeded > 0) showToast(`Uploaded ${succeeded} file${succeeded !== 1 ? 's' : ''}`);
-            if (failed > 0) showToast(`${failed} file${failed !== 1 ? 's' : ''} failed`, true);
             if (dropState.capped) showToast(`Folder too large — only first ${_MAX_UPLOAD_FILES} files uploaded`, true);
             loadFiles(currentPath);
             await loadTree();

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -5747,7 +5747,9 @@
             // Tree item ondrop calls stopPropagation for external drops, so this
             // only fires when the drop lands outside the tree (main content area).
             if (!draggedItems) {
-                await doExternalUpload(e.dataTransfer, currentPath);
+                // Always smart-sort when dropping onto the editor panel, regardless
+                // of which folder the user is currently browsed into.
+                await doExternalUpload(e.dataTransfer, '');
             }
         });
 

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -3697,7 +3697,7 @@
 <body>
     <div class="app">
         <!-- Sidebar - single glass container with fill-based sections -->
-        <aside class="sidebar glass">
+        <aside class="sidebar glass" id="sidebar">
             <div class="sidebar-header">
                 <img src="/static/logo.png" alt="Santai" onerror="this.style.display='none'" onclick="showDashboard()" style="cursor: pointer;">
                 <h1 onclick="showDashboard()" style="cursor: pointer;">Santai</h1>
@@ -4990,6 +4990,7 @@
         // Move item (drag and drop)
         let draggedItems = null;    // array of { path, name, isDir } for current drag
         let currentDropGroup = null; // <li> currently highlighted as drop target
+        let currentExtDropGroup = null; // <li> highlighted for external file drag
 
         function getFlatVisibleTreeItems() {
             return Array.from(document.querySelectorAll('#tree-view .tree-item'));
@@ -5096,6 +5097,24 @@
             document.getElementById('folder-move-tooltip').classList.remove('visible');
         }
 
+        function applyExtDropHighlight(li) {
+            li.classList.add('drag-drop-target');
+            const svgNS = 'http://www.w3.org/2000/svg';
+            const svg = document.createElementNS(svgNS, 'svg');
+            svg.classList.add('drag-group-svg');
+            svg.appendChild(document.createElementNS(svgNS, 'rect'));
+            li.insertBefore(svg, li.firstChild);
+        }
+
+        function clearExtDropHighlight() {
+            if (currentExtDropGroup) {
+                currentExtDropGroup.classList.remove('drag-drop-target');
+                const svg = currentExtDropGroup.querySelector(':scope > .drag-group-svg');
+                if (svg) svg.remove();
+                currentExtDropGroup = null;
+            }
+        }
+
         function handleDragEnd(event) {
             event.target.classList.remove('dragging');
             clearDropGroupHighlight();
@@ -5106,7 +5125,21 @@
 
         function handleDragOver(event, targetPath, targetIsDir) {
             event.preventDefault();
-            if (!draggedItems) return;
+            if (!draggedItems) {
+                // External file drag over sidebar tree: suppress full-screen drop-zone,
+                // highlight the hovered folder instead.
+                const treeItem = event.target.closest('#tree-view .tree-item');
+                if (!treeItem) return; // not in the sidebar tree — let document handler show overlay
+                event.stopPropagation();
+                event.dataTransfer.dropEffect = 'copy';
+                const groupLi = findGroupLi(treeItem, targetIsDir);
+                if (groupLi !== currentExtDropGroup) {
+                    clearExtDropHighlight();
+                    currentExtDropGroup = groupLi;
+                    if (currentExtDropGroup) applyExtDropHighlight(currentExtDropGroup);
+                }
+                return;
+            }
 
             // For file targets, drop lands in the file's parent folder
             const dropFolder = targetIsDir ? targetPath : targetPath.split('/').slice(0, -1).join('/');
@@ -5148,7 +5181,16 @@
             event.preventDefault();
             clearDropGroupHighlight();
 
-            if (!draggedItems) return;
+            if (!draggedItems) {
+                // External file drop onto a specific tree folder
+                clearExtDropHighlight();
+                document.getElementById('drop-zone').classList.remove('show');
+                if (!event.dataTransfer.items || !event.dataTransfer.items.length) return;
+                event.stopPropagation(); // prevent document drop handler
+                const dropFolder = targetIsDir ? targetPath : targetPath.split('/').slice(0, -1).join('/');
+                doExternalUpload(event.dataTransfer, dropFolder);
+                return;
+            }
 
             // For file targets, drop lands in the file's parent folder
             const dropFolder = targetIsDir ? targetPath : targetPath.split('/').slice(0, -1).join('/');
@@ -5457,22 +5499,10 @@
         // Show smart-sort results as a bot message (hides suggestion chips automatically).
         function appendSortNotification(placements) {
             if (!placements.length) return;
-            let md;
-            if (placements.length === 1) {
-                const p = placements[0];
-                md = `Sorted \`${p.name}\` → \`${p.dest}\``;
-            } else if (placements.length <= 6) {
-                const lines = placements.map(p => `- \`${p.name}\` → \`${p.dest}\``);
-                md = `Sorted ${placements.length} files:\n${lines.join('\n')}`;
-            } else {
-                const byFolder = {};
-                for (const p of placements) {
-                    const folder = p.dest.split('/')[0];
-                    byFolder[folder] = (byFolder[folder] || 0) + 1;
-                }
-                const parts = Object.entries(byFolder).map(([f, n]) => `\`${f}/\` (${n})`);
-                md = `Sorted ${placements.length} files → ${parts.join(', ')}`;
-            }
+            const n = placements.length;
+            const label = n === 1 ? 'Uploaded 1 file:' : `Uploaded ${n} files:`;
+            const lines = placements.map(p => `- ${p.dest}`);
+            const md = `${label}\n\n${lines.join('\n')}`;
             appendChatMessage('assistant', md);
         }
 
@@ -5562,104 +5592,124 @@
             }
         });
 
+        // Shared handler for external file drops; targetFolder='' triggers smart sort.
+        async function doExternalUpload(dataTransfer, targetFolder) {
+            if (!dataTransfer.items || !dataTransfer.items.length) return;
+            const entries = Array.from(dataTransfer.items)
+                .map(item => item.webkitGetAsEntry?.())
+                .filter(Boolean);
+
+            let succeeded = 0, failed = 0;
+            const dropState = { count: 0, capped: false };
+            const smartSort = targetFolder === '';
+            const sortedPlacements = [];
+
+            for (const entry of entries) {
+                const collected = await collectEntryFiles(entry, '', dropState);
+
+                if (smartSort && entry.isFile) {
+                    const { file } = collected[0] || {};
+                    if (!file) continue;
+                    const preview = await readTextPreview(file);
+                    const smartPath = await callSmartPlace(file.name, preview);
+                    try {
+                        const formData = new FormData();
+                        formData.append('file', file);
+                        const url = smartPath
+                            ? `/api/files?path=&relative_path=${encodeURIComponent(smartPath)}`
+                            : `/api/files?path=`;
+                        const res = await fetch(url, { method: 'POST', body: formData });
+                        if (!res.ok) { const err = await res.json(); throw new Error(err.detail); }
+                        succeeded++;
+                        if (smartPath) sortedPlacements.push({ name: file.name, dest: smartPath });
+                    } catch { failed++; }
+
+                } else if (smartSort && entry.isDirectory) {
+                    const folderName = entry.name;
+                    const sampleNames = collected.slice(0, 30).map(({ file: f }) => f.name).join(', ');
+                    const smartFolderPath = await callSmartPlace(folderName, `Folder containing: ${sampleNames}`);
+                    const baseDir = smartFolderPath ? smartFolderPath.split('/')[0] : '';
+                    for (const { file, relPath } of collected) {
+                        const uploadPath = baseDir ? `${baseDir}/${relPath}` : relPath;
+                        try {
+                            const formData = new FormData();
+                            formData.append('file', file);
+                            const res = await fetch(
+                                `/api/files?path=&relative_path=${encodeURIComponent(uploadPath)}`,
+                                { method: 'POST', body: formData }
+                            );
+                            if (!res.ok) { const err = await res.json(); throw new Error(err.detail); }
+                            succeeded++;
+                        } catch { failed++; }
+                    }
+                    if (smartFolderPath) sortedPlacements.push({ name: folderName + '/', dest: smartFolderPath + '/' });
+
+                } else {
+                    for (const { file, relPath } of collected) {
+                        try {
+                            const formData = new FormData();
+                            formData.append('file', file);
+                            const url = relPath.includes('/')
+                                ? `/api/files?path=${encodeURIComponent(targetFolder)}&relative_path=${encodeURIComponent(relPath)}`
+                                : `/api/files?path=${encodeURIComponent(targetFolder)}`;
+                            const res = await fetch(url, { method: 'POST', body: formData });
+                            if (!res.ok) { const err = await res.json(); throw new Error(err.detail); }
+                            succeeded++;
+                        } catch { failed++; }
+                    }
+                }
+            }
+            appendSortNotification(sortedPlacements);
+            if (succeeded > 0) showToast(`Uploaded ${succeeded} file${succeeded !== 1 ? 's' : ''}`);
+            if (failed > 0) showToast(`${failed} file${failed !== 1 ? 's' : ''} failed`, true);
+            if (dropState.capped) showToast(`Folder too large — only first ${_MAX_UPLOAD_FILES} files uploaded`, true);
+            loadFiles(currentPath);
+            loadTree();
+        }
+
         // Drag and drop (external files only - not internal moves)
+
+        // Suppress the full-screen overlay whenever the drag is anywhere over the sidebar.
+        document.getElementById('sidebar').addEventListener('dragover', (e) => {
+            if (!draggedItems) {
+                e.preventDefault();
+                e.stopPropagation();
+                e.dataTransfer.dropEffect = 'copy';
+                document.getElementById('drop-zone').classList.remove('show');
+            }
+        });
+
+        document.getElementById('sidebar').addEventListener('dragleave', (e) => {
+            // When leaving the sidebar entirely, clear any per-folder highlight.
+            if (!draggedItems && !e.currentTarget.contains(e.relatedTarget)) {
+                clearExtDropHighlight();
+            }
+        });
+
         document.addEventListener('dragover', (e) => {
             e.preventDefault();
-            // Only show drop zone for external file drags, not internal moves
             if (!draggedItems) {
+                // Tree item ondragover calls stopPropagation, so this only fires outside the tree
+                clearExtDropHighlight();
                 document.getElementById('drop-zone').classList.add('show');
             }
         });
 
         document.addEventListener('dragleave', (e) => {
             if (e.relatedTarget === null) {
+                clearExtDropHighlight();
                 document.getElementById('drop-zone').classList.remove('show');
             }
         });
 
         document.addEventListener('drop', async (e) => {
             e.preventDefault();
+            clearExtDropHighlight();
             document.getElementById('drop-zone').classList.remove('show');
-
-            // Only handle file uploads if not an internal drag
-            if (!draggedItems && e.dataTransfer.items && e.dataTransfer.items.length > 0) {
-                const entries = Array.from(e.dataTransfer.items)
-                    .map(item => item.webkitGetAsEntry?.())
-                    .filter(Boolean);
-
-                let succeeded = 0, failed = 0;
-                const dropState = { count: 0, capped: false };
-                const smartSort = currentPath === '';
-                const sortedPlacements = [];
-
-                for (const entry of entries) {
-                    const collected = await collectEntryFiles(entry, '', dropState);
-
-                    if (smartSort && entry.isFile) {
-                        // Single file at root: AI-classify and route to correct folder
-                        const { file } = collected[0] || {};
-                        if (!file) continue;
-                        const preview = await readTextPreview(file);
-                        const smartPath = await callSmartPlace(file.name, preview);
-                        try {
-                            const formData = new FormData();
-                            formData.append('file', file);
-                            const url = smartPath
-                                ? `/api/files?path=&relative_path=${encodeURIComponent(smartPath)}`
-                                : `/api/files?path=`;
-                            const res = await fetch(url, { method: 'POST', body: formData });
-                            if (!res.ok) { const err = await res.json(); throw new Error(err.detail); }
-                            succeeded++;
-                            if (smartPath) sortedPlacements.push({ name: file.name, dest: smartPath });
-                        } catch { failed++; }
-
-                    } else if (smartSort && entry.isDirectory) {
-                        // Folder at root: classify by contents, preserve internal structure
-                        const folderName = entry.name;
-                        const sampleNames = collected.slice(0, 30).map(({ file: f }) => f.name).join(', ');
-                        const smartFolderPath = await callSmartPlace(folderName, `Folder containing: ${sampleNames}`);
-                        // smartFolderPath = e.g. "notes/my-project"; base dir = "notes"
-                        const baseDir = smartFolderPath ? smartFolderPath.split('/')[0] : '';
-
-                        for (const { file, relPath } of collected) {
-                            // relPath already includes folderName (e.g. "my-project/src/main.py")
-                            const uploadPath = baseDir ? `${baseDir}/${relPath}` : relPath;
-                            try {
-                                const formData = new FormData();
-                                formData.append('file', file);
-                                const res = await fetch(
-                                    `/api/files?path=&relative_path=${encodeURIComponent(uploadPath)}`,
-                                    { method: 'POST', body: formData }
-                                );
-                                if (!res.ok) { const err = await res.json(); throw new Error(err.detail); }
-                                succeeded++;
-                            } catch { failed++; }
-                        }
-                        if (smartFolderPath) sortedPlacements.push({ name: folderName + '/', dest: smartFolderPath + '/' });
-
-                    } else {
-                        // Non-root drop: respect the user's chosen folder
-                        for (const { file, relPath } of collected) {
-                            try {
-                                const formData = new FormData();
-                                formData.append('file', file);
-                                const url = relPath.includes('/')
-                                    ? `/api/files?path=${encodeURIComponent(currentPath)}&relative_path=${encodeURIComponent(relPath)}`
-                                    : `/api/files?path=${encodeURIComponent(currentPath)}`;
-                                const res = await fetch(url, { method: 'POST', body: formData });
-                                if (!res.ok) { const err = await res.json(); throw new Error(err.detail); }
-                                succeeded++;
-                            } catch { failed++; }
-                        }
-                    }
-                }
-                appendSortNotification(sortedPlacements);
-
-                if (succeeded > 0) showToast(`Uploaded ${succeeded} file${succeeded !== 1 ? 's' : ''}`);
-                if (failed > 0) showToast(`${failed} file${failed !== 1 ? 's' : ''} failed`, true);
-                if (dropState.capped) showToast(`Folder too large — only first ${_MAX_UPLOAD_FILES} files uploaded`, true);
-                loadFiles(currentPath);
-                loadTree();
+            // Tree item ondrop calls stopPropagation for external drops, so this
+            // only fires when the drop lands outside the tree (main content area).
+            if (!draggedItems) {
+                await doExternalUpload(e.dataTransfer, currentPath);
             }
         });
 

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -6160,15 +6160,15 @@
                     showFileBrowser(path);
                 }
             } else {
-                // For files, open preview panel
-                openFilePreview(path);
-                // If already in browser view, navigate to the file's parent folder
+                // Navigate the browser panel to the file's parent folder first so
+                // showFileBrowser doesn't hide the preview we're about to open.
                 if (currentView === 'browser') {
                     const parentPath = path.split('/').slice(0, -1).join('/');
                     if (parentPath !== currentPath) {
                         showFileBrowser(parentPath);
                     }
                 }
+                openFilePreview(path);
             }
         }
 

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -5395,9 +5395,10 @@
         }
 
         const _MAX_UPLOAD_FILES = 500;
+        const _IGNORED_FILENAMES = new Set(['.DS_Store', 'Thumbs.db', 'desktop.ini', '.localized']);
 
         async function handleFolderSelect(event) {
-            const files = Array.from(event.target.files);
+            const files = Array.from(event.target.files).filter(f => !_IGNORED_FILENAMES.has(f.name));
             event.target.value = '';
             if (files.length === 0) return;
             const capped = files.length > _MAX_UPLOAD_FILES;
@@ -5533,6 +5534,7 @@
             const results = [];
             if (_state.capped) return results;
             if (entry.isFile) {
+                if (_IGNORED_FILENAMES.has(entry.name)) return results;
                 if (_state.count >= _MAX_UPLOAD_FILES) { _state.capped = true; return results; }
                 await new Promise(resolve => entry.file(f => {
                     _state.count++;


### PR DESCRIPTION
### Summary
  
  - Smart file placement: uploaded files and folders are automatically routed to notes/, media/, or history/ using AI classification. 
  - Folder-aware drag-and-drop: dragging over a tree folder highlights it as the drop target, and overrides smart sorting.
  - Sort notification as bot message: after smart placement the confirmation appears as a chat message with escaped filenames (prevents markdown injection).
  - Answer-tool chat loop: the chat engine now requires the model to call at least one tool per turn and use an explicit answer() tool to deliver its response. Generated content (poems, haikus, summaries, lists, code) is automatically written to notes/ before answer() is called.
  - media/ folder rename: resources/ replaced with media/ everywhere.
  - Single source of truth for folder semantics: SANTAI_FOLDER_DESCRIPTIONS added to core/project.py; both the smart-place AI prompt and the chat system prompt derive from it.
  - Bug fixes: get_response/get_response_sync no longer crash on tool calls (dict events filtered before join); duplicate guard now applies to smart-placed uploads (not just plain uploads); extensionless AI path suggestions now get the correct suffix appended; dropped tool_choice constraints are logged as warnings.
---
### Test plan

#### Smart placement
- [ ] Drag a .png onto the editor panel — verify it lands in media/ and the chat says "Uploaded 1 file: media/..."
- [ ] Drag a .md note onto the editor panel — verify it lands in notes/ 
- [ ] Drag a file onto a specific folder in the file tree — verify it lands in that folder with no chat message
- [ ] Use File Upload to select 2–3 files of different types — verify each lands in an appropriate folder, chat lists all paths, editor does not flicker between files
- [ ] Drag an OS folder onto a tree folder — verify it lands inside that folder with no chat message
- [ ] Click Folder Upload and select a folder — verify it is smart-sorted as a unit and the chat message references the folder, not a file inside it
- [ ] Upload the same file twice — verify the second upload is blocked (with toast message explaining it's a duplicate)

#### Chat / answer-tool loop
- [ ] Ask (ex) "write me a haiku about the ocean" — verify the AI chatbot creates a note for it
- [ ] Ask "write a summary of X and delete Y" — verify both steps complete before the final reply