### PR TITLE
fix: resolve lint, format, and type-check issues (#118)

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -9,7 +9,7 @@ permissions:
   contents: read
 jobs:
   lint:
-    name: lint + type check (warn-only)
+    name: lint + type check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
@@ -24,13 +24,10 @@ jobs:
       - name: Install dev deps
         run: uv sync --frozen
       - name: ruff check
-        continue-on-error: true
         run: uv run ruff check
       - name: ruff format --check
-        continue-on-error: true
         run: uv run ruff format --check
       - name: ty check
-        continue-on-error: true
         run: uv run ty check src
 
   build:

--- a/README.md
+++ b/README.md
@@ -163,12 +163,24 @@ A Santai project contains these directories:
 ```bash
 uv sync --group dev
 uv run santai --help
-ruff format .
-ruff check --fix .
 
 # Serve documentation locally
 uv run mkdocs serve
 ```
+
+### Linting, formatting, and type checking
+
+Run these from the repo root before opening a PR:
+
+```bash
+uv run ruff format .          # Format code
+uv run ruff check --fix .     # Lint with auto-fix
+uv run ty check src/          # Type check
+```
+
+To check formatting without applying changes (e.g. in CI), use `uv run ruff format --check .`.
+
+Pre-commit hooks (via [prek](https://prek.j178.dev/)) also run `ruff format` on commit.
 
 ### Source Layout
 

--- a/src/santai_cli/commands/auth.py
+++ b/src/santai_cli/commands/auth.py
@@ -113,7 +113,8 @@ def login(
             self.end_headers()
             self.wfile.write(
                 b"<html><body><h2>Authenticated!</h2>"
-                b"<p>You can close this tab and return to your terminal.</p></body></html>"
+                b"<p>You can close this tab and return to your terminal.</p>"
+                b"</body></html>"
             )
             got_callback.set()
 
@@ -141,7 +142,7 @@ def login(
     except KeyboardInterrupt:
         console.print("\n[yellow]Login cancelled.[/yellow]")
         server.server_close()
-        raise typer.Exit(1)
+        raise typer.Exit(1) from None
 
     server.server_close()
 
@@ -189,9 +190,8 @@ def whoami() -> None:
             data = json.loads(resp.read())
             user = data.get("user", {})
             session = data.get("session", {})
-            console.print(
-                f"Logged in as [bold]{user.get('username', creds.get('username', 'unknown'))}[/bold]"
-            )
+            username = user.get("username", creds.get("username", "unknown"))
+            console.print(f"Logged in as [bold]{username}[/bold]")
             console.print(f"  Name:  {user.get('name', 'N/A')}")
             console.print(f"  Email: {user.get('email', 'N/A')}")
             console.print(f"  Hub:   [dim]{hub}[/dim]")
@@ -200,14 +200,17 @@ def whoami() -> None:
     except urllib.error.HTTPError as e:
         if e.code == 401:
             console.print(
-                "[yellow]Session expired. Run [bold]santai login[/bold] to re-authenticate.[/yellow]"
+                "[yellow]Session expired. Run [bold]santai login[/bold] "
+                "to re-authenticate.[/yellow]"
             )
             _clear_credentials()
-            raise typer.Exit(1)
+            raise typer.Exit(1) from e
         console.print(f"[red]Failed to verify session: HTTP {e.code}[/red]")
-        raise typer.Exit(1)
+        raise typer.Exit(1) from e
     except (urllib.error.URLError, TimeoutError):
+        username = creds.get("username", "unknown")
         console.print(
-            f"Logged in as [bold]{creds.get('username', 'unknown')}[/bold]  [dim](offline — could not reach hub)[/dim]"
+            f"Logged in as [bold]{username}[/bold]  "
+            "[dim](offline — could not reach hub)[/dim]"
         )
         console.print(f"  Hub: [dim]{hub}[/dim]")

--- a/src/santai_cli/commands/chat.py
+++ b/src/santai_cli/commands/chat.py
@@ -424,6 +424,8 @@ def _stream_assistant_response(state: _ChatState) -> str | None:
                     provider_config,
                     state.model,
                 ):
+                    if not isinstance(chunk, str):
+                        continue
                     full_text += chunk
                     live.update(Markdown(full_text))
                 return full_text

--- a/src/santai_cli/commands/pull.py
+++ b/src/santai_cli/commands/pull.py
@@ -71,17 +71,18 @@ def pull(
     except urllib.error.HTTPError as e:
         if e.code == 401:
             console.print(
-                "[yellow]Session expired. Run [bold]santai login[/bold] to re-authenticate.[/yellow]"
+                "[yellow]Session expired. Run [bold]santai login[/bold] "
+                "to re-authenticate.[/yellow]"
             )
-            raise typer.Exit(1)
+            raise typer.Exit(1) from e
         if e.code == 404:
             console.print(f"[red]Project '{name}' not found.[/red]")
-            raise typer.Exit(1)
+            raise typer.Exit(1) from e
         console.print(f"[red]Pull failed (HTTP {e.code})[/red]")
-        raise typer.Exit(1)
-    except (urllib.error.URLError, TimeoutError):
+        raise typer.Exit(1) from e
+    except (urllib.error.URLError, TimeoutError) as e:
         console.print("[red]Could not reach the hub. Check your connection.[/red]")
-        raise typer.Exit(1)
+        raise typer.Exit(1) from e
 
     download_url = data.get("downloadUrl")
     if not download_url:
@@ -109,12 +110,12 @@ def pull(
                 member_path = (dest_path / member.filename).resolve()
                 try:
                     member_path.relative_to(dest_path.resolve())
-                except ValueError:
+                except ValueError as ve:
                     console.print(
                         "[red]Error: Zip contains unsafe path "
                         f"'{member.filename}'[/red]"
                     )
-                    raise typer.Exit(1)
+                    raise typer.Exit(1) from ve
                 # Reject symlinks (type_flag 'l' via external_attr or compress_type)
                 if member.external_attr >> 28 == 0xA:
                     console.print(
@@ -124,17 +125,17 @@ def pull(
             zf.extractall(dest_path)
 
         console.print(f"[green]Pulled [bold]{name}[/bold] to {dest_path}[/green]")
-    except (urllib.error.URLError, TimeoutError):
+    except (urllib.error.URLError, TimeoutError) as e:
         console.print(
             "[red]Download failed. The URL may have expired — try again.[/red]"
         )
         if dest_path.exists() and not any(dest_path.iterdir()):
             dest_path.rmdir()
-        raise typer.Exit(1)
-    except zipfile.BadZipFile:
+        raise typer.Exit(1) from e
+    except zipfile.BadZipFile as e:
         console.print("[red]Downloaded file is not a valid zip.[/red]")
         if dest_path.exists() and not any(dest_path.iterdir()):
             dest_path.rmdir()
-        raise typer.Exit(1)
+        raise typer.Exit(1) from e
     finally:
         tmp_path.unlink(missing_ok=True)

--- a/src/santai_cli/commands/push.py
+++ b/src/santai_cli/commands/push.py
@@ -133,8 +133,10 @@ def push(
         body_parts: list[bytes] = []
 
         body_parts.append(f"--{boundary}\r\n".encode())
+        filename = f"{quote(project_name)}.zip"
         body_parts.append(
-            f'Content-Disposition: form-data; name="file"; filename="{quote(project_name)}.zip"\r\n'.encode()
+            f'Content-Disposition: form-data; name="file"; '
+            f'filename="{filename}"\r\n'.encode()
         )
         body_parts.append(b"Content-Type: application/zip\r\n\r\n")
         body_parts.append(zip_bytes)
@@ -164,9 +166,10 @@ def push(
         except urllib.error.HTTPError as e:
             if e.code == 401:
                 console.print(
-                    "[yellow]Session expired. Run [bold]santai login[/bold] to re-authenticate.[/yellow]"
+                    "[yellow]Session expired. Run [bold]santai login[/bold] "
+                    "to re-authenticate.[/yellow]"
                 )
-                raise typer.Exit(1)
+                raise typer.Exit(1) from e
             body_text = e.read().decode(errors="replace")
             try:
                 err_data = json.loads(body_text)
@@ -174,9 +177,9 @@ def push(
             except json.JSONDecodeError:
                 msg = body_text
             console.print(f"[red]Push failed (HTTP {e.code}): {msg}[/red]")
-            raise typer.Exit(1)
-        except (urllib.error.URLError, TimeoutError):
+            raise typer.Exit(1) from e
+        except (urllib.error.URLError, TimeoutError) as e:
             console.print("[red]Could not reach the hub. Check your connection.[/red]")
-            raise typer.Exit(1)
+            raise typer.Exit(1) from e
     finally:
         tmp_path.unlink(missing_ok=True)

--- a/src/santai_cli/core/chat.py
+++ b/src/santai_cli/core/chat.py
@@ -54,7 +54,9 @@ TOOLS = [
             "properties": {
                 "filepath": {
                     "type": "string",
-                    "description": "The file path to write to (relative to project root)",
+                    "description": (
+                        "The file path to write to (relative to project root)"
+                    ),
                 },
                 "content": {
                     "type": "string",
@@ -101,7 +103,9 @@ TOOLS = [
             "properties": {
                 "path": {
                     "type": "string",
-                    "description": "The directory path to create (relative to project root)",
+                    "description": (
+                        "The directory path to create (relative to project root)"
+                    ),
                 },
             },
             "required": ["path"],
@@ -124,20 +128,26 @@ TOOLS = [
     {
         "name": "remove_dir",
         "description": (
-            "Remove a directory. If the directory is empty, it is deleted immediately. "
-            "If it has contents, the tool returns a warning — relay the warning to the user "
-            "and ask for confirmation. Once the user confirms, call again with confirmed=true."
+            "Remove a directory. If the directory is empty, it is deleted "
+            "immediately. If it has contents, the tool returns a warning — relay "
+            "the warning to the user and ask for confirmation. Once the user "
+            "confirms, call again with confirmed=true."
         ),
         "input_schema": {
             "type": "object",
             "properties": {
                 "path": {
                     "type": "string",
-                    "description": "The directory path to remove (relative to project root)",
+                    "description": (
+                        "The directory path to remove (relative to project root)"
+                    ),
                 },
                 "confirmed": {
                     "type": "boolean",
-                    "description": "Set to true after the user has confirmed deletion of a non-empty directory.",
+                    "description": (
+                        "Set to true after the user has confirmed deletion of a "
+                        "non-empty directory."
+                    ),
                 },
             },
             "required": ["path"],
@@ -145,7 +155,10 @@ TOOLS = [
     },
     {
         "name": "move",
-        "description": "Move a file or directory to a new location. Prefer this over manually copying and deleting.",
+        "description": (
+            "Move a file or directory to a new location. Prefer this over "
+            "manually copying and deleting."
+        ),
         "input_schema": {
             "type": "object",
             "properties": {
@@ -573,9 +586,10 @@ def _tool_read_file(tool_call: dict[str, Any], project_root: Path | None) -> str
         content = path.read_text(encoding="utf-8")
         max_len = 100000
         if len(content) > max_len:
-            content = (
-                content[:max_len]
-                + f"\n... (truncated: true, showed {max_len} of {len(content)} total bytes — use read_file with start_line/end_line to read a specific range)"
+            content = content[:max_len] + (
+                f"\n... (truncated: true, showed {max_len} of {len(content)} "
+                "total bytes — use read_file with start_line/end_line to read "
+                "a specific range)"
             )
         return content
     except Exception as e:
@@ -735,7 +749,8 @@ async def get_response(
     """
     chunks: list[str] = []
     async for chunk in stream_response(session, provider, provider_config, model):
-        chunks.append(chunk)
+        if isinstance(chunk, str):
+            chunks.append(chunk)
     return "".join(chunks)
 
 

--- a/src/santai_cli/core/project.py
+++ b/src/santai_cli/core/project.py
@@ -1,5 +1,6 @@
 """Project detection and data loading for Santai projects."""
 
+import contextlib
 import math
 import re
 from collections import Counter
@@ -509,7 +510,8 @@ _STOP_WORDS = frozenset(
 )
 
 _MARKDOWN_STRIP = re.compile(
-    r"```.*?```|`[^`]+`|\[([^\]]+)\]\([^)]+\)|\[\[([^\]|]+)(?:\|[^\]]+)?\]\]|#{1,6} |[*_~]",
+    r"```.*?```|`[^`]+`|\[([^\]]+)\]\([^)]+\)"
+    r"|\[\[([^\]|]+)(?:\|[^\]]+)?\]\]|#{1,6} |[*_~]",
     re.DOTALL,
 )
 
@@ -664,10 +666,8 @@ def _add_file_to_graph(
         file_map[file_id] = file_path
 
         if file_path.suffix.lower() in text_extensions:
-            try:
+            with contextlib.suppress(UnicodeDecodeError):
                 file_contents[file_id] = file_path.read_text(encoding="utf-8")
-            except UnicodeDecodeError:
-                pass
 
     except (OSError, ValueError):
         pass

--- a/src/santai_cli/core/repo_context.py
+++ b/src/santai_cli/core/repo_context.py
@@ -138,11 +138,25 @@ def build_repo_context_prompt(context: RepoContext) -> str:
         [
             "",
             "## Important Guidelines",
-            "- You can see the file tree above, but you do NOT have the file contents in context.",
-            "- IMPORTANT: Whenever a user asks a question that could be answered by a file in this project (notes, media, history, or any other file), you MUST call read_file to read the relevant file(s) before answering. Never answer knowledge-base questions from memory — always fetch fresh content with the tool.",
+            (
+                "- You can see the file tree above, but you do NOT have the "
+                "file contents in context."
+            ),
+            (
+                "- IMPORTANT: Whenever a user asks a question that could be "
+                "answered by a file in this project (notes, media, history, or "
+                "any other file), you MUST call read_file to read the relevant "
+                "file(s) before answering. Never answer knowledge-base "
+                "questions from memory — always fetch fresh content with the "
+                "tool."
+            ),
             "- If multiple files might be relevant, read each one before responding.",
             "- Use [[wikilinks]] or markdown links when referencing project files.",
-            "- IMPORTANT: If a read_file result includes 'truncated: true', the file was cut off. Acknowledge this to the user rather than treating the partial content as complete.",
+            (
+                "- IMPORTANT: If a read_file result includes 'truncated: "
+                "true', the file was cut off. Acknowledge this to the user "
+                "rather than treating the partial content as complete."
+            ),
         ]
     )
 
@@ -150,7 +164,11 @@ def build_repo_context_prompt(context: RepoContext) -> str:
         [
             "",
             "## Available Tools",
-            "You have access to the following tools. WHEN THE USER ASKS YOU TO CREATE OR WRITE A FILE, YOU MUST USE THE write_file TOOL - DO NOT JUST TELL THEM HOW TO DO IT:",
+            (
+                "You have access to the following tools. WHEN THE USER ASKS "
+                "YOU TO CREATE OR WRITE A FILE, YOU MUST USE THE write_file "
+                "TOOL - DO NOT JUST TELL THEM HOW TO DO IT:"
+            ),
             "",
             "- **write_file**: Write content to a file. Creates directories as needed.",
             "  Arguments: filepath (string), content (string)",
@@ -165,17 +183,34 @@ def build_repo_context_prompt(context: RepoContext) -> str:
             "- **mkdir**: Create a directory. Creates parent directories as needed.",
             "  Arguments: path (string)",
             "",
-            "- **move**: Move a file or directory to a new location. Prefer this over manually copying and deleting.",
+            (
+                "- **move**: Move a file or directory to a new location. "
+                "Prefer this over manually copying and deleting."
+            ),
             "  Arguments: source (string), destination (string)",
             "",
             "- **remove_file**: Remove a file.",
             "  Arguments: filepath (string)",
             "",
-            "- **remove_dir**: Remove a directory. If empty, deletes immediately. If non-empty, the tool returns a CONFIRM_REQUIRED message — show only that message to the user (do not add any preamble or narration), then wait for confirmation before calling again with confirmed=true.",
+            (
+                "- **remove_dir**: Remove a directory. If empty, deletes "
+                "immediately. If non-empty, the tool returns a "
+                "CONFIRM_REQUIRED message — show only that message to the user "
+                "(do not add any preamble or narration), then wait for "
+                "confirmation before calling again with confirmed=true."
+            ),
             "  Arguments: path (string), confirmed (boolean, optional)",
             "",
-            "IMPORTANT: When the user asks you to create, write, or edit a file, use the write_file tool - do not describe how to do it or suggest commands.",
-            "IMPORTANT: For remove_dir, call the tool first without narrating — do not say you are about to delete anything. Let the tool result determine what to say.",
+            (
+                "IMPORTANT: When the user asks you to create, write, or edit a "
+                "file, use the write_file tool - do not describe how to do it "
+                "or suggest commands."
+            ),
+            (
+                "IMPORTANT: For remove_dir, call the tool first without "
+                "narrating — do not say you are about to delete anything. Let "
+                "the tool result determine what to say."
+            ),
         ]
     )
 

--- a/src/santai_cli/tui/app.py
+++ b/src/santai_cli/tui/app.py
@@ -107,9 +107,7 @@ class StatsPanel(Static):
         dir_table.add_row(
             "[bold]Total[/bold]",
             f"[bold]{
-                stats.media_count
-                + stats.history_count
-                + stats.notes_count
+                stats.media_count + stats.history_count + stats.notes_count
             }[/bold]",
         )
         dir_table.add_row("Size", format_size(stats.total_size_bytes))
@@ -1792,6 +1790,8 @@ class ChatScreen(ModalScreen):
             async for chunk in stream_response(
                 self._session, self._provider, provider_config, self._model
             ):
+                if not isinstance(chunk, str):
+                    continue
                 full_text += chunk
                 # RichLog doesn't support in-place updates easily,
                 # so we write chunks as they arrive

--- a/src/santai_cli/web/app.py
+++ b/src/santai_cli/web/app.py
@@ -960,8 +960,8 @@ def create_app(project: SantaiProject) -> FastAPI:
         provider_errors: dict[str, dict[str, str]] = {}
         for provider_name, provider_config in config.providers.items():
 
-            def _err(kind: str) -> dict[str, str]:
-                return {"type": kind, "display": provider_config.name}
+            def _err(kind: str, pc=provider_config) -> dict[str, str]:
+                return {"type": kind, "display": pc.name}
 
             if provider_config.base_url:
                 # Fetch model list from LiteLLM proxy
@@ -1054,10 +1054,11 @@ def create_app(project: SantaiProject) -> FastAPI:
         seen: set[str] = set()
         deduped: list[dict[str, str | bool]] = []
         for m in models:
-            if m["display"] not in seen:
-                seen.add(m["display"])
+            display = str(m["display"])
+            if display not in seen:
+                seen.add(display)
                 deduped.append(m)
-        deduped.sort(key=lambda m: m["display"].lower())
+        deduped.sort(key=lambda m: str(m["display"]).lower())
         return {
             "models": deduped,
             "configured": config.has_any_provider,
@@ -1202,7 +1203,9 @@ def create_app(project: SantaiProject) -> FastAPI:
         # Read existing values
         existing: dict[str, str] = {}
         if env_path.is_file():
-            existing = dict(dotenv_values(env_path))
+            existing = {
+                k: v for k, v in dotenv_values(env_path).items() if v is not None
+            }
 
         # Update with new values (empty string = leave unchanged)
         if req.anthropic_api_key is not None and req.anthropic_api_key.strip():


### PR DESCRIPTION
## Summary
- Closes #118
- Resolves 39 ruff lint errors and 5 ty type errors that had accumulated on `main`
- Documents how to run the checks locally in [README.md](README.md)
- Promotes the `lint + type check` job in [smoke-test.yml](.github/workflows/smoke-test.yml) from warn-only to enforced

## Lint and type-check fixes
- **B904** (13 fixes): added `from err` / `from None` to `raise typer.Exit(1)` inside `except` blocks across `commands/auth.py`, `commands/pull.py`, `commands/push.py`
- **E501** (24 fixes): wrapped long string literals in `core/chat.py` (tool descriptions), `core/repo_context.py` (system prompt sections), `core/project.py`, `commands/auth.py`, `commands/push.py`
- **B023** (1 fix): bound loop variable `provider_config` via default arg in the nested `_err` closure in `web/app.py`
- **SIM105** (1 fix): replaced `try/except UnicodeDecodeError/pass` with `contextlib.suppress(...)` in `core/project.py`
- **ty unsupported-operator/invalid-argument-type** (3 fixes): `stream_response` yields `str | dict`, but consumers in `commands/chat.py`, `core/chat.py`, and `tui/app.py` were treating every chunk as `str` — added `isinstance(chunk, str)` guards before concatenation
- **ty invalid-argument-type** (1 fix): coerce dict values to `str` before set membership / sort key in `web/app.py` `chat_models` endpoint
- **ty invalid-assignment** (1 fix): filter `None` values out of `dotenv_values()` result in `web/app.py` `save_settings` endpoint
- Reformatting fix to `tui/app.py` `StatsPanel` total expression that was already pending on `main`

## Docs
- New "Linting, formatting, and type checking" subsection in [README.md](README.md) with the `uv run ruff format`, `uv run ruff check --fix`, `uv run ty check src/`, and `ruff format --check` commands

## CI
- Removed `continue-on-error: true` from the `ruff check`, `ruff format --check`, and `ty check src` steps in the smoke-test workflow's `lint` job
- Renamed the job from `lint + type check (warn-only)` to `lint + type check` — failures now block the build
- Suggested follow-up: add `lint + type check` as a required status check in branch protection rules

## Test plan
- [ ] Run `uv run ruff check .` — All checks passed
- [ ] Run `uv run ruff format --check .` — .. files already formatted
- [ ] Run `uv run ty check src/` — All checks passed
- [ ] Smoke test: `santai init` and `--help` flows still work as expected