### PR TITLE
feat: push to cloud, pull from cloud in web ui

### DIFF
--- a/src/santai_cli/commands/auth.py
+++ b/src/santai_cli/commands/auth.py
@@ -172,7 +172,7 @@ def whoami() -> None:
     import urllib.error
     import urllib.request
 
-    from santai_cli.core.hub import USER_AGENT
+    from santai_cli.core.hub import USER_AGENT, get_backend_url
 
     creds = load_credentials()
     if not creds:
@@ -180,11 +180,11 @@ def whoami() -> None:
         raise typer.Exit(1)
 
     hub = creds.get("hub_url", DEFAULT_HUB_URL)
-    backend = hub.replace(":3000", ":3001") if ":3000" in hub else hub
+    backend = get_backend_url(hub)
 
     try:
         req = urllib.request.Request(
-            f"{backend}/api/auth/get-session",
+            f"{backend}/auth/get-session",
             headers={
                 "Authorization": f"Bearer {creds['token']}",
                 "User-Agent": USER_AGENT,

--- a/src/santai_cli/commands/pull.py
+++ b/src/santai_cli/commands/pull.py
@@ -55,7 +55,7 @@ def pull(
 
     console.print(f"Looking up [bold]{name}[/bold]...")
 
-    base_id = resolve_base_id(backend, creds["token"], name)
+    base_id = resolve_base_id(backend, creds["token"], name, creds.get("username", ""))
     if not base_id:
         console.print(f"[red]Project '{name}' not found.[/red]")
         raise typer.Exit(1)

--- a/src/santai_cli/commands/push.py
+++ b/src/santai_cli/commands/push.py
@@ -13,7 +13,12 @@ import typer
 from rich.console import Console
 
 from santai_cli.commands.auth import DEFAULT_HUB_URL, load_credentials
-from santai_cli.core.hub import USER_AGENT, create_base, get_backend_url, resolve_base_id
+from santai_cli.core.hub import (
+    USER_AGENT,
+    create_base,
+    get_backend_url,
+    resolve_base_id,
+)
 
 console = Console()
 
@@ -92,7 +97,9 @@ def push(
 
     console.print(f"Looking up [bold]{project_name}[/bold]...")
 
-    base_id = resolve_base_id(backend, creds["token"], project_name)
+    base_id = resolve_base_id(
+        backend, creds["token"], project_name, creds.get("username", "")
+    )
     if not base_id:
         console.print(f"  Not found — creating [bold]{project_name}[/bold]...")
         base_id = create_base(backend, creds["token"], project_name)

--- a/src/santai_cli/core/hub.py
+++ b/src/santai_cli/core/hub.py
@@ -14,7 +14,10 @@ USER_AGENT = f"santai-cli/{_CLI_VERSION}"
 
 
 def get_backend_url(hub_url: str) -> str:
-    return hub_url.replace(":3000", ":3001") if ":3000" in hub_url else hub_url
+    if ":3000" in hub_url:
+        return hub_url.replace(":3000", ":3001")
+    # Production hub: API routes live under /api
+    return hub_url.rstrip("/") + "/api"
 
 
 def create_base(backend: str, token: str, name: str) -> str | None:

--- a/src/santai_cli/core/hub.py
+++ b/src/santai_cli/core/hub.py
@@ -56,7 +56,16 @@ def resolve_base_id(backend: str, token: str, name: str) -> str | None:
     try:
         with urllib.request.urlopen(req, timeout=15) as resp:
             data = json.loads(resp.read())
-    except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError):
+    except urllib.error.HTTPError as e:
+        # Hub returns 401 with a valid JSON body when the user has no bases yet.
+        if e.code == 401:
+            try:
+                data = json.loads(e.read().decode("utf-8", errors="replace"))
+            except Exception:
+                return None
+        else:
+            return None
+    except (urllib.error.URLError, TimeoutError):
         return None
 
     for base in data.get("bases", []):

--- a/src/santai_cli/core/hub.py
+++ b/src/santai_cli/core/hub.py
@@ -44,31 +44,23 @@ def create_base(backend: str, token: str, name: str) -> str | None:
         return None
 
 
-def resolve_base_id(backend: str, token: str, name: str) -> str | None:
+def resolve_base_id(backend: str, token: str, name: str, username: str) -> str | None:
     """Return the base ID for the authenticated user's base with the given name."""
     import urllib.error
     import urllib.request
+    from urllib.parse import quote
 
     req = urllib.request.Request(
-        f"{backend}/me/bases",
+        f"{backend}/bases?author={quote(username)}",
         headers={"Authorization": f"Bearer {token}", "User-Agent": USER_AGENT},
     )
     try:
         with urllib.request.urlopen(req, timeout=15) as resp:
             data = json.loads(resp.read())
-    except urllib.error.HTTPError as e:
-        # Hub returns 401 with a valid JSON body when the user has no bases yet.
-        if e.code == 401:
-            try:
-                data = json.loads(e.read().decode("utf-8", errors="replace"))
-            except Exception:
-                return None
-        else:
-            return None
-    except (urllib.error.URLError, TimeoutError):
+    except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError):
         return None
 
-    for base in data.get("bases", []):
+    for base in data.get("data", []):
         if base.get("name") == name:
             return str(base["id"])
     return None

--- a/src/santai_cli/core/repo_context.py
+++ b/src/santai_cli/core/repo_context.py
@@ -150,6 +150,7 @@ def build_repo_context_prompt(context: RepoContext) -> str:
             "- Use [[wikilinks]] or markdown links when referencing project files.",
             "- IMPORTANT: If a read_file result includes 'truncated: true', the file was cut off. Acknowledge this to the user rather than treating the partial content as complete.",
             "- IMPORTANT: For multi-step requests (e.g. 'delete X and write Y'): complete EVERY step before calling answer(). Do not call answer() after only the first step.",
+            "- Cloud sync: This project can be synced with Santai Cloud. The chat intercepts these requests automatically — if the user asks to push/save to the cloud or pull/load from the cloud, the action executes directly. If asked how to sync, tell the user they can say 'push to cloud' or 'pull from cloud'.",
         ]
     )
 

--- a/src/santai_cli/web/app.py
+++ b/src/santai_cli/web/app.py
@@ -1466,6 +1466,51 @@ def create_app(project: SantaiProject) -> FastAPI:
 
         return {"status": "saved"}
 
+    # === Auth callback (handles redirect from hub after browser login) ===
+
+    # Holds the hub URL that initiated the most recent in-progress login so
+    # the /callback handler can save credentials against the right hub.
+    _pending_hub_url: list[str] = ["https://hub.sant.ai"]
+
+    @app.get("/callback")
+    async def auth_callback(
+        token: str = Query(default=None),
+        username: str = Query(default=None),
+    ) -> HTMLResponse:
+        """Receive the token redirect from the hub after browser-based login."""
+        from santai_cli.commands.auth import _save_credentials
+
+        if token:
+            _save_credentials(token, username or "", _pending_hub_url[0])
+
+        html = """<!DOCTYPE html>
+<html>
+<head><title>Santai — Signed in</title>
+<style>body{font-family:sans-serif;display:flex;align-items:center;justify-content:center;height:100vh;margin:0;background:#0f0f0f;color:#e5e5e5}</style>
+</head>
+<body>
+<div style="text-align:center">
+  <p style="font-size:1.2rem">Signed in successfully. You can close this tab.</p>
+</div>
+<script>
+  if (window.opener) { window.opener.postMessage('santai-signed-in', '*'); }
+  setTimeout(function(){ window.close(); }, 1500);
+</script>
+</body>
+</html>"""
+        return HTMLResponse(html)
+
+    @app.get("/api/cloud/login-url")
+    async def cloud_login_url(request: Request) -> dict[str, str]:
+        """Return the hub auth URL that will callback to this app's port."""
+        from santai_cli.commands.auth import DEFAULT_HUB_URL, load_credentials
+
+        creds = load_credentials()
+        hub = creds.get("hub_url", DEFAULT_HUB_URL) if creds else DEFAULT_HUB_URL
+        _pending_hub_url[0] = hub
+        port = request.url.port or 80
+        return {"url": f"{hub}/auth/cli?callback_port={port}"}
+
     # === Cloud Push / Pull Endpoints ===
 
     _CLOUD_IGNORED_DIRS = {
@@ -1493,10 +1538,17 @@ def create_app(project: SantaiProject) -> FastAPI:
         """Return whether the user is logged in to the Santai cloud."""
         from santai_cli.commands.auth import load_credentials
 
+        from santai_cli.commands.auth import DEFAULT_HUB_URL
+
         creds = load_credentials()
+        hub_url = creds.get("hub_url", DEFAULT_HUB_URL) if creds else DEFAULT_HUB_URL
         if not creds:
-            return {"logged_in": False, "username": None}
-        return {"logged_in": True, "username": creds.get("username")}
+            return {"logged_in": False, "username": None, "hub_url": hub_url}
+        return {
+            "logged_in": True,
+            "username": creds.get("username"),
+            "hub_url": hub_url,
+        }
 
     @app.post("/api/cloud/push")
     async def cloud_push(req: CloudPushRequest) -> StreamingResponse:
@@ -1529,8 +1581,10 @@ def create_app(project: SantaiProject) -> FastAPI:
             except Exception:
                 return f"Server error {e.code}."
 
-        def _resolve_or_create(backend: str, token: str, name: str) -> "str | str":
-            """Return (base_id, None) on success or (None, error_message) on failure."""
+        def _resolve_or_create(
+            backend: str, token: str, name: str, hub_url: str
+        ) -> "tuple[str | None, str | None, str | None]":
+            """Return (base_id, None, None) on success or (None, message, login_url) on failure."""
             auth = {"Authorization": f"Bearer {token}", "User-Agent": USER_AGENT}
             # Look up existing base
             try:
@@ -1539,11 +1593,12 @@ def create_app(project: SantaiProject) -> FastAPI:
                     data = _json.loads(resp.read())
                 for base in data.get("bases", []):
                     if base.get("name") == name:
-                        return str(base["id"]), None
+                        return str(base["id"]), None, None
             except urllib.error.HTTPError as e:
-                return None, _http_error_msg(e)
+                login_url = hub_url if e.code in (401, 403) else None
+                return None, _http_error_msg(e), login_url
             except (urllib.error.URLError, TimeoutError):
-                return None, "Could not reach the hub. Check your connection."
+                return None, "Could not reach the hub. Check your connection.", None
             # Not found — create it
             body = _json.dumps({"name": name}).encode()
             try:
@@ -1556,20 +1611,29 @@ def create_app(project: SantaiProject) -> FastAPI:
                 with urllib.request.urlopen(req_create, timeout=30) as resp:
                     data = _json.loads(resp.read())
                     if "id" in data:
-                        return str(data["id"]), None
-                    return None, f"Unexpected response creating '{name}'."
+                        return str(data["id"]), None, None
+                    return None, f"Unexpected response creating '{name}'.", None
             except urllib.error.HTTPError as e:
-                return None, f"Could not create '{name}': {_http_error_msg(e)}"
+                login_url = hub_url if e.code in (401, 403) else None
+                return (
+                    None,
+                    f"Could not create '{name}': {_http_error_msg(e)}",
+                    login_url,
+                )
             except (urllib.error.URLError, TimeoutError):
-                return None, "Could not reach the hub. Check your connection."
+                return None, "Could not reach the hub. Check your connection.", None
 
         async def event_gen():
             creds = load_credentials()
+            hub_url = (
+                creds.get("hub_url", DEFAULT_HUB_URL) if creds else DEFAULT_HUB_URL
+            )
             if not creds:
                 yield _sse(
                     {
                         "type": "error",
                         "message": "Not logged in. Run 'santai login' first.",
+                        "login_url": hub_url,
                     }
                 )
                 return
@@ -1579,15 +1643,18 @@ def create_app(project: SantaiProject) -> FastAPI:
                 ignored_files.discard(".env")
 
             project_name = project.name
-            backend = get_backend_url(creds.get("hub_url", DEFAULT_HUB_URL))
+            backend = get_backend_url(hub_url)
 
             yield _sse({"type": "status", "message": f"Looking up {project_name}..."})
 
-            base_id, err = await asyncio.to_thread(
-                _resolve_or_create, backend, creds["token"], project_name
+            base_id, err, login_url = await asyncio.to_thread(
+                _resolve_or_create, backend, creds["token"], project_name, hub_url
             )
             if err:
-                yield _sse({"type": "error", "message": err})
+                event: dict = {"type": "error", "message": err}
+                if login_url:
+                    event["login_url"] = login_url
+                yield _sse(event)
                 return
 
             yield _sse({"type": "status", "message": "Packaging..."})
@@ -1672,7 +1739,10 @@ def create_app(project: SantaiProject) -> FastAPI:
 
             upload_result = await asyncio.to_thread(upload, zip_bytes)
             if isinstance(upload_result, str):
-                yield _sse({"type": "error", "message": upload_result})
+                err_event: dict = {"type": "error", "message": upload_result}
+                if "login" in upload_result.lower():
+                    err_event["login_url"] = hub_url
+                yield _sse(err_event)
                 return
 
             yield _sse({"type": "done", "version": upload_result.get("version", "?")})
@@ -1704,18 +1774,22 @@ def create_app(project: SantaiProject) -> FastAPI:
 
         async def event_gen():
             creds = load_credentials()
+            hub_url = (
+                creds.get("hub_url", DEFAULT_HUB_URL) if creds else DEFAULT_HUB_URL
+            )
             if not creds:
                 yield _sse(
                     {
                         "type": "error",
                         "message": "Not logged in. Run 'santai login' first.",
+                        "login_url": hub_url,
                     }
                 )
                 return
 
             project_name = project.root.name
             dest_path = project.root.resolve()
-            backend = get_backend_url(creds.get("hub_url", DEFAULT_HUB_URL))
+            backend = get_backend_url(hub_url)
 
             yield _sse({"type": "status", "message": f"Looking up {project_name}..."})
 
@@ -1753,7 +1827,10 @@ def create_app(project: SantaiProject) -> FastAPI:
 
             info = await asyncio.to_thread(get_download_info)
             if isinstance(info, str):
-                yield _sse({"type": "error", "message": info})
+                pull_err: dict = {"type": "error", "message": info}
+                if "login" in info.lower():
+                    pull_err["login_url"] = hub_url
+                yield _sse(pull_err)
                 return
 
             download_url = info.get("downloadUrl")

--- a/src/santai_cli/web/app.py
+++ b/src/santai_cli/web/app.py
@@ -1737,6 +1737,12 @@ def create_app(project: SantaiProject) -> FastAPI:
                             if member.external_attr >> 28 == 0xA:
                                 return f"Zip contains symlink '{member.filename}'."
                             plan.append((member, target))
+                        # Preserve sensitive local files that are never pushed
+                        preserved: dict[Path, bytes] = {}
+                        for fname in _CLOUD_SENSITIVE:
+                            p = dest_path / fname
+                            if p.is_file():
+                                preserved[p] = p.read_bytes()
                         # Clear existing contents so files absent from the cloud are removed
                         for item in dest_path.iterdir():
                             if item.is_dir():
@@ -1747,6 +1753,9 @@ def create_app(project: SantaiProject) -> FastAPI:
                         for member, target in plan:
                             target.parent.mkdir(parents=True, exist_ok=True)
                             target.write_bytes(zf.read(member))
+                        # Restore preserved files
+                        for p, data in preserved.items():
+                            p.write_bytes(data)
                     return None
                 except zipfile.BadZipFile:
                     return "Downloaded file is not a valid zip."

--- a/src/santai_cli/web/app.py
+++ b/src/santai_cli/web/app.py
@@ -77,8 +77,7 @@ class CloudPushRequest(BaseModel):
 
 
 class CloudPullRequest(BaseModel):
-    name: str
-    dest: str | None = None
+    pass
 
 
 class SmartPlaceRequest(BaseModel):
@@ -1634,7 +1633,7 @@ def create_app(project: SantaiProject) -> FastAPI:
 
     @app.post("/api/cloud/pull")
     async def cloud_pull(req: CloudPullRequest) -> StreamingResponse:
-        """Pull a project from the cloud into a sibling directory, streaming SSE progress."""
+        """Pull the current project from the cloud, overwriting local files in place."""
         import asyncio
         import json as _json
         import urllib.error
@@ -1658,34 +1657,25 @@ def create_app(project: SantaiProject) -> FastAPI:
                 )
                 return
 
-            if req.dest:
-                dest_path = (project.root.parent / req.dest).resolve()
-            else:
-                dest_path = (project.root.parent / req.name).resolve()
+            project_name = project.root.name
+            dest_path = project.root.resolve()
+            backend = get_backend_url(creds.get("hub_url", DEFAULT_HUB_URL))
 
-            if dest_path.exists():
+            yield _sse({"type": "status", "message": f"Looking up {project_name}..."})
+
+            base_id = await asyncio.to_thread(
+                resolve_base_id, backend, creds["token"], project_name
+            )
+            if not base_id:
                 yield _sse(
                     {
                         "type": "error",
-                        "message": f"'{dest_path.name}' already exists in {dest_path.parent}.",
+                        "message": f"Project '{project_name}' not found in the cloud.",
                     }
                 )
                 return
 
-            backend = get_backend_url(creds.get("hub_url", DEFAULT_HUB_URL))
-
-            yield _sse({"type": "status", "message": f"Looking up {req.name}..."})
-
-            base_id = await asyncio.to_thread(
-                resolve_base_id, backend, creds["token"], req.name
-            )
-            if not base_id:
-                yield _sse(
-                    {"type": "error", "message": f"Project '{req.name}' not found."}
-                )
-                return
-
-            def get_download_info() -> dict | str:
+            def get_download_info() -> "dict | str":
                 info_req = urllib.request.Request(
                     f"{backend}/bases/{base_id}/download",
                     headers={"Authorization": f"Bearer {creds['token']}"},
@@ -1697,7 +1687,7 @@ def create_app(project: SantaiProject) -> FastAPI:
                     if e.code == 401:
                         return "Session expired. Run 'santai login' to re-authenticate."
                     if e.code == 404:
-                        return f"Project '{req.name}' not found."
+                        return f"Project '{project_name}' not found."
                     return f"Pull failed (HTTP {e.code})."
                 except (urllib.error.URLError, TimeoutError):
                     return "Could not reach the hub. Check your connection."
@@ -1714,13 +1704,10 @@ def create_app(project: SantaiProject) -> FastAPI:
 
             size = info.get("size", 0)
             yield _sse(
-                {
-                    "type": "status",
-                    "message": f"Found ({format_size(size)}). Downloading...",
-                }
+                {"type": "status", "message": f"Downloading ({format_size(size)})..."}
             )
 
-            def download_and_extract() -> str | None:
+            def download_and_extract() -> "str | None":
                 import tempfile as _tmp
 
                 with _tmp.NamedTemporaryFile(suffix=".zip", delete=False) as tmp:
@@ -1730,29 +1717,21 @@ def create_app(project: SantaiProject) -> FastAPI:
                     with urllib.request.urlopen(dl_req, timeout=120) as resp:
                         tmp_path.write_bytes(resp.read())
 
-                    dest_path.mkdir(parents=True, exist_ok=True)
                     with zipfile.ZipFile(tmp_path, "r") as zf:
+                        # Validate all members before extracting
                         for member in zf.infolist():
                             member_path = (dest_path / member.filename).resolve()
                             try:
-                                member_path.relative_to(dest_path.resolve())
+                                member_path.relative_to(dest_path)
                             except ValueError:
-                                if dest_path.exists() and not any(dest_path.iterdir()):
-                                    dest_path.rmdir()
                                 return f"Zip contains unsafe path '{member.filename}'."
                             if member.external_attr >> 28 == 0xA:
-                                if dest_path.exists() and not any(dest_path.iterdir()):
-                                    dest_path.rmdir()
                                 return f"Zip contains symlink '{member.filename}'."
                         zf.extractall(dest_path)
                     return None
                 except zipfile.BadZipFile:
-                    if dest_path.exists() and not any(dest_path.iterdir()):
-                        dest_path.rmdir()
                     return "Downloaded file is not a valid zip."
                 except (urllib.error.URLError, TimeoutError):
-                    if dest_path.exists() and not any(dest_path.iterdir()):
-                        dest_path.rmdir()
                     return "Download failed. The URL may have expired — try again."
                 finally:
                     tmp_path.unlink(missing_ok=True)
@@ -1763,7 +1742,7 @@ def create_app(project: SantaiProject) -> FastAPI:
                 yield _sse({"type": "error", "message": err})
                 return
 
-            yield _sse({"type": "done", "path": str(dest_path)})
+            yield _sse({"type": "done", "pulled": True})
 
         return StreamingResponse(
             event_gen(),

--- a/src/santai_cli/web/app.py
+++ b/src/santai_cli/web/app.py
@@ -85,6 +85,49 @@ class SmartPlaceRequest(BaseModel):
     content: str = ""
 
 
+_IMAGE_MIME: dict[str, str] = {
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".gif": "image/gif",
+    ".webp": "image/webp",
+    ".bmp": "image/bmp",
+    ".ico": "image/x-icon",
+}
+
+
+def _encode_data_url(path: Path) -> str:
+    """Return a base64 data URL string for a binary image file.
+
+    If the file already contains a data URL, return it as-is to avoid
+    double-encoding.
+    """
+    import base64 as _b64
+
+    raw = path.read_bytes()
+    if raw.startswith(b"data:"):
+        return raw.decode("ascii")
+    mime = _IMAGE_MIME.get(path.suffix.lower(), "image/png")
+    encoded = _b64.b64encode(raw).decode("ascii")
+    return f"data:{mime};base64,{encoded}"
+
+
+def _decode_data_url(data: bytes) -> bytes:
+    """Decode a base64 data URL back to raw binary bytes.
+
+    If the bytes are not a data URL (already raw binary), return unchanged.
+    """
+    import base64 as _b64
+
+    if not data.startswith(b"data:"):
+        return data
+    try:
+        comma = data.index(b",")
+        return _b64.b64decode(data[comma + 1 :])
+    except Exception:
+        return data
+
+
 def format_size(size_bytes: int | float) -> str:
     """Format bytes as human-readable size."""
     for unit in ["B", "KB", "MB", "GB"]:
@@ -1435,6 +1478,15 @@ def create_app(project: SantaiProject) -> FastAPI:
     }
     _CLOUD_SENSITIVE = {".env", "credentials.json"}
     _CLOUD_MAX_BYTES = 50 * 1024 * 1024
+    _CLOUD_IMAGE_EXTS = {
+        ".png",
+        ".jpg",
+        ".jpeg",
+        ".gif",
+        ".webp",
+        ".bmp",
+        ".ico",
+    }
 
     @app.get("/api/cloud/status")
     async def cloud_status() -> dict[str, Any]:
@@ -1555,7 +1607,10 @@ def create_app(project: SantaiProject) -> FastAPI:
                                 continue
                             if rel.name in ignored_files:
                                 continue
-                            zf.write(fp, rel)
+                            if fp.suffix.lower() in _CLOUD_IMAGE_EXTS:
+                                zf.writestr(str(rel), _encode_data_url(fp))
+                            else:
+                                zf.write(fp, rel)
                     size = tmp_path.stat().st_size
                     if size > _CLOUD_MAX_BYTES:
                         return (
@@ -1756,7 +1811,10 @@ def create_app(project: SantaiProject) -> FastAPI:
                         # Extract with cloud wrapper stripped
                         for member, target in plan:
                             target.parent.mkdir(parents=True, exist_ok=True)
-                            target.write_bytes(zf.read(member))
+                            raw = zf.read(member)
+                            if target.suffix.lower() in _CLOUD_IMAGE_EXTS:
+                                raw = _decode_data_url(raw)
+                            target.write_bytes(raw)
                         # Restore preserved files
                         for p, data in preserved.items():
                             p.write_bytes(data)

--- a/src/santai_cli/web/app.py
+++ b/src/santai_cli/web/app.py
@@ -1457,7 +1457,7 @@ def create_app(project: SantaiProject) -> FastAPI:
         from urllib.parse import quote
 
         from santai_cli.commands.auth import DEFAULT_HUB_URL, load_credentials
-        from santai_cli.core.hub import get_backend_url
+        from santai_cli.core.hub import USER_AGENT, get_backend_url
 
         def _sse(data: dict) -> str:
             return f"data: {_json.dumps(data)}\n\n"
@@ -1479,7 +1479,7 @@ def create_app(project: SantaiProject) -> FastAPI:
 
         def _resolve_or_create(backend: str, token: str, name: str) -> "str | str":
             """Return (base_id, None) on success or (None, error_message) on failure."""
-            auth = {"Authorization": f"Bearer {token}"}
+            auth = {"Authorization": f"Bearer {token}", "User-Agent": USER_AGENT}
             # Look up existing base
             try:
                 req_list = urllib.request.Request(f"{backend}/me/bases", headers=auth)
@@ -1597,6 +1597,7 @@ def create_app(project: SantaiProject) -> FastAPI:
                     headers={
                         "Authorization": f"Bearer {creds['token']}",
                         "Content-Type": f"multipart/form-data; boundary={boundary}",
+                        "User-Agent": USER_AGENT,
                     },
                 )
                 try:
@@ -1641,7 +1642,7 @@ def create_app(project: SantaiProject) -> FastAPI:
         import zipfile
 
         from santai_cli.commands.auth import DEFAULT_HUB_URL, load_credentials
-        from santai_cli.core.hub import get_backend_url, resolve_base_id
+        from santai_cli.core.hub import USER_AGENT, get_backend_url, resolve_base_id
 
         def _sse(data: dict) -> str:
             return f"data: {_json.dumps(data)}\n\n"
@@ -1678,7 +1679,10 @@ def create_app(project: SantaiProject) -> FastAPI:
             def get_download_info() -> "dict | str":
                 info_req = urllib.request.Request(
                     f"{backend}/bases/{base_id}/download",
-                    headers={"Authorization": f"Bearer {creds['token']}"},
+                    headers={
+                        "Authorization": f"Bearer {creds['token']}",
+                        "User-Agent": USER_AGENT,
+                    },
                 )
                 try:
                     with urllib.request.urlopen(info_req, timeout=15) as resp:

--- a/src/santai_cli/web/app.py
+++ b/src/santai_cli/web/app.py
@@ -1582,28 +1582,25 @@ def create_app(project: SantaiProject) -> FastAPI:
                 return f"Server error {e.code}."
 
         def _resolve_or_create(
-            backend: str, token: str, name: str, hub_url: str
+            backend: str, token: str, name: str, hub_url: str, username: str
         ) -> "tuple[str | None, str | None, str | None]":
             """Return (base_id, None, None) on success or (None, message, login_url) on failure."""
+            from urllib.parse import quote as _quote
+
             auth = {"Authorization": f"Bearer {token}", "User-Agent": USER_AGENT}
-            # Look up existing base
+            # Look up existing base by author username
             try:
-                req_list = urllib.request.Request(f"{backend}/me/bases", headers=auth)
+                req_list = urllib.request.Request(
+                    f"{backend}/bases?author={_quote(username)}", headers=auth
+                )
                 with urllib.request.urlopen(req_list, timeout=15) as resp:
                     data = _json.loads(resp.read())
             except urllib.error.HTTPError as e:
-                if e.code == 401:
-                    # Hub returns 401 with a valid JSON body when no bases exist yet.
-                    try:
-                        data = _json.loads(e.read().decode("utf-8", errors="replace"))
-                    except Exception:
-                        return None, _http_error_msg(e), hub_url
-                else:
-                    login_url = hub_url if e.code == 403 else None
-                    return None, _http_error_msg(e), login_url
+                login_url = hub_url if e.code in (401, 403) else None
+                return None, _http_error_msg(e), login_url
             except (urllib.error.URLError, TimeoutError):
                 return None, "Could not reach the hub. Check your connection.", None
-            for base in data.get("bases", []):
+            for base in data.get("data", []):
                 if base.get("name") == name:
                     return str(base["id"]), None, None
             # Not found — create it
@@ -1655,7 +1652,12 @@ def create_app(project: SantaiProject) -> FastAPI:
             yield _sse({"type": "status", "message": f"Looking up {project_name}..."})
 
             base_id, err, login_url = await asyncio.to_thread(
-                _resolve_or_create, backend, creds["token"], project_name, hub_url
+                _resolve_or_create,
+                backend,
+                creds["token"],
+                project_name,
+                hub_url,
+                creds.get("username", ""),
             )
             if err:
                 event: dict = {"type": "error", "message": err}
@@ -1801,7 +1803,11 @@ def create_app(project: SantaiProject) -> FastAPI:
             yield _sse({"type": "status", "message": f"Looking up {project_name}..."})
 
             base_id = await asyncio.to_thread(
-                resolve_base_id, backend, creds["token"], project_name
+                resolve_base_id,
+                backend,
+                creds["token"],
+                project_name,
+                creds.get("username", ""),
             )
             if not base_id:
                 yield _sse(

--- a/src/santai_cli/web/app.py
+++ b/src/santai_cli/web/app.py
@@ -97,19 +97,14 @@ _IMAGE_MIME: dict[str, str] = {
 
 
 def _encode_data_url(path: Path) -> str:
-    """Return a base64 data URL string for a binary image file.
-
-    If the file already contains a data URL, return it as-is to avoid
-    double-encoding.
-    """
+    # Cloud storage corrupts raw binary; base64 text survives the round-trip intact.
     import base64 as _b64
 
     raw = path.read_bytes()
     if raw.startswith(b"data:"):
         return raw.decode("ascii")
     mime = _IMAGE_MIME.get(path.suffix.lower(), "image/png")
-    encoded = _b64.b64encode(raw).decode("ascii")
-    return f"data:{mime};base64,{encoded}"
+    return f"data:{mime};base64,{_b64.b64encode(raw).decode('ascii')}"
 
 
 def _decode_data_url(data: bytes) -> bytes:
@@ -1536,9 +1531,7 @@ def create_app(project: SantaiProject) -> FastAPI:
     @app.get("/api/cloud/status")
     async def cloud_status() -> dict[str, Any]:
         """Return whether the user is logged in to the Santai cloud."""
-        from santai_cli.commands.auth import load_credentials
-
-        from santai_cli.commands.auth import DEFAULT_HUB_URL
+        from santai_cli.commands.auth import DEFAULT_HUB_URL, load_credentials
 
         creds = load_credentials()
         hub_url = creds.get("hub_url", DEFAULT_HUB_URL) if creds else DEFAULT_HUB_URL

--- a/src/santai_cli/web/app.py
+++ b/src/santai_cli/web/app.py
@@ -1,5 +1,6 @@
 """FastAPI web application for Santai."""
 
+import asyncio
 import logging
 import os
 import re
@@ -447,6 +448,8 @@ def create_app(project: SantaiProject) -> FastAPI:
     app = FastAPI(title=f"Santai - {project.name}")
     app.mount("/static", StaticFiles(directory=str(STATIC_DIR)), name="static")
     templates = Jinja2Templates(directory=str(TEMPLATES_DIR))
+    _cloud_push_lock = asyncio.Lock()
+    _cloud_pull_lock = asyncio.Lock()
 
     # Add custom filters to Jinja2
     templates.env.filters["format_size"] = format_size
@@ -1546,7 +1549,6 @@ def create_app(project: SantaiProject) -> FastAPI:
     @app.post("/api/cloud/push")
     async def cloud_push(req: CloudPushRequest) -> StreamingResponse:
         """Push the current project to the cloud, streaming SSE progress events."""
-        import asyncio
         import json as _json
         import urllib.error
         import urllib.request
@@ -1621,133 +1623,146 @@ def create_app(project: SantaiProject) -> FastAPI:
                 return None, "Could not reach the hub. Check your connection.", None
 
         async def event_gen():
-            creds = load_credentials()
-            hub_url = (
-                creds.get("hub_url", DEFAULT_HUB_URL) if creds else DEFAULT_HUB_URL
-            )
-            if not creds:
+            if _cloud_push_lock.locked():
+                yield _sse(
+                    {"type": "error", "message": "A push is already in progress."}
+                )
+                return
+            await _cloud_push_lock.acquire()
+            try:
+                creds = load_credentials()
+                hub_url = (
+                    creds.get("hub_url", DEFAULT_HUB_URL) if creds else DEFAULT_HUB_URL
+                )
+                if not creds:
+                    yield _sse(
+                        {
+                            "type": "error",
+                            "message": "Not logged in. Run 'santai login' first.",
+                            "login_url": hub_url,
+                        }
+                    )
+                    return
+
+                ignored_files = set(_CLOUD_SENSITIVE)
+                if req.include_env:
+                    ignored_files.discard(".env")
+
+                project_name = project.name
+                backend = get_backend_url(hub_url)
+
+                yield _sse(
+                    {"type": "status", "message": f"Looking up {project_name}..."}
+                )
+
+                base_id, err, login_url = await asyncio.to_thread(
+                    _resolve_or_create,
+                    backend,
+                    creds["token"],
+                    project_name,
+                    hub_url,
+                    creds.get("username", ""),
+                )
+                if err:
+                    event: dict = {"type": "error", "message": err}
+                    if login_url:
+                        event["login_url"] = login_url
+                    yield _sse(event)
+                    return
+
+                yield _sse({"type": "status", "message": "Packaging..."})
+
+                def build_zip() -> bytes | str:
+                    import tempfile as _tmp
+
+                    with _tmp.NamedTemporaryFile(suffix=".zip", delete=False) as tmp:
+                        tmp_path = Path(tmp.name)
+                    try:
+                        with zipfile.ZipFile(tmp_path, "w", zipfile.ZIP_DEFLATED) as zf:
+                            for fp in sorted(project.root.rglob("*")):
+                                if not fp.is_file():
+                                    continue
+                                rel = fp.relative_to(project.root)
+                                if any(
+                                    part in _CLOUD_IGNORED_DIRS for part in rel.parts
+                                ):
+                                    continue
+                                if rel.name in ignored_files:
+                                    continue
+                                if fp.suffix.lower() in _CLOUD_IMAGE_EXTS:
+                                    zf.writestr(str(rel), _encode_data_url(fp))
+                                else:
+                                    zf.write(fp, rel)
+                        size = tmp_path.stat().st_size
+                        if size > _CLOUD_MAX_BYTES:
+                            return f"Archive is {format_size(size)}, exceeds the 50 MB limit."
+                        return tmp_path.read_bytes()
+                    finally:
+                        tmp_path.unlink(missing_ok=True)
+
+                result = await asyncio.to_thread(build_zip)
+                if isinstance(result, str):
+                    yield _sse({"type": "error", "message": result})
+                    return
+
+                zip_bytes: bytes = result
                 yield _sse(
                     {
-                        "type": "error",
-                        "message": "Not logged in. Run 'santai login' first.",
-                        "login_url": hub_url,
+                        "type": "status",
+                        "message": f"Uploading ({format_size(len(zip_bytes))})...",
                     }
                 )
-                return
 
-            ignored_files = set(_CLOUD_SENSITIVE)
-            if req.include_env:
-                ignored_files.discard(".env")
-
-            project_name = project.name
-            backend = get_backend_url(hub_url)
-
-            yield _sse({"type": "status", "message": f"Looking up {project_name}..."})
-
-            base_id, err, login_url = await asyncio.to_thread(
-                _resolve_or_create,
-                backend,
-                creds["token"],
-                project_name,
-                hub_url,
-                creds.get("username", ""),
-            )
-            if err:
-                event: dict = {"type": "error", "message": err}
-                if login_url:
-                    event["login_url"] = login_url
-                yield _sse(event)
-                return
-
-            yield _sse({"type": "status", "message": "Packaging..."})
-
-            def build_zip() -> bytes | str:
-                import tempfile as _tmp
-
-                with _tmp.NamedTemporaryFile(suffix=".zip", delete=False) as tmp:
-                    tmp_path = Path(tmp.name)
-                try:
-                    with zipfile.ZipFile(tmp_path, "w", zipfile.ZIP_DEFLATED) as zf:
-                        for fp in sorted(project.root.rglob("*")):
-                            if not fp.is_file():
-                                continue
-                            rel = fp.relative_to(project.root)
-                            if any(part in _CLOUD_IGNORED_DIRS for part in rel.parts):
-                                continue
-                            if rel.name in ignored_files:
-                                continue
-                            if fp.suffix.lower() in _CLOUD_IMAGE_EXTS:
-                                zf.writestr(str(rel), _encode_data_url(fp))
-                            else:
-                                zf.write(fp, rel)
-                    size = tmp_path.stat().st_size
-                    if size > _CLOUD_MAX_BYTES:
-                        return (
-                            f"Archive is {format_size(size)}, exceeds the 50 MB limit."
-                        )
-                    return tmp_path.read_bytes()
-                finally:
-                    tmp_path.unlink(missing_ok=True)
-
-            result = await asyncio.to_thread(build_zip)
-            if isinstance(result, str):
-                yield _sse({"type": "error", "message": result})
-                return
-
-            zip_bytes: bytes = result
-            yield _sse(
-                {
-                    "type": "status",
-                    "message": f"Uploading ({format_size(len(zip_bytes))})...",
-                }
-            )
-
-            def upload(data: bytes) -> dict | str:
-                boundary = "----SantaiWebUpload"
-                body = b"".join(
-                    [
-                        f"--{boundary}\r\n".encode(),
-                        f'Content-Disposition: form-data; name="file"; filename="{quote(project_name)}.zip"\r\n'.encode(),
-                        b"Content-Type: application/zip\r\n\r\n",
-                        data,
-                        b"\r\n",
-                        f"--{boundary}--\r\n".encode(),
-                    ]
-                )
-                upload_req = urllib.request.Request(
-                    f"{backend}/bases/{base_id}/upload",
-                    data=body,
-                    method="POST",
-                    headers={
-                        "Authorization": f"Bearer {creds['token']}",
-                        "Content-Type": f"multipart/form-data; boundary={boundary}",
-                        "User-Agent": USER_AGENT,
-                    },
-                )
-                try:
-                    with urllib.request.urlopen(upload_req, timeout=120) as resp:
-                        return _json.loads(resp.read())
-                except urllib.error.HTTPError as e:
-                    if e.code == 401:
-                        return "Session expired. Run 'santai login' to re-authenticate."
-                    body_text = e.read().decode(errors="replace")
+                def upload(data: bytes) -> dict | str:
+                    boundary = "----SantaiWebUpload"
+                    body = b"".join(
+                        [
+                            f"--{boundary}\r\n".encode(),
+                            f'Content-Disposition: form-data; name="file"; filename="{quote(project_name)}.zip"\r\n'.encode(),
+                            b"Content-Type: application/zip\r\n\r\n",
+                            data,
+                            b"\r\n",
+                            f"--{boundary}--\r\n".encode(),
+                        ]
+                    )
+                    upload_req = urllib.request.Request(
+                        f"{backend}/bases/{base_id}/upload",
+                        data=body,
+                        method="POST",
+                        headers={
+                            "Authorization": f"Bearer {creds['token']}",
+                            "Content-Type": f"multipart/form-data; boundary={boundary}",
+                            "User-Agent": USER_AGENT,
+                        },
+                    )
                     try:
-                        err_data = _json.loads(body_text)
-                        return f"Push failed: {err_data.get('error', body_text)}"
-                    except _json.JSONDecodeError:
-                        return f"Push failed (HTTP {e.code}): {body_text}"
-                except (urllib.error.URLError, TimeoutError):
-                    return "Could not reach the hub. Check your connection."
+                        with urllib.request.urlopen(upload_req, timeout=120) as resp:
+                            return _json.loads(resp.read())
+                    except urllib.error.HTTPError as e:
+                        if e.code == 401:
+                            return "Session expired. Run 'santai login' to re-authenticate."
+                        body_text = e.read().decode(errors="replace")
+                        try:
+                            err_data = _json.loads(body_text)
+                            return f"Push failed: {err_data.get('error', body_text)}"
+                        except _json.JSONDecodeError:
+                            return f"Push failed (HTTP {e.code}): {body_text}"
+                    except (urllib.error.URLError, TimeoutError):
+                        return "Could not reach the hub. Check your connection."
 
-            upload_result = await asyncio.to_thread(upload, zip_bytes)
-            if isinstance(upload_result, str):
-                err_event: dict = {"type": "error", "message": upload_result}
-                if "login" in upload_result.lower():
-                    err_event["login_url"] = hub_url
-                yield _sse(err_event)
-                return
+                upload_result = await asyncio.to_thread(upload, zip_bytes)
+                if isinstance(upload_result, str):
+                    err_event: dict = {"type": "error", "message": upload_result}
+                    if "login" in upload_result.lower():
+                        err_event["login_url"] = hub_url
+                    yield _sse(err_event)
+                    return
 
-            yield _sse({"type": "done", "version": upload_result.get("version", "?")})
+                yield _sse(
+                    {"type": "done", "version": upload_result.get("version", "?")}
+                )
+            finally:
+                _cloud_push_lock.release()
 
         return StreamingResponse(
             event_gen(),
@@ -1762,7 +1777,6 @@ def create_app(project: SantaiProject) -> FastAPI:
     @app.post("/api/cloud/pull")
     async def cloud_pull(req: CloudPullRequest) -> StreamingResponse:
         """Pull the current project from the cloud, overwriting local files in place."""
-        import asyncio
         import json as _json
         import urllib.error
         import urllib.request
@@ -1775,147 +1789,181 @@ def create_app(project: SantaiProject) -> FastAPI:
             return f"data: {_json.dumps(data)}\n\n"
 
         async def event_gen():
-            creds = load_credentials()
-            hub_url = (
-                creds.get("hub_url", DEFAULT_HUB_URL) if creds else DEFAULT_HUB_URL
-            )
-            if not creds:
+            if _cloud_pull_lock.locked():
+                yield _sse(
+                    {"type": "error", "message": "A pull is already in progress."}
+                )
+                return
+            await _cloud_pull_lock.acquire()
+            try:
+                creds = load_credentials()
+                hub_url = (
+                    creds.get("hub_url", DEFAULT_HUB_URL) if creds else DEFAULT_HUB_URL
+                )
+                if not creds:
+                    yield _sse(
+                        {
+                            "type": "error",
+                            "message": "Not logged in. Run 'santai login' first.",
+                            "login_url": hub_url,
+                        }
+                    )
+                    return
+
+                project_name = project.root.name
+                dest_path = project.root.resolve()
+                backend = get_backend_url(hub_url)
+
+                yield _sse(
+                    {"type": "status", "message": f"Looking up {project_name}..."}
+                )
+
+                base_id = await asyncio.to_thread(
+                    resolve_base_id,
+                    backend,
+                    creds["token"],
+                    project_name,
+                    creds.get("username", ""),
+                )
+                if not base_id:
+                    yield _sse(
+                        {
+                            "type": "error",
+                            "message": f"Project '{project_name}' not found in the cloud.",
+                        }
+                    )
+                    return
+
+                def get_download_info() -> "dict | str":
+                    info_req = urllib.request.Request(
+                        f"{backend}/bases/{base_id}/download",
+                        headers={
+                            "Authorization": f"Bearer {creds['token']}",
+                            "User-Agent": USER_AGENT,
+                        },
+                    )
+                    try:
+                        with urllib.request.urlopen(info_req, timeout=15) as resp:
+                            return _json.loads(resp.read())
+                    except urllib.error.HTTPError as e:
+                        if e.code == 401:
+                            return "Session expired. Run 'santai login' to re-authenticate."
+                        if e.code == 404:
+                            return f"Project '{project_name}' not found."
+                        return f"Pull failed (HTTP {e.code})."
+                    except (urllib.error.URLError, TimeoutError):
+                        return "Could not reach the hub. Check your connection."
+
+                info = await asyncio.to_thread(get_download_info)
+                if isinstance(info, str):
+                    pull_err: dict = {"type": "error", "message": info}
+                    if "login" in info.lower():
+                        pull_err["login_url"] = hub_url
+                    yield _sse(pull_err)
+                    return
+
+                download_url = info.get("downloadUrl")
+                if not download_url:
+                    yield _sse(
+                        {"type": "error", "message": "No download URL received."}
+                    )
+                    return
+                if not download_url.startswith(("https://", "http://")):
+                    yield _sse(
+                        {
+                            "type": "error",
+                            "message": "Download URL has unexpected scheme.",
+                        }
+                    )
+                    return
+
+                size = info.get("size", 0)
                 yield _sse(
                     {
-                        "type": "error",
-                        "message": "Not logged in. Run 'santai login' first.",
-                        "login_url": hub_url,
+                        "type": "status",
+                        "message": f"Downloading ({format_size(size)})...",
                     }
                 )
-                return
 
-            project_name = project.root.name
-            dest_path = project.root.resolve()
-            backend = get_backend_url(hub_url)
+                def download_and_extract() -> "str | None":
+                    import tempfile as _tmp
 
-            yield _sse({"type": "status", "message": f"Looking up {project_name}..."})
+                    with _tmp.NamedTemporaryFile(suffix=".zip", delete=False) as tmp:
+                        tmp_path = Path(tmp.name)
+                    try:
+                        dl_req = urllib.request.Request(download_url)
+                        with urllib.request.urlopen(dl_req, timeout=120) as resp:
+                            with open(tmp_path, "wb") as f:
+                                shutil.copyfileobj(resp, f)
 
-            base_id = await asyncio.to_thread(
-                resolve_base_id,
-                backend,
-                creds["token"],
-                project_name,
-                creds.get("username", ""),
-            )
-            if not base_id:
-                yield _sse(
-                    {
-                        "type": "error",
-                        "message": f"Project '{project_name}' not found in the cloud.",
-                    }
-                )
-                return
+                        with zipfile.ZipFile(tmp_path, "r") as zf:
+                            # Build extraction plan: strip cloud wrapper (manifest.json + files/ prefix)
+                            plan: list[tuple[zipfile.ZipInfo, Path]] = []
+                            for member in zf.infolist():
+                                name = member.filename
+                                if name == "manifest.json":
+                                    continue
+                                if name.startswith("files/"):
+                                    name = name[len("files/") :]
+                                # Skip directory entries and empty names
+                                if not name or name.endswith("/"):
+                                    continue
+                                target = (dest_path / name).resolve()
+                                try:
+                                    target.relative_to(dest_path)
+                                except ValueError:
+                                    return (
+                                        f"Zip contains unsafe path '{member.filename}'."
+                                    )
+                                if member.external_attr >> 28 == 0xA:
+                                    return f"Zip contains symlink '{member.filename}'."
+                                plan.append((member, target))
+                            # Preserve sensitive local files that are never pushed
+                            preserved: dict[Path, bytes] = {}
+                            for fname in _CLOUD_SENSITIVE:
+                                p = dest_path / fname
+                                if p.is_file():
+                                    preserved[p] = p.read_bytes()
+                            # Clear project files that are absent from the cloud archive.
+                            # Skip directories/files that are never pushed so their local
+                            # state is not destroyed (e.g. .git, .venv, node_modules).
+                            for item in dest_path.iterdir():
+                                if (
+                                    item.name.startswith(".")
+                                    or item.name in _CLOUD_IGNORED_DIRS
+                                ):
+                                    continue
+                                if item.is_dir():
+                                    shutil.rmtree(item)
+                                else:
+                                    item.unlink()
+                            # Extract with cloud wrapper stripped
+                            for member, target in plan:
+                                target.parent.mkdir(parents=True, exist_ok=True)
+                                raw = zf.read(member)
+                                if target.suffix.lower() in _CLOUD_IMAGE_EXTS:
+                                    raw = _decode_data_url(raw)
+                                target.write_bytes(raw)
+                            # Restore preserved files
+                            for p, data in preserved.items():
+                                p.write_bytes(data)
+                        return None
+                    except zipfile.BadZipFile:
+                        return "Downloaded file is not a valid zip."
+                    except (urllib.error.URLError, TimeoutError):
+                        return "Download failed. The URL may have expired — try again."
+                    finally:
+                        tmp_path.unlink(missing_ok=True)
 
-            def get_download_info() -> "dict | str":
-                info_req = urllib.request.Request(
-                    f"{backend}/bases/{base_id}/download",
-                    headers={
-                        "Authorization": f"Bearer {creds['token']}",
-                        "User-Agent": USER_AGENT,
-                    },
-                )
-                try:
-                    with urllib.request.urlopen(info_req, timeout=15) as resp:
-                        return _json.loads(resp.read())
-                except urllib.error.HTTPError as e:
-                    if e.code == 401:
-                        return "Session expired. Run 'santai login' to re-authenticate."
-                    if e.code == 404:
-                        return f"Project '{project_name}' not found."
-                    return f"Pull failed (HTTP {e.code})."
-                except (urllib.error.URLError, TimeoutError):
-                    return "Could not reach the hub. Check your connection."
+                yield _sse({"type": "status", "message": "Extracting..."})
+                err = await asyncio.to_thread(download_and_extract)
+                if err:
+                    yield _sse({"type": "error", "message": err})
+                    return
 
-            info = await asyncio.to_thread(get_download_info)
-            if isinstance(info, str):
-                pull_err: dict = {"type": "error", "message": info}
-                if "login" in info.lower():
-                    pull_err["login_url"] = hub_url
-                yield _sse(pull_err)
-                return
-
-            download_url = info.get("downloadUrl")
-            if not download_url:
-                yield _sse({"type": "error", "message": "No download URL received."})
-                return
-
-            size = info.get("size", 0)
-            yield _sse(
-                {"type": "status", "message": f"Downloading ({format_size(size)})..."}
-            )
-
-            def download_and_extract() -> "str | None":
-                import tempfile as _tmp
-
-                with _tmp.NamedTemporaryFile(suffix=".zip", delete=False) as tmp:
-                    tmp_path = Path(tmp.name)
-                try:
-                    dl_req = urllib.request.Request(download_url)
-                    with urllib.request.urlopen(dl_req, timeout=120) as resp:
-                        tmp_path.write_bytes(resp.read())
-
-                    with zipfile.ZipFile(tmp_path, "r") as zf:
-                        # Build extraction plan: strip cloud wrapper (manifest.json + files/ prefix)
-                        plan: list[tuple[zipfile.ZipInfo, Path]] = []
-                        for member in zf.infolist():
-                            name = member.filename
-                            if name == "manifest.json":
-                                continue
-                            if name.startswith("files/"):
-                                name = name[len("files/") :]
-                            # Skip directory entries and empty names
-                            if not name or name.endswith("/"):
-                                continue
-                            target = (dest_path / name).resolve()
-                            try:
-                                target.relative_to(dest_path)
-                            except ValueError:
-                                return f"Zip contains unsafe path '{member.filename}'."
-                            if member.external_attr >> 28 == 0xA:
-                                return f"Zip contains symlink '{member.filename}'."
-                            plan.append((member, target))
-                        # Preserve sensitive local files that are never pushed
-                        preserved: dict[Path, bytes] = {}
-                        for fname in _CLOUD_SENSITIVE:
-                            p = dest_path / fname
-                            if p.is_file():
-                                preserved[p] = p.read_bytes()
-                        # Clear existing contents so files absent from the cloud are removed
-                        for item in dest_path.iterdir():
-                            if item.is_dir():
-                                shutil.rmtree(item)
-                            else:
-                                item.unlink()
-                        # Extract with cloud wrapper stripped
-                        for member, target in plan:
-                            target.parent.mkdir(parents=True, exist_ok=True)
-                            raw = zf.read(member)
-                            if target.suffix.lower() in _CLOUD_IMAGE_EXTS:
-                                raw = _decode_data_url(raw)
-                            target.write_bytes(raw)
-                        # Restore preserved files
-                        for p, data in preserved.items():
-                            p.write_bytes(data)
-                    return None
-                except zipfile.BadZipFile:
-                    return "Downloaded file is not a valid zip."
-                except (urllib.error.URLError, TimeoutError):
-                    return "Download failed. The URL may have expired — try again."
-                finally:
-                    tmp_path.unlink(missing_ok=True)
-
-            yield _sse({"type": "status", "message": "Extracting..."})
-            err = await asyncio.to_thread(download_and_extract)
-            if err:
-                yield _sse({"type": "error", "message": err})
-                return
-
-            yield _sse({"type": "done", "pulled": True})
+                yield _sse({"type": "done", "pulled": True})
+            finally:
+                _cloud_pull_lock.release()
 
         return StreamingResponse(
             event_gen(),

--- a/src/santai_cli/web/app.py
+++ b/src/santai_cli/web/app.py
@@ -1718,22 +1718,35 @@ def create_app(project: SantaiProject) -> FastAPI:
                         tmp_path.write_bytes(resp.read())
 
                     with zipfile.ZipFile(tmp_path, "r") as zf:
-                        # Validate all members before extracting
+                        # Build extraction plan: strip cloud wrapper (manifest.json + files/ prefix)
+                        plan: list[tuple[zipfile.ZipInfo, Path]] = []
                         for member in zf.infolist():
-                            member_path = (dest_path / member.filename).resolve()
+                            name = member.filename
+                            if name == "manifest.json":
+                                continue
+                            if name.startswith("files/"):
+                                name = name[len("files/") :]
+                            # Skip directory entries and empty names
+                            if not name or name.endswith("/"):
+                                continue
+                            target = (dest_path / name).resolve()
                             try:
-                                member_path.relative_to(dest_path)
+                                target.relative_to(dest_path)
                             except ValueError:
                                 return f"Zip contains unsafe path '{member.filename}'."
                             if member.external_attr >> 28 == 0xA:
                                 return f"Zip contains symlink '{member.filename}'."
+                            plan.append((member, target))
                         # Clear existing contents so files absent from the cloud are removed
                         for item in dest_path.iterdir():
                             if item.is_dir():
                                 shutil.rmtree(item)
                             else:
                                 item.unlink()
-                        zf.extractall(dest_path)
+                        # Extract with cloud wrapper stripped
+                        for member, target in plan:
+                            target.parent.mkdir(parents=True, exist_ok=True)
+                            target.write_bytes(zf.read(member))
                     return None
                 except zipfile.BadZipFile:
                     return "Downloaded file is not a valid zip."

--- a/src/santai_cli/web/app.py
+++ b/src/santai_cli/web/app.py
@@ -72,6 +72,15 @@ class SettingsRequest(BaseModel):
     openai_api_key: str | None = None
 
 
+class CloudPushRequest(BaseModel):
+    include_env: bool = False
+
+
+class CloudPullRequest(BaseModel):
+    name: str
+    dest: str | None = None
+
+
 class SmartPlaceRequest(BaseModel):
     filename: str
     content: str = ""
@@ -1414,5 +1423,317 @@ def create_app(project: SantaiProject) -> FastAPI:
         load_dotenv(env_path, override=True)
 
         return {"status": "saved"}
+
+    # === Cloud Push / Pull Endpoints ===
+
+    _CLOUD_IGNORED_DIRS = {
+        ".git",
+        ".ruff_cache",
+        ".rumdl_cache",
+        "__pycache__",
+        ".venv",
+        "node_modules",
+    }
+    _CLOUD_SENSITIVE = {".env", "credentials.json"}
+    _CLOUD_MAX_BYTES = 50 * 1024 * 1024
+
+    @app.get("/api/cloud/status")
+    async def cloud_status() -> dict[str, Any]:
+        """Return whether the user is logged in to the Santai cloud."""
+        from santai_cli.commands.auth import load_credentials
+
+        creds = load_credentials()
+        if not creds:
+            return {"logged_in": False, "username": None}
+        return {"logged_in": True, "username": creds.get("username")}
+
+    @app.post("/api/cloud/push")
+    async def cloud_push(req: CloudPushRequest) -> StreamingResponse:
+        """Push the current project to the cloud, streaming SSE progress events."""
+        import asyncio
+        import json as _json
+        import urllib.error
+        import urllib.request
+        import zipfile
+        from urllib.parse import quote
+
+        from santai_cli.commands.auth import DEFAULT_HUB_URL, load_credentials
+        from santai_cli.core.hub import create_base, get_backend_url, resolve_base_id
+
+        def _sse(data: dict) -> str:
+            return f"data: {_json.dumps(data)}\n\n"
+
+        async def event_gen():
+            creds = load_credentials()
+            if not creds:
+                yield _sse(
+                    {
+                        "type": "error",
+                        "message": "Not logged in. Run 'santai login' first.",
+                    }
+                )
+                return
+
+            ignored_files = set(_CLOUD_SENSITIVE)
+            if req.include_env:
+                ignored_files.discard(".env")
+
+            project_name = project.name
+            backend = get_backend_url(creds.get("hub_url", DEFAULT_HUB_URL))
+
+            yield _sse({"type": "status", "message": f"Looking up {project_name}..."})
+
+            base_id = await asyncio.to_thread(
+                resolve_base_id, backend, creds["token"], project_name
+            )
+            if not base_id:
+                yield _sse({"type": "status", "message": f"Creating {project_name}..."})
+                base_id = await asyncio.to_thread(
+                    create_base, backend, creds["token"], project_name
+                )
+                if not base_id:
+                    yield _sse(
+                        {
+                            "type": "error",
+                            "message": f"Failed to create project '{project_name}'.",
+                        }
+                    )
+                    return
+
+            yield _sse({"type": "status", "message": "Packaging..."})
+
+            def build_zip() -> bytes | str:
+                import tempfile as _tmp
+
+                with _tmp.NamedTemporaryFile(suffix=".zip", delete=False) as tmp:
+                    tmp_path = Path(tmp.name)
+                try:
+                    with zipfile.ZipFile(tmp_path, "w", zipfile.ZIP_DEFLATED) as zf:
+                        for fp in sorted(project.root.rglob("*")):
+                            if not fp.is_file():
+                                continue
+                            rel = fp.relative_to(project.root)
+                            if any(part in _CLOUD_IGNORED_DIRS for part in rel.parts):
+                                continue
+                            if rel.name in ignored_files:
+                                continue
+                            zf.write(fp, rel)
+                    size = tmp_path.stat().st_size
+                    if size > _CLOUD_MAX_BYTES:
+                        return (
+                            f"Archive is {format_size(size)}, exceeds the 50 MB limit."
+                        )
+                    return tmp_path.read_bytes()
+                finally:
+                    tmp_path.unlink(missing_ok=True)
+
+            result = await asyncio.to_thread(build_zip)
+            if isinstance(result, str):
+                yield _sse({"type": "error", "message": result})
+                return
+
+            zip_bytes: bytes = result
+            yield _sse(
+                {
+                    "type": "status",
+                    "message": f"Uploading ({format_size(len(zip_bytes))})...",
+                }
+            )
+
+            def upload(data: bytes) -> dict | str:
+                boundary = "----SantaiWebUpload"
+                body = b"".join(
+                    [
+                        f"--{boundary}\r\n".encode(),
+                        f'Content-Disposition: form-data; name="file"; filename="{quote(project_name)}.zip"\r\n'.encode(),
+                        b"Content-Type: application/zip\r\n\r\n",
+                        data,
+                        b"\r\n",
+                        f"--{boundary}--\r\n".encode(),
+                    ]
+                )
+                upload_req = urllib.request.Request(
+                    f"{backend}/bases/{base_id}/upload",
+                    data=body,
+                    method="POST",
+                    headers={
+                        "Authorization": f"Bearer {creds['token']}",
+                        "Content-Type": f"multipart/form-data; boundary={boundary}",
+                    },
+                )
+                try:
+                    with urllib.request.urlopen(upload_req, timeout=120) as resp:
+                        return _json.loads(resp.read())
+                except urllib.error.HTTPError as e:
+                    if e.code == 401:
+                        return "Session expired. Run 'santai login' to re-authenticate."
+                    body_text = e.read().decode(errors="replace")
+                    try:
+                        err_data = _json.loads(body_text)
+                        return f"Push failed: {err_data.get('error', body_text)}"
+                    except _json.JSONDecodeError:
+                        return f"Push failed (HTTP {e.code}): {body_text}"
+                except (urllib.error.URLError, TimeoutError):
+                    return "Could not reach the hub. Check your connection."
+
+            upload_result = await asyncio.to_thread(upload, zip_bytes)
+            if isinstance(upload_result, str):
+                yield _sse({"type": "error", "message": upload_result})
+                return
+
+            yield _sse({"type": "done", "version": upload_result.get("version", "?")})
+
+        return StreamingResponse(
+            event_gen(),
+            media_type="text/event-stream",
+            headers={
+                "Cache-Control": "no-cache",
+                "Connection": "keep-alive",
+                "X-Accel-Buffering": "no",
+            },
+        )
+
+    @app.post("/api/cloud/pull")
+    async def cloud_pull(req: CloudPullRequest) -> StreamingResponse:
+        """Pull a project from the cloud into a sibling directory, streaming SSE progress."""
+        import asyncio
+        import json as _json
+        import urllib.error
+        import urllib.request
+        import zipfile
+
+        from santai_cli.commands.auth import DEFAULT_HUB_URL, load_credentials
+        from santai_cli.core.hub import get_backend_url, resolve_base_id
+
+        def _sse(data: dict) -> str:
+            return f"data: {_json.dumps(data)}\n\n"
+
+        async def event_gen():
+            creds = load_credentials()
+            if not creds:
+                yield _sse(
+                    {
+                        "type": "error",
+                        "message": "Not logged in. Run 'santai login' first.",
+                    }
+                )
+                return
+
+            if req.dest:
+                dest_path = (project.root.parent / req.dest).resolve()
+            else:
+                dest_path = (project.root.parent / req.name).resolve()
+
+            if dest_path.exists():
+                yield _sse(
+                    {
+                        "type": "error",
+                        "message": f"'{dest_path.name}' already exists in {dest_path.parent}.",
+                    }
+                )
+                return
+
+            backend = get_backend_url(creds.get("hub_url", DEFAULT_HUB_URL))
+
+            yield _sse({"type": "status", "message": f"Looking up {req.name}..."})
+
+            base_id = await asyncio.to_thread(
+                resolve_base_id, backend, creds["token"], req.name
+            )
+            if not base_id:
+                yield _sse(
+                    {"type": "error", "message": f"Project '{req.name}' not found."}
+                )
+                return
+
+            def get_download_info() -> dict | str:
+                info_req = urllib.request.Request(
+                    f"{backend}/bases/{base_id}/download",
+                    headers={"Authorization": f"Bearer {creds['token']}"},
+                )
+                try:
+                    with urllib.request.urlopen(info_req, timeout=15) as resp:
+                        return _json.loads(resp.read())
+                except urllib.error.HTTPError as e:
+                    if e.code == 401:
+                        return "Session expired. Run 'santai login' to re-authenticate."
+                    if e.code == 404:
+                        return f"Project '{req.name}' not found."
+                    return f"Pull failed (HTTP {e.code})."
+                except (urllib.error.URLError, TimeoutError):
+                    return "Could not reach the hub. Check your connection."
+
+            info = await asyncio.to_thread(get_download_info)
+            if isinstance(info, str):
+                yield _sse({"type": "error", "message": info})
+                return
+
+            download_url = info.get("downloadUrl")
+            if not download_url:
+                yield _sse({"type": "error", "message": "No download URL received."})
+                return
+
+            size = info.get("size", 0)
+            yield _sse(
+                {
+                    "type": "status",
+                    "message": f"Found ({format_size(size)}). Downloading...",
+                }
+            )
+
+            def download_and_extract() -> str | None:
+                import tempfile as _tmp
+
+                with _tmp.NamedTemporaryFile(suffix=".zip", delete=False) as tmp:
+                    tmp_path = Path(tmp.name)
+                try:
+                    dl_req = urllib.request.Request(download_url)
+                    with urllib.request.urlopen(dl_req, timeout=120) as resp:
+                        tmp_path.write_bytes(resp.read())
+
+                    dest_path.mkdir(parents=True, exist_ok=True)
+                    with zipfile.ZipFile(tmp_path, "r") as zf:
+                        for member in zf.infolist():
+                            member_path = (dest_path / member.filename).resolve()
+                            try:
+                                member_path.relative_to(dest_path.resolve())
+                            except ValueError:
+                                if dest_path.exists() and not any(dest_path.iterdir()):
+                                    dest_path.rmdir()
+                                return f"Zip contains unsafe path '{member.filename}'."
+                            if member.external_attr >> 28 == 0xA:
+                                if dest_path.exists() and not any(dest_path.iterdir()):
+                                    dest_path.rmdir()
+                                return f"Zip contains symlink '{member.filename}'."
+                        zf.extractall(dest_path)
+                    return None
+                except zipfile.BadZipFile:
+                    if dest_path.exists() and not any(dest_path.iterdir()):
+                        dest_path.rmdir()
+                    return "Downloaded file is not a valid zip."
+                except (urllib.error.URLError, TimeoutError):
+                    if dest_path.exists() and not any(dest_path.iterdir()):
+                        dest_path.rmdir()
+                    return "Download failed. The URL may have expired — try again."
+                finally:
+                    tmp_path.unlink(missing_ok=True)
+
+            yield _sse({"type": "status", "message": "Extracting..."})
+            err = await asyncio.to_thread(download_and_extract)
+            if err:
+                yield _sse({"type": "error", "message": err})
+                return
+
+            yield _sse({"type": "done", "path": str(dest_path)})
+
+        return StreamingResponse(
+            event_gen(),
+            media_type="text/event-stream",
+            headers={
+                "Cache-Control": "no-cache",
+                "Connection": "keep-alive",
+                "X-Accel-Buffering": "no",
+            },
+        )
 
     return app

--- a/src/santai_cli/web/app.py
+++ b/src/santai_cli/web/app.py
@@ -1458,10 +1458,59 @@ def create_app(project: SantaiProject) -> FastAPI:
         from urllib.parse import quote
 
         from santai_cli.commands.auth import DEFAULT_HUB_URL, load_credentials
-        from santai_cli.core.hub import create_base, get_backend_url, resolve_base_id
+        from santai_cli.core.hub import get_backend_url
 
         def _sse(data: dict) -> str:
             return f"data: {_json.dumps(data)}\n\n"
+
+        def _http_error_msg(e: "urllib.error.HTTPError") -> str:
+            if e.code == 401:
+                return "Session expired. Run 'santai login' to re-authenticate."
+            if e.code == 403:
+                return "Access denied. Check your account permissions."
+            try:
+                body = _json.loads(e.read().decode(errors="replace"))
+                return (
+                    body.get("error")
+                    or body.get("message")
+                    or f"Server error {e.code}."
+                )
+            except Exception:
+                return f"Server error {e.code}."
+
+        def _resolve_or_create(backend: str, token: str, name: str) -> "str | str":
+            """Return (base_id, None) on success or (None, error_message) on failure."""
+            auth = {"Authorization": f"Bearer {token}"}
+            # Look up existing base
+            try:
+                req_list = urllib.request.Request(f"{backend}/me/bases", headers=auth)
+                with urllib.request.urlopen(req_list, timeout=15) as resp:
+                    data = _json.loads(resp.read())
+                for base in data.get("bases", []):
+                    if base.get("name") == name:
+                        return str(base["id"]), None
+            except urllib.error.HTTPError as e:
+                return None, _http_error_msg(e)
+            except (urllib.error.URLError, TimeoutError):
+                return None, "Could not reach the hub. Check your connection."
+            # Not found — create it
+            body = _json.dumps({"name": name}).encode()
+            try:
+                req_create = urllib.request.Request(
+                    f"{backend}/bases/init",
+                    data=body,
+                    method="POST",
+                    headers={**auth, "Content-Type": "application/json"},
+                )
+                with urllib.request.urlopen(req_create, timeout=30) as resp:
+                    data = _json.loads(resp.read())
+                    if "id" in data:
+                        return str(data["id"]), None
+                    return None, f"Unexpected response creating '{name}'."
+            except urllib.error.HTTPError as e:
+                return None, f"Could not create '{name}': {_http_error_msg(e)}"
+            except (urllib.error.URLError, TimeoutError):
+                return None, "Could not reach the hub. Check your connection."
 
         async def event_gen():
             creds = load_credentials()
@@ -1483,22 +1532,12 @@ def create_app(project: SantaiProject) -> FastAPI:
 
             yield _sse({"type": "status", "message": f"Looking up {project_name}..."})
 
-            base_id = await asyncio.to_thread(
-                resolve_base_id, backend, creds["token"], project_name
+            base_id, err = await asyncio.to_thread(
+                _resolve_or_create, backend, creds["token"], project_name
             )
-            if not base_id:
-                yield _sse({"type": "status", "message": f"Creating {project_name}..."})
-                base_id = await asyncio.to_thread(
-                    create_base, backend, creds["token"], project_name
-                )
-                if not base_id:
-                    yield _sse(
-                        {
-                            "type": "error",
-                            "message": f"Failed to create project '{project_name}'.",
-                        }
-                    )
-                    return
+            if err:
+                yield _sse({"type": "error", "message": err})
+                return
 
             yield _sse({"type": "status", "message": "Packaging..."})
 

--- a/src/santai_cli/web/app.py
+++ b/src/santai_cli/web/app.py
@@ -1727,6 +1727,12 @@ def create_app(project: SantaiProject) -> FastAPI:
                                 return f"Zip contains unsafe path '{member.filename}'."
                             if member.external_attr >> 28 == 0xA:
                                 return f"Zip contains symlink '{member.filename}'."
+                        # Clear existing contents so files absent from the cloud are removed
+                        for item in dest_path.iterdir():
+                            if item.is_dir():
+                                shutil.rmtree(item)
+                            else:
+                                item.unlink()
                         zf.extractall(dest_path)
                     return None
                 except zipfile.BadZipFile:

--- a/src/santai_cli/web/app.py
+++ b/src/santai_cli/web/app.py
@@ -1591,14 +1591,21 @@ def create_app(project: SantaiProject) -> FastAPI:
                 req_list = urllib.request.Request(f"{backend}/me/bases", headers=auth)
                 with urllib.request.urlopen(req_list, timeout=15) as resp:
                     data = _json.loads(resp.read())
-                for base in data.get("bases", []):
-                    if base.get("name") == name:
-                        return str(base["id"]), None, None
             except urllib.error.HTTPError as e:
-                login_url = hub_url if e.code in (401, 403) else None
-                return None, _http_error_msg(e), login_url
+                if e.code == 401:
+                    # Hub returns 401 with a valid JSON body when no bases exist yet.
+                    try:
+                        data = _json.loads(e.read().decode("utf-8", errors="replace"))
+                    except Exception:
+                        return None, _http_error_msg(e), hub_url
+                else:
+                    login_url = hub_url if e.code == 403 else None
+                    return None, _http_error_msg(e), login_url
             except (urllib.error.URLError, TimeoutError):
                 return None, "Could not reach the hub. Check your connection.", None
+            for base in data.get("bases", []):
+                if base.get("name") == name:
+                    return str(base["id"]), None, None
             # Not found — create it
             body = _json.dumps({"name": name}).encode()
             try:

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -656,11 +656,11 @@
 
         .cloud-sync-btns {
             display: flex;
+            flex-direction: column;
             gap: 6px;
         }
 
         .cloud-sync-btns .btn {
-            flex: 1;
             justify-content: center;
             font-size: 13px;
             gap: 4px;

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -711,6 +711,12 @@
 
         .cloud-inline-form.visible { display: flex; }
 
+        .cloud-confirm-msg {
+            font-size: 12px;
+            color: var(--text-secondary, var(--text-muted));
+            line-height: 1.4;
+        }
+
         .cloud-inline-form input[type="text"] {
             background: rgba(255,255,255,0.6);
             border: 1px solid rgba(0,0,0,0.12);
@@ -3822,12 +3828,11 @@
                             Pull from Cloud
                         </button>
                     </div>
-                    <div class="cloud-inline-form" id="cloud-pull-form">
-                        <input type="text" id="cloud-pull-name" placeholder="Project name"
-                               onkeydown="if(event.key==='Enter')cloudPullConfirm()">
+                    <div class="cloud-inline-form" id="cloud-pull-confirm">
+                        <span class="cloud-confirm-msg">Replace local files with the latest cloud version?</span>
                         <div class="cloud-form-row">
-                            <button class="btn btn-primary" onclick="cloudPullConfirm()">Pull</button>
-                            <button class="btn" onclick="cloudPullFormClose()">Cancel</button>
+                            <button class="btn btn-primary" onclick="cloudPullConfirm()">Replace</button>
+                            <button class="btn" onclick="cloudPullCancel()">Cancel</button>
                         </div>
                     </div>
                     <span class="cloud-status" id="cloud-status"></span>
@@ -9088,29 +9093,25 @@
 
         function cloudPullStart() {
             if (_cloudStreaming) return;
-            document.getElementById('cloud-pull-name').value = '';
             setCloudStatus('');
-            document.getElementById('cloud-pull-form').classList.add('visible');
-            setTimeout(() => document.getElementById('cloud-pull-name').focus(), 50);
+            document.getElementById('cloud-pull-confirm').classList.add('visible');
         }
 
-        function cloudPullFormClose() {
-            document.getElementById('cloud-pull-form').classList.remove('visible');
+        function cloudPullCancel() {
+            document.getElementById('cloud-pull-confirm').classList.remove('visible');
             setCloudStatus('');
         }
 
         async function cloudPullConfirm() {
             if (_cloudStreaming) return;
-            const name = document.getElementById('cloud-pull-name').value.trim();
-            if (!name) { setCloudStatus('Enter a project name', 'error'); return; }
-            document.getElementById('cloud-pull-form').classList.remove('visible');
+            document.getElementById('cloud-pull-confirm').classList.remove('visible');
             _cloudStreaming = true;
             setCloudStatus('Looking up project...');
             try {
                 const response = await fetch('/api/cloud/pull', {
                     method: 'POST',
                     headers: {'Content-Type': 'application/json'},
-                    body: JSON.stringify({name}),
+                    body: JSON.stringify({}),
                 });
                 if (!response.ok) {
                     const err = await response.json().catch(() => ({}));
@@ -9142,7 +9143,12 @@
                         if (data.type === 'status') {
                             setCloudStatus(data.message);
                         } else if (data.type === 'done') {
-                            setCloudStatus('Successfully saved to the cloud.', 'success');
+                            if (data.pulled) {
+                                setCloudStatus('Successfully pulled from cloud.', 'success');
+                                refreshTree();
+                            } else {
+                                setCloudStatus('Successfully saved to the cloud.', 'success');
+                            }
                             setTimeout(() => setCloudStatus(''), 4000);
                         } else if (data.type === 'error') {
                             setCloudStatus(data.message, 'error');

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -664,12 +664,11 @@
             justify-content: center;
             font-size: 12px;
             gap: 5px;
-            padding: 8px 12px;
             transition: border-radius 0.1s;
         }
 
         .cloud-split .cloud-caret {
-            padding: 8px 10px;
+            padding: 10px 10px;
             border-radius: 0 12px 12px 0;
             border-left: 1px solid rgba(0,0,0,0.08);
             transition: border-radius 0.1s;
@@ -3824,13 +3823,13 @@
             <!-- Cloud sync -->
             <div class="cloud-bar" id="cloud-bar">
                 <div class="cloud-split">
-                    <button class="btn cloud-main" id="cloud-push-btn" onclick="cloudPushStart()" disabled title="Run 'santai login' first">
+                    <button class="btn cloud-main" id="cloud-push-btn" onclick="cloudPushStart()">
                         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" style="width:15px;height:15px;">
                             <path stroke-linecap="round" stroke-linejoin="round" d="M12 16.5V9.75m0 0l3 3m-3-3l-3 3M6.75 19.5a4.5 4.5 0 01-1.41-8.775 5.25 5.25 0 0110.233-2.33 3 3 0 013.758 3.848A3.752 3.752 0 0118 19.5H6.75z" />
                         </svg>
                         Push to Cloud
                     </button>
-                    <button class="btn cloud-caret" id="cloud-caret-btn" onclick="toggleCloudMenu(event)" disabled title="More cloud options">
+                    <button class="btn cloud-caret" id="cloud-caret-btn" onclick="toggleCloudMenu(event)" title="More cloud options">
                         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" style="width:14px;height:14px;">
                             <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 8.25l7.5 7.5 7.5-7.5" />
                         </svg>
@@ -9085,13 +9084,11 @@
                 const data = await res.json();
                 if (data.logged_in) {
                     const pushBtn = document.getElementById('cloud-push-btn');
-                    const caretBtn = document.getElementById('cloud-caret-btn');
-                    if (pushBtn) { pushBtn.disabled = false; pushBtn.title = `Push to cloud${data.username ? ' (' + data.username + ')' : ''}`; }
-                    if (caretBtn) { caretBtn.disabled = false; caretBtn.title = 'More cloud options'; }
+                    if (pushBtn && data.username) pushBtn.title = `Push to cloud (${data.username})`;
                 } else {
                     setCloudStatus("Not logged in — run 'santai login'", 'error');
                 }
-            } catch { /* ignore network errors on status check */ }
+            } catch { /* ignore — buttons always clickable, backend returns error if needed */ }
         }
 
         function setCloudStatus(msg, type) {
@@ -9099,13 +9096,6 @@
             if (!el) return;
             el.textContent = msg;
             el.className = 'cloud-status' + (type ? ' ' + type : '');
-        }
-
-        function _setCloudBtnsDisabled(disabled) {
-            const pb = document.getElementById('cloud-push-btn');
-            const pc = document.getElementById('cloud-caret-btn');
-            if (pb) pb.disabled = disabled;
-            if (pc) pc.disabled = disabled;
         }
 
         function toggleCloudMenu(e) {
@@ -9126,7 +9116,6 @@
         async function cloudPushStart() {
             if (_cloudStreaming) return;
             _cloudStreaming = true;
-            _setCloudBtnsDisabled(true);
             setCloudStatus('Packaging...');
             try {
                 const response = await fetch('/api/cloud/push', {
@@ -9144,7 +9133,6 @@
                 setCloudStatus('Connection error', 'error');
             } finally {
                 _cloudStreaming = false;
-                _setCloudBtnsDisabled(false);
             }
         }
 
@@ -9168,7 +9156,6 @@
             if (!name) { setCloudStatus('Enter a project name', 'error'); return; }
             document.getElementById('cloud-pull-form').classList.remove('visible');
             _cloudStreaming = true;
-            _setCloudBtnsDisabled(true);
             setCloudStatus('Looking up project...');
             try {
                 const response = await fetch('/api/cloud/pull', {
@@ -9186,7 +9173,6 @@
                 setCloudStatus('Connection error', 'error');
             } finally {
                 _cloudStreaming = false;
-                _setCloudBtnsDisabled(false);
             }
         }
 

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -9065,16 +9065,41 @@
                     const pushBtn = document.getElementById('cloud-push-btn');
                     if (pushBtn && data.username) pushBtn.title = `Push to cloud (${data.username})`;
                 } else {
-                    setCloudStatus("Not logged in — run 'santai login'", 'error');
+                    setCloudStatus("Not logged in — run 'santai login'", 'error', true);
                 }
             } catch { /* ignore — buttons always clickable, backend returns error if needed */ }
         }
 
-        function setCloudStatus(msg, type) {
+        function setCloudStatus(msg, type, showLogin) {
             const el = document.getElementById('cloud-status');
             if (!el) return;
-            el.textContent = msg;
+            if (showLogin) {
+                const safe = msg.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+                el.innerHTML = `${safe}, or <a href="#" onclick="startCloudLogin(event)" style="color:inherit;text-decoration:underline">sign in here</a>`;
+            } else {
+                el.textContent = msg;
+            }
             el.className = 'cloud-status' + (type ? ' ' + type : '');
+        }
+
+        async function startCloudLogin(e) {
+            if (e) e.preventDefault();
+            try {
+                const res = await fetch('/api/cloud/login-url');
+                const data = await res.json();
+                const popup = window.open(data.url, '_blank');
+                const handler = function(event) {
+                    if (event.data === 'santai-signed-in') {
+                        window.removeEventListener('message', handler);
+                        initCloudStatus();
+                        setCloudStatus('Signed in. Ready to push/pull.', 'success');
+                        setTimeout(() => setCloudStatus(''), 4000);
+                    }
+                };
+                window.addEventListener('message', handler);
+            } catch {
+                setCloudStatus('Could not reach hub to start login.', 'error');
+            }
         }
 
         async function cloudPushStart() {
@@ -9160,7 +9185,7 @@
                             }
                             setTimeout(() => setCloudStatus(''), 4000);
                         } else if (data.type === 'error') {
-                            setCloudStatus(data.message, 'error');
+                            setCloudStatus(data.message, 'error', !!data.login_url);
                         }
                     } catch { /* ignore malformed SSE lines */ }
                 }

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -7996,11 +7996,11 @@
 
             // Intercept cloud commands before sending to LLM
             const _cmdText = userText.trim();
-            if (/^push(\s+to)?(\s+the)?\s+cloud[.!?]*$/i.test(_cmdText)) {
+            if (/^(push(\s+to)?|save(\s+to)?)\s+(the\s+)?cloud[.!?]*$/i.test(_cmdText)) {
                 await chatCloudPush();
                 return;
             }
-            if (/^pull(\s+from)?(\s+the)?\s+cloud[.!?]*$/i.test(_cmdText)) {
+            if (/^(pull(\s+from)?|load(\s+from)?)\s+(the\s+)?cloud[.!?]*$/i.test(_cmdText)) {
                 chatCloudPullInit();
                 return;
             }

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -3810,13 +3810,13 @@
                 <div class="cloud-sync" id="cloud-bar">
                     <div class="cloud-sync-btns">
                         <button class="btn" id="cloud-push-btn" onclick="cloudPushStart()">
-                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" style="width:13px;height:13px;flex-shrink:0;">
+                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" style="width:17px;height:17px;flex-shrink:0;display:block;">
                                 <path stroke-linecap="round" stroke-linejoin="round" d="M12 16.5V9.75m0 0l3 3m-3-3l-3 3M6.75 19.5a4.5 4.5 0 01-1.41-8.775 5.25 5.25 0 0110.233-2.33 3 3 0 013.758 3.848A3.752 3.752 0 0118 19.5H6.75z" />
                             </svg>
                             Push to Cloud
                         </button>
                         <button class="btn" id="cloud-pull-btn" onclick="cloudPullStart()">
-                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" style="width:13px;height:13px;flex-shrink:0;">
+                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" style="width:17px;height:17px;flex-shrink:0;display:block;">
                                 <path stroke-linecap="round" stroke-linejoin="round" d="M12 7.5V14.25m0 0l-3-3m3 3l3-3M6.75 19.5a4.5 4.5 0 01-1.41-8.775 5.25 5.25 0 0110.233-2.33 3 3 0 013.758 3.848A3.752 3.752 0 0118 19.5H6.75z" />
                             </svg>
                             Pull from Cloud
@@ -9142,7 +9142,7 @@
                         if (data.type === 'status') {
                             setCloudStatus(data.message);
                         } else if (data.type === 'done') {
-                            setCloudStatus('Successfully saved to the cloud', 'success');
+                            setCloudStatus('Successfully saved to the cloud.', 'success');
                             setTimeout(() => setCloudStatus(''), 4000);
                         } else if (data.type === 'error') {
                             setCloudStatus(data.message, 'error');

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -651,18 +651,79 @@
             display: flex;
             flex-direction: column;
             gap: 6px;
+            margin-bottom: -8px;
         }
 
-        .cloud-bar-row {
+        .cloud-split {
+            position: relative;
             display: flex;
-            gap: 6px;
+            gap: 1px;
         }
 
-        .cloud-bar-row .btn {
+        .cloud-split .cloud-main {
             flex: 1;
+            border-radius: 12px 0 0 12px;
             justify-content: center;
             font-size: 12px;
             gap: 5px;
+            transition: border-radius 0.1s;
+        }
+
+        .cloud-split .cloud-caret {
+            padding: 10px 10px;
+            border-radius: 0 12px 12px 0;
+            border-left: 1px solid rgba(0,0,0,0.08);
+            transition: border-radius 0.1s;
+        }
+
+        .cloud-split .cloud-caret svg {
+            transition: transform 0.2s ease;
+        }
+
+        .cloud-split:has(.cloud-popup.open) .cloud-caret {
+            border-radius: 0 0 12px 0;
+        }
+
+        .cloud-split:has(.cloud-popup.open) .cloud-caret svg {
+            transform: rotate(180deg);
+        }
+
+        .cloud-popup {
+            display: none;
+            position: absolute;
+            top: 100%;
+            right: 0;
+            background: rgba(255, 255, 255, 0.7);
+            backdrop-filter: blur(12px);
+            border: 1px solid rgba(0, 0, 0, 0.08);
+            border-top: none;
+            border-radius: 0 0 12px 12px;
+            box-shadow: 0 4px 16px rgba(0, 0, 0, 0.08);
+            overflow: hidden;
+            z-index: 200;
+            width: max-content;
+        }
+
+        .cloud-popup.open {
+            display: flex;
+            flex-direction: column;
+        }
+
+        .cloud-popup button {
+            display: flex;
+            align-items: center;
+            gap: 3px;
+            padding: 12px 10px;
+            background: none;
+            border: none;
+            font-size: 12px;
+            color: #333;
+            cursor: pointer;
+            white-space: nowrap;
+        }
+
+        .cloud-popup button:hover {
+            background: rgba(0, 0, 0, 0.05);
         }
 
         .cloud-status {
@@ -3768,19 +3829,26 @@
 
             <!-- Cloud sync -->
             <div class="cloud-bar">
-                <div class="cloud-bar-row">
-                    <button class="btn" id="cloud-push-btn" onclick="cloudPushStart()" disabled title="Run 'santai login' first">
+                <div class="cloud-split" id="cloud-split">
+                    <button class="btn cloud-main" id="cloud-push-btn" onclick="cloudPushStart()" disabled title="Run 'santai login' first">
                         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" style="width:15px;height:15px;">
                             <path stroke-linecap="round" stroke-linejoin="round" d="M12 16.5V9.75m0 0l3 3m-3-3l-3 3M6.75 19.5a4.5 4.5 0 01-1.41-8.775 5.25 5.25 0 0110.233-2.33 3 3 0 013.758 3.848A3.752 3.752 0 0118 19.5H6.75z" />
                         </svg>
                         Push to Cloud
                     </button>
-                    <button class="btn" id="cloud-pull-btn" onclick="cloudPullStart()" disabled title="Run 'santai login' first">
-                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" style="width:15px;height:15px;">
-                            <path stroke-linecap="round" stroke-linejoin="round" d="M12 7.5V14.25m0 0l-3-3m3 3l3-3M6.75 19.5a4.5 4.5 0 01-1.41-8.775 5.25 5.25 0 0110.233-2.33 3 3 0 013.758 3.848A3.752 3.752 0 0118 19.5H6.75z" />
+                    <button class="btn cloud-caret" id="cloud-caret-btn" onclick="toggleCloudMenu(event)" disabled title="More cloud options">
+                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" style="width:14px;height:14px;">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 8.25l7.5 7.5 7.5-7.5" />
                         </svg>
-                        Pull from Cloud
                     </button>
+                    <div class="cloud-popup" id="cloud-popup">
+                        <button onclick="cloudPullStart()">
+                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" style="width:15px;height:15px;">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M12 7.5V14.25m0 0l-3-3m3 3l3-3M6.75 19.5a4.5 4.5 0 01-1.41-8.775 5.25 5.25 0 0110.233-2.33 3 3 0 013.758 3.848A3.752 3.752 0 0118 19.5H6.75z" />
+                            </svg>
+                            Pull from Cloud
+                        </button>
+                    </div>
                 </div>
                 <div class="cloud-inline-form" id="cloud-pull-form">
                     <input type="text" id="cloud-pull-name" placeholder="Project name"
@@ -9023,9 +9091,9 @@
                 const data = await res.json();
                 if (data.logged_in) {
                     const pushBtn = document.getElementById('cloud-push-btn');
-                    const pullBtn = document.getElementById('cloud-pull-btn');
+                    const caretBtn = document.getElementById('cloud-caret-btn');
                     if (pushBtn) { pushBtn.disabled = false; pushBtn.title = `Push to cloud${data.username ? ' (' + data.username + ')' : ''}`; }
-                    if (pullBtn) { pullBtn.disabled = false; pullBtn.title = 'Pull a project from cloud'; }
+                    if (caretBtn) { caretBtn.disabled = false; caretBtn.title = 'More cloud options'; }
                 } else {
                     setCloudStatus("Not logged in — run 'santai login'", 'error');
                 }
@@ -9041,10 +9109,25 @@
 
         function _setCloudBtnsDisabled(disabled) {
             const pb = document.getElementById('cloud-push-btn');
-            const pu = document.getElementById('cloud-pull-btn');
+            const pc = document.getElementById('cloud-caret-btn');
             if (pb) pb.disabled = disabled;
-            if (pu) pu.disabled = disabled;
+            if (pc) pc.disabled = disabled;
         }
+
+        function toggleCloudMenu(e) {
+            e.stopPropagation();
+            document.getElementById('cloud-popup').classList.toggle('open');
+        }
+
+        function closeCloudMenu() {
+            document.getElementById('cloud-popup').classList.remove('open');
+        }
+
+        document.addEventListener('click', (e) => {
+            if (!document.getElementById('cloud-split').contains(e.target)) {
+                closeCloudMenu();
+            }
+        });
 
         async function cloudPushStart() {
             if (_cloudStreaming) return;
@@ -9072,6 +9155,7 @@
         }
 
         function cloudPullStart() {
+            closeCloudMenu();
             if (_cloudStreaming) return;
             document.getElementById('cloud-pull-name').value = '';
             setCloudStatus('');

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -8000,10 +8000,9 @@
             if (_chatPullPendingConfirm) {
                 if (/\b(yes|yeah|yep|yup|ok|okay|sure|go ahead|do it|proceed|confirm|absolutely|definitely|please|sounds good|let's go|go for it|affirmative|correct|right)\b/i.test(_cmdText)) {
                     _chatPullPendingConfirm = false;
-                    const _confirmDiv = _chatPullConfirmMsgDiv;
                     _chatPullConfirmMsgDiv = null;
-                    _confirmDiv.textContent = 'Looking up project…';
-                    await _chatCloudPullExecute(_confirmDiv);
+                    const _progressDiv = appendChatMessage('assistant', 'Looking up project…');
+                    await _chatCloudPullExecute(_progressDiv);
                     return;
                 }
                 // Non-affirmative: clear pending state and let message go to LLM
@@ -9275,7 +9274,7 @@
                 _chatShowCloudLoginError('pull');
                 return;
             }
-            const msg = 'This will replace your local project files with the latest cloud version. Are you sure?';
+            const msg = 'This will replace your local project files with the latest cloud version. Do you want to continue?';
             const msgDiv = appendChatMessage('assistant', msg);
             chatMessages.push({role: 'assistant', content: msg});
             saveChatHistory();

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -650,12 +650,10 @@
         .cloud-bar {
             display: flex;
             flex-direction: column;
-            gap: 6px;
-            margin-bottom: -8px;
+            margin-bottom: -12px;
         }
 
         .cloud-split {
-            position: relative;
             display: flex;
             gap: 1px;
         }
@@ -666,11 +664,12 @@
             justify-content: center;
             font-size: 12px;
             gap: 5px;
+            padding: 8px 12px;
             transition: border-radius 0.1s;
         }
 
         .cloud-split .cloud-caret {
-            padding: 10px 10px;
+            padding: 8px 10px;
             border-radius: 0 12px 12px 0;
             border-left: 1px solid rgba(0,0,0,0.08);
             transition: border-radius 0.1s;
@@ -680,28 +679,20 @@
             transition: transform 0.2s ease;
         }
 
-        .cloud-split:has(.cloud-popup.open) .cloud-caret {
-            border-radius: 0 0 12px 0;
+        .cloud-bar:has(.cloud-popup.open) .cloud-main {
+            border-bottom-left-radius: 0;
         }
 
-        .cloud-split:has(.cloud-popup.open) .cloud-caret svg {
+        .cloud-bar:has(.cloud-popup.open) .cloud-caret {
+            border-bottom-right-radius: 0;
+        }
+
+        .cloud-bar:has(.cloud-popup.open) .cloud-caret svg {
             transform: rotate(180deg);
         }
 
         .cloud-popup {
             display: none;
-            position: absolute;
-            top: 100%;
-            right: 0;
-            background: rgba(255, 255, 255, 0.7);
-            backdrop-filter: blur(12px);
-            border: 1px solid rgba(0, 0, 0, 0.08);
-            border-top: none;
-            border-radius: 0 0 12px 12px;
-            box-shadow: 0 4px 16px rgba(0, 0, 0, 0.08);
-            overflow: hidden;
-            z-index: 200;
-            width: max-content;
         }
 
         .cloud-popup.open {
@@ -710,20 +701,23 @@
         }
 
         .cloud-popup button {
+            background: rgba(255, 255, 255, 0.7);
+            border: none;
+            border-radius: 0 0 12px 12px;
+            padding: 8px 14px;
+            font-size: 12px;
+            font-weight: 500;
+            color: var(--text-primary);
+            cursor: pointer;
             display: flex;
             align-items: center;
-            gap: 3px;
-            padding: 12px 10px;
-            background: none;
-            border: none;
-            font-size: 12px;
-            color: #333;
-            cursor: pointer;
-            white-space: nowrap;
+            gap: 5px;
+            width: 100%;
+            justify-content: center;
         }
 
         .cloud-popup button:hover {
-            background: rgba(0, 0, 0, 0.05);
+            background: rgba(255, 255, 255, 0.9);
         }
 
         .cloud-status {
@@ -3828,8 +3822,8 @@
             </div>
 
             <!-- Cloud sync -->
-            <div class="cloud-bar">
-                <div class="cloud-split" id="cloud-split">
+            <div class="cloud-bar" id="cloud-bar">
+                <div class="cloud-split">
                     <button class="btn cloud-main" id="cloud-push-btn" onclick="cloudPushStart()" disabled title="Run 'santai login' first">
                         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" style="width:15px;height:15px;">
                             <path stroke-linecap="round" stroke-linejoin="round" d="M12 16.5V9.75m0 0l3 3m-3-3l-3 3M6.75 19.5a4.5 4.5 0 01-1.41-8.775 5.25 5.25 0 0110.233-2.33 3 3 0 013.758 3.848A3.752 3.752 0 0118 19.5H6.75z" />
@@ -3841,14 +3835,14 @@
                             <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 8.25l7.5 7.5 7.5-7.5" />
                         </svg>
                     </button>
-                    <div class="cloud-popup" id="cloud-popup">
-                        <button onclick="cloudPullStart()">
-                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" style="width:15px;height:15px;">
-                                <path stroke-linecap="round" stroke-linejoin="round" d="M12 7.5V14.25m0 0l-3-3m3 3l3-3M6.75 19.5a4.5 4.5 0 01-1.41-8.775 5.25 5.25 0 0110.233-2.33 3 3 0 013.758 3.848A3.752 3.752 0 0118 19.5H6.75z" />
-                            </svg>
-                            Pull from Cloud
-                        </button>
-                    </div>
+                </div>
+                <div class="cloud-popup" id="cloud-popup">
+                    <button onclick="cloudPullStart()">
+                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" style="width:15px;height:15px;">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M12 7.5V14.25m0 0l-3-3m3 3l3-3M6.75 19.5a4.5 4.5 0 01-1.41-8.775 5.25 5.25 0 0110.233-2.33 3 3 0 013.758 3.848A3.752 3.752 0 0118 19.5H6.75z" />
+                        </svg>
+                        Pull from Cloud
+                    </button>
                 </div>
                 <div class="cloud-inline-form" id="cloud-pull-form">
                     <input type="text" id="cloud-pull-name" placeholder="Project name"
@@ -9124,7 +9118,7 @@
         }
 
         document.addEventListener('click', (e) => {
-            if (!document.getElementById('cloud-split').contains(e.target)) {
+            if (!document.getElementById('cloud-bar').contains(e.target)) {
                 closeCloudMenu();
             }
         });

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -8019,7 +8019,7 @@
                 return;
             }
             if (/\b(pull|load)(\s+from)?\s+(the\s+)?cloud\b/i.test(_cmdText) && _cmdText.length < 150) {
-                chatCloudPullInit();
+                await chatCloudPullInit();
                 return;
             }
 
@@ -9274,7 +9274,7 @@
             }
         }
 
-        function chatCloudPullInit() {
+        async function chatCloudPullInit() {
             if (_cloudStreaming) {
                 appendChatMessage('assistant', 'A cloud operation is already in progress.');
                 return;
@@ -9283,7 +9283,10 @@
                 _chatShowCloudLoginError('pull');
                 return;
             }
-            const msg = 'This will replace your local project files with the latest cloud version. Do you want to continue?';
+            const removeThinking = showThinkingIndicator();
+            await new Promise(r => setTimeout(r, 1000));
+            removeThinking();
+            const msg = 'This will replace your local project files with the latest cloud version. Are you sure?';
             const msgDiv = appendChatMessage('assistant', msg);
             chatMessages.push({role: 'assistant', content: msg});
             saveChatHistory();

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -647,84 +647,22 @@
             white-space: nowrap;
         }
 
-        .cloud-section {
-            grid-column: 1 / -1;
+        .cloud-bar {
             display: flex;
             flex-direction: column;
             gap: 6px;
-            padding-top: 8px;
-            border-top: 1px solid rgba(0,0,0,0.07);
-            margin-top: 2px;
         }
 
-        .cloud-split {
-            position: relative;
+        .cloud-bar-row {
             display: flex;
-            gap: 1px;
+            gap: 6px;
         }
 
-        .cloud-split .cloud-main {
+        .cloud-bar-row .btn {
             flex: 1;
-            border-radius: 12px 0 0 12px;
             justify-content: center;
-            transition: border-radius 0.1s;
-        }
-
-        .cloud-split .cloud-caret {
-            padding: 10px 10px;
-            border-radius: 0 12px 12px 0;
-            border-left: 1px solid rgba(0,0,0,0.08);
-            transition: border-radius 0.1s;
-        }
-
-        .cloud-split .cloud-caret svg {
-            transition: transform 0.2s ease;
-        }
-
-        .cloud-split:has(.cloud-popup.open) .cloud-caret {
-            border-radius: 0 0 12px 0;
-        }
-
-        .cloud-split:has(.cloud-popup.open) .cloud-caret svg {
-            transform: rotate(180deg);
-        }
-
-        .cloud-popup {
-            display: none;
-            position: absolute;
-            bottom: 100%;
-            right: 0;
-            background: rgba(255, 255, 255, 0.7);
-            backdrop-filter: blur(12px);
-            border: 1px solid rgba(0, 0, 0, 0.08);
-            border-bottom: none;
-            border-radius: 12px 12px 0 12px;
-            box-shadow: 0 -4px 16px rgba(0, 0, 0, 0.08);
-            overflow: hidden;
-            z-index: 200;
-            width: max-content;
-        }
-
-        .cloud-popup.open {
-            display: flex;
-            flex-direction: column;
-        }
-
-        .cloud-popup button {
-            display: flex;
-            align-items: center;
-            gap: 3px;
-            padding: 16px 8px 16px 9px;
-            background: none;
-            border: none;
-            font-size: 13px;
-            color: #333;
-            cursor: pointer;
-            white-space: nowrap;
-        }
-
-        .cloud-popup button:hover {
-            background: rgba(0, 0, 0, 0.05);
+            font-size: 12px;
+            gap: 5px;
         }
 
         .cloud-status {
@@ -3828,6 +3766,33 @@
                 <h1 onclick="showDashboard()" style="cursor: pointer;">Santai</h1>
             </div>
 
+            <!-- Cloud sync -->
+            <div class="cloud-bar">
+                <div class="cloud-bar-row">
+                    <button class="btn" id="cloud-push-btn" onclick="cloudPushStart()" disabled title="Run 'santai login' first">
+                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" style="width:15px;height:15px;">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M12 16.5V9.75m0 0l3 3m-3-3l-3 3M6.75 19.5a4.5 4.5 0 01-1.41-8.775 5.25 5.25 0 0110.233-2.33 3 3 0 013.758 3.848A3.752 3.752 0 0118 19.5H6.75z" />
+                        </svg>
+                        Push to Cloud
+                    </button>
+                    <button class="btn" id="cloud-pull-btn" onclick="cloudPullStart()" disabled title="Run 'santai login' first">
+                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" style="width:15px;height:15px;">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M12 7.5V14.25m0 0l-3-3m3 3l3-3M6.75 19.5a4.5 4.5 0 01-1.41-8.775 5.25 5.25 0 0110.233-2.33 3 3 0 013.758 3.848A3.752 3.752 0 0118 19.5H6.75z" />
+                        </svg>
+                        Pull from Cloud
+                    </button>
+                </div>
+                <div class="cloud-inline-form" id="cloud-pull-form">
+                    <input type="text" id="cloud-pull-name" placeholder="Project name"
+                           onkeydown="if(event.key==='Enter')cloudPullConfirm()">
+                    <div class="cloud-form-row">
+                        <button class="btn btn-primary" onclick="cloudPullConfirm()">Pull</button>
+                        <button class="btn" onclick="cloudPullFormClose()">Cancel</button>
+                    </div>
+                </div>
+                <span class="cloud-status" id="cloud-status"></span>
+            </div>
+
             <!-- Tree View -->
             <div class="sidebar-section tree-container">
                 <div class="tree-search">
@@ -3881,39 +3846,6 @@
                             Folder Upload
                         </button>
                     </div>
-                </div>
-                <!-- Cloud sync -->
-                <div class="cloud-section">
-                    <div class="cloud-split" id="cloud-split">
-                        <button class="btn cloud-main" id="cloud-push-btn" onclick="cloudPushStart()" disabled title="Run 'santai login' first">
-                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" style="width:16px;height:16px;">
-                                <path stroke-linecap="round" stroke-linejoin="round" d="M12 16.5V9.75m0 0l3 3m-3-3l-3 3M6.75 19.5a4.5 4.5 0 01-1.41-8.775 5.25 5.25 0 0110.233-2.33 3 3 0 013.758 3.848A3.752 3.752 0 0118 19.5H6.75z" />
-                            </svg>
-                            Push to Cloud
-                        </button>
-                        <button class="btn cloud-caret" id="cloud-caret-btn" onclick="toggleCloudMenu(event)" disabled title="More cloud options">
-                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" style="width:14px;height:14px;">
-                                <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 15.75l7.5-7.5 7.5 7.5" />
-                            </svg>
-                        </button>
-                        <div class="cloud-popup" id="cloud-popup">
-                            <button onclick="cloudPullStart()">
-                                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" style="width:16px;height:16px;margin-left:-1px;">
-                                    <path stroke-linecap="round" stroke-linejoin="round" d="M12 7.5V14.25m0 0l-3-3m3 3l3-3M6.75 19.5a4.5 4.5 0 01-1.41-8.775 5.25 5.25 0 0110.233-2.33 3 3 0 013.758 3.848A3.752 3.752 0 0118 19.5H6.75z" />
-                                </svg>
-                                Pull from Cloud
-                            </button>
-                        </div>
-                    </div>
-                    <div class="cloud-inline-form" id="cloud-pull-form">
-                        <input type="text" id="cloud-pull-name" placeholder="Project name"
-                               onkeydown="if(event.key==='Enter')cloudPullConfirm()">
-                        <div class="cloud-form-row">
-                            <button class="btn btn-primary" onclick="cloudPullConfirm()">Pull</button>
-                            <button class="btn" onclick="cloudPullFormClose()">Cancel</button>
-                        </div>
-                    </div>
-                    <span class="cloud-status" id="cloud-status"></span>
                 </div>
             </div>
         </aside>
@@ -9091,9 +9023,9 @@
                 const data = await res.json();
                 if (data.logged_in) {
                     const pushBtn = document.getElementById('cloud-push-btn');
-                    const caretBtn = document.getElementById('cloud-caret-btn');
+                    const pullBtn = document.getElementById('cloud-pull-btn');
                     if (pushBtn) { pushBtn.disabled = false; pushBtn.title = `Push to cloud${data.username ? ' (' + data.username + ')' : ''}`; }
-                    if (caretBtn) { caretBtn.disabled = false; caretBtn.title = 'More cloud options'; }
+                    if (pullBtn) { pullBtn.disabled = false; pullBtn.title = 'Pull a project from cloud'; }
                 } else {
                     setCloudStatus("Not logged in — run 'santai login'", 'error');
                 }
@@ -9109,25 +9041,10 @@
 
         function _setCloudBtnsDisabled(disabled) {
             const pb = document.getElementById('cloud-push-btn');
-            const pc = document.getElementById('cloud-caret-btn');
+            const pu = document.getElementById('cloud-pull-btn');
             if (pb) pb.disabled = disabled;
-            if (pc) pc.disabled = disabled;
+            if (pu) pu.disabled = disabled;
         }
-
-        function toggleCloudMenu(e) {
-            e.stopPropagation();
-            document.getElementById('cloud-popup').classList.toggle('open');
-        }
-
-        function closeCloudMenu() {
-            document.getElementById('cloud-popup').classList.remove('open');
-        }
-
-        document.addEventListener('click', (e) => {
-            if (!document.getElementById('cloud-split').contains(e.target)) {
-                closeCloudMenu();
-            }
-        });
 
         async function cloudPushStart() {
             if (_cloudStreaming) return;
@@ -9155,7 +9072,6 @@
         }
 
         function cloudPullStart() {
-            closeCloudMenu();
             if (_cloudStreaming) return;
             document.getElementById('cloud-pull-name').value = '';
             setCloudStatus('');

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -647,76 +647,27 @@
             white-space: nowrap;
         }
 
-        .cloud-bar {
+        .cloud-sync {
             display: flex;
             flex-direction: column;
-            margin-bottom: -12px;
+            gap: 6px;
+            margin-bottom: 8px;
         }
 
-        .cloud-split {
+        .cloud-sync-btns {
             display: flex;
-            gap: 1px;
+            gap: 6px;
         }
 
-        .cloud-split .cloud-main {
+        .cloud-sync-btns .btn {
             flex: 1;
-            border-radius: 12px 0 0 12px;
             justify-content: center;
-            font-size: 12px;
-            gap: 5px;
-            transition: border-radius 0.1s;
-        }
-
-        .cloud-split .cloud-caret {
-            padding: 10px 10px;
-            border-radius: 0 12px 12px 0;
-            border-left: 1px solid rgba(0,0,0,0.08);
-            transition: border-radius 0.1s;
-        }
-
-        .cloud-split .cloud-caret svg {
-            transition: transform 0.2s ease;
-        }
-
-        .cloud-bar:has(.cloud-popup.open) .cloud-main {
-            border-bottom-left-radius: 0;
-        }
-
-        .cloud-bar:has(.cloud-popup.open) .cloud-caret {
-            border-bottom-right-radius: 0;
-        }
-
-        .cloud-bar:has(.cloud-popup.open) .cloud-caret svg {
-            transform: rotate(180deg);
-        }
-
-        .cloud-popup {
-            display: none;
-        }
-
-        .cloud-popup.open {
-            display: flex;
-            flex-direction: column;
-        }
-
-        .cloud-popup button {
-            background: rgba(255, 255, 255, 0.7);
-            border: none;
-            border-radius: 0 0 12px 12px;
-            padding: 8px 14px;
-            font-size: 12px;
-            font-weight: 500;
-            color: var(--text-primary);
-            cursor: pointer;
-            display: flex;
-            align-items: center;
-            gap: 5px;
-            width: 100%;
-            justify-content: center;
-        }
-
-        .cloud-popup button:hover {
-            background: rgba(255, 255, 255, 0.9);
+            font-size: 11px;
+            gap: 4px;
+            padding: 7px 6px;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
         }
 
         .cloud-status {
@@ -3820,40 +3771,6 @@
                 <h1 onclick="showDashboard()" style="cursor: pointer;">Santai</h1>
             </div>
 
-            <!-- Cloud sync -->
-            <div class="cloud-bar" id="cloud-bar">
-                <div class="cloud-split">
-                    <button class="btn cloud-main" id="cloud-push-btn" onclick="cloudPushStart()">
-                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" style="width:15px;height:15px;">
-                            <path stroke-linecap="round" stroke-linejoin="round" d="M12 16.5V9.75m0 0l3 3m-3-3l-3 3M6.75 19.5a4.5 4.5 0 01-1.41-8.775 5.25 5.25 0 0110.233-2.33 3 3 0 013.758 3.848A3.752 3.752 0 0118 19.5H6.75z" />
-                        </svg>
-                        Push to Cloud
-                    </button>
-                    <button class="btn cloud-caret" id="cloud-caret-btn" onclick="toggleCloudMenu(event)" title="More cloud options">
-                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" style="width:14px;height:14px;">
-                            <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 8.25l7.5 7.5 7.5-7.5" />
-                        </svg>
-                    </button>
-                </div>
-                <div class="cloud-popup" id="cloud-popup">
-                    <button onclick="cloudPullStart()">
-                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" style="width:15px;height:15px;">
-                            <path stroke-linecap="round" stroke-linejoin="round" d="M12 7.5V14.25m0 0l-3-3m3 3l3-3M6.75 19.5a4.5 4.5 0 01-1.41-8.775 5.25 5.25 0 0110.233-2.33 3 3 0 013.758 3.848A3.752 3.752 0 0118 19.5H6.75z" />
-                        </svg>
-                        Pull from Cloud
-                    </button>
-                </div>
-                <div class="cloud-inline-form" id="cloud-pull-form">
-                    <input type="text" id="cloud-pull-name" placeholder="Project name"
-                           onkeydown="if(event.key==='Enter')cloudPullConfirm()">
-                    <div class="cloud-form-row">
-                        <button class="btn btn-primary" onclick="cloudPullConfirm()">Pull</button>
-                        <button class="btn" onclick="cloudPullFormClose()">Cancel</button>
-                    </div>
-                </div>
-                <span class="cloud-status" id="cloud-status"></span>
-            </div>
-
             <!-- Tree View -->
             <div class="sidebar-section tree-container">
                 <div class="tree-search">
@@ -3866,6 +3783,32 @@
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
                         </svg>
                     </button>
+                </div>
+                <!-- Cloud sync -->
+                <div class="cloud-sync" id="cloud-bar">
+                    <div class="cloud-sync-btns">
+                        <button class="btn" id="cloud-push-btn" onclick="cloudPushStart()">
+                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" style="width:13px;height:13px;flex-shrink:0;">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M12 16.5V9.75m0 0l3 3m-3-3l-3 3M6.75 19.5a4.5 4.5 0 01-1.41-8.775 5.25 5.25 0 0110.233-2.33 3 3 0 013.758 3.848A3.752 3.752 0 0118 19.5H6.75z" />
+                            </svg>
+                            Push to Cloud
+                        </button>
+                        <button class="btn" id="cloud-pull-btn" onclick="cloudPullStart()">
+                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" style="width:13px;height:13px;flex-shrink:0;">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M12 7.5V14.25m0 0l-3-3m3 3l3-3M6.75 19.5a4.5 4.5 0 01-1.41-8.775 5.25 5.25 0 0110.233-2.33 3 3 0 013.758 3.848A3.752 3.752 0 0118 19.5H6.75z" />
+                            </svg>
+                            Pull from Cloud
+                        </button>
+                    </div>
+                    <div class="cloud-inline-form" id="cloud-pull-form">
+                        <input type="text" id="cloud-pull-name" placeholder="Project name"
+                               onkeydown="if(event.key==='Enter')cloudPullConfirm()">
+                        <div class="cloud-form-row">
+                            <button class="btn btn-primary" onclick="cloudPullConfirm()">Pull</button>
+                            <button class="btn" onclick="cloudPullFormClose()">Cancel</button>
+                        </div>
+                    </div>
+                    <span class="cloud-status" id="cloud-status"></span>
                 </div>
                 <ul class="tree-view" id="tree-view"></ul>
             </div>
@@ -9098,21 +9041,6 @@
             el.className = 'cloud-status' + (type ? ' ' + type : '');
         }
 
-        function toggleCloudMenu(e) {
-            e.stopPropagation();
-            document.getElementById('cloud-popup').classList.toggle('open');
-        }
-
-        function closeCloudMenu() {
-            document.getElementById('cloud-popup').classList.remove('open');
-        }
-
-        document.addEventListener('click', (e) => {
-            if (!document.getElementById('cloud-bar').contains(e.target)) {
-                closeCloudMenu();
-            }
-        });
-
         async function cloudPushStart() {
             if (_cloudStreaming) return;
             _cloudStreaming = true;
@@ -9137,7 +9065,6 @@
         }
 
         function cloudPullStart() {
-            closeCloudMenu();
             if (_cloudStreaming) return;
             document.getElementById('cloud-pull-name').value = '';
             setCloudStatus('');

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -8001,6 +8001,9 @@
                 if (/\b(yes|yeah|yep|yup|ok|okay|sure|go ahead|do it|proceed|confirm|absolutely|definitely|please|sounds good|let's go|go for it|affirmative|correct|right)\b/i.test(_cmdText)) {
                     _chatPullPendingConfirm = false;
                     _chatPullConfirmMsgDiv = null;
+                    const _removeThinking = showThinkingIndicator();
+                    await new Promise(r => setTimeout(r, 1000));
+                    _removeThinking();
                     const _progressDiv = appendChatMessage('assistant', 'Looking up project…');
                     await _chatCloudPullExecute(_progressDiv);
                     return;
@@ -9240,24 +9243,30 @@
                 return;
             }
             _cloudStreaming = true;
-            const msgDiv = appendChatMessage('assistant', 'Packaging…');
+            const removeThinking = showThinkingIndicator();
             try {
-                const response = await fetch('/api/cloud/push', {
-                    method: 'POST',
-                    headers: {'Content-Type': 'application/json'},
-                    body: JSON.stringify({include_env: false}),
-                });
+                const [response] = await Promise.all([
+                    fetch('/api/cloud/push', {
+                        method: 'POST',
+                        headers: {'Content-Type': 'application/json'},
+                        body: JSON.stringify({include_env: false}),
+                    }),
+                    new Promise(r => setTimeout(r, 1000)),
+                ]);
+                removeThinking();
                 if (!response.ok) {
                     const err = await response.json().catch(() => ({}));
                     const text = err.detail || 'Push failed.';
-                    msgDiv.textContent = text;
+                    appendChatMessage('assistant', text);
                     chatMessages.push({role: 'assistant', content: text});
                     saveChatHistory();
                     return;
                 }
+                const msgDiv = appendChatMessage('assistant', 'Packaging…');
                 await _readCloudStreamToChat(response, 'push', msgDiv);
             } catch {
-                msgDiv.textContent = 'Connection error.';
+                removeThinking();
+                appendChatMessage('assistant', 'Connection error.');
                 chatMessages.push({role: 'assistant', content: 'Connection error.'});
                 saveChatHistory();
             } finally {

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -7996,11 +7996,11 @@
 
             // Intercept cloud commands before sending to LLM
             const _cmdText = userText.trim();
-            if (/^(push(\s+to)?|save(\s+to)?)\s+(the\s+)?cloud[.!?]*$/i.test(_cmdText)) {
+            if (/\b(push|save)(\s+to)?\s+(the\s+)?cloud\b/i.test(_cmdText) && _cmdText.length < 150) {
                 await chatCloudPush();
                 return;
             }
-            if (/^(pull(\s+from)?|load(\s+from)?)\s+(the\s+)?cloud[.!?]*$/i.test(_cmdText)) {
+            if (/\b(pull|load)(\s+from)?\s+(the\s+)?cloud\b/i.test(_cmdText) && _cmdText.length < 150) {
                 chatCloudPullInit();
                 return;
             }

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -7999,7 +7999,8 @@
             // If awaiting post-login action confirmation
             if (_chatPostLoginPending) {
                 const _pendingAction = _chatPostLoginPending;
-                if (/\b(yes|yeah|yep|yup|ok|okay|sure|go ahead|do it|proceed|confirm|absolutely|definitely|please|sounds good|let's go|go for it|affirmative|correct|right)\b/i.test(_cmdText)) {
+                const _loginNegated = /\b(no|not|don'?t|never|cancel|nope|stop)\b/i.test(_cmdText);
+                if (!_loginNegated && /\b(yes|yeah|yep|yup|ok|okay|sure|go ahead|do it|proceed|confirm|absolutely|definitely|please|sounds good|let's go|go for it|affirmative|correct|right)\b/i.test(_cmdText)) {
                     _chatPostLoginPending = null;
                     if (_pendingAction === 'push') {
                         await chatCloudPush();
@@ -8018,9 +8019,9 @@
 
             // If awaiting pull confirmation, check for affirmative before anything else
             if (_chatPullPendingConfirm) {
-                if (/\b(yes|yeah|yep|yup|ok|okay|sure|go ahead|do it|proceed|confirm|absolutely|definitely|please|sounds good|let's go|go for it|affirmative|correct|right)\b/i.test(_cmdText)) {
+                const _pullNegated = /\b(no|not|don'?t|never|cancel|nope|stop)\b/i.test(_cmdText);
+                if (!_pullNegated && /\b(yes|yeah|yep|yup|ok|okay|sure|go ahead|do it|proceed|confirm|absolutely|definitely|please|sounds good|let's go|go for it|affirmative|correct|right)\b/i.test(_cmdText)) {
                     _chatPullPendingConfirm = false;
-                    _chatPullConfirmMsgDiv = null;
                     const _removeThinking = showThinkingIndicator();
                     await new Promise(r => setTimeout(r, 1000));
                     _removeThinking();
@@ -8030,15 +8031,16 @@
                 }
                 // Non-affirmative: clear pending state and let message go to LLM
                 _chatPullPendingConfirm = false;
-                _chatPullConfirmMsgDiv = null;
             }
 
-            // Intercept cloud commands before sending to LLM
-            if (/\b(push|save)(\s+to)?\s+(the\s+)?cloud\b/i.test(_cmdText) && _cmdText.length < 150) {
+            // Intercept cloud commands before sending to LLM.
+            // Negation check prevents "don't push to cloud" from triggering an action.
+            const _cmdNegated = /\b(no|not|don'?t|never|cancel|nope|stop|without)\b/i.test(_cmdText);
+            if (!_cmdNegated && /\b(push|save)(\s+to)?\s+(the\s+)?cloud\b/i.test(_cmdText) && _cmdText.length < 150) {
                 await chatCloudPush();
                 return;
             }
-            if (/\b(pull|load)(\s+from)?\s+(the\s+)?cloud\b/i.test(_cmdText) && _cmdText.length < 150) {
+            if (!_cmdNegated && /\b(pull|load)(\s+from)?\s+(the\s+)?cloud\b/i.test(_cmdText) && _cmdText.length < 150) {
                 await chatCloudPullInit();
                 return;
             }
@@ -9104,9 +9106,8 @@
         // ── Cloud push / pull ────────────────────────────────────────────────
 
         let _cloudStreaming = false;
-        let _cloudLoggedIn = true;
+        let _cloudLoggedIn = false;
         let _chatPullPendingConfirm = false;
-        let _chatPullConfirmMsgDiv = null;
         let _chatPostLoginPending = null; // 'push' | 'pull'
 
         async function initCloudStatus() {
@@ -9318,7 +9319,6 @@
             chatMessages.push({role: 'assistant', content: msg});
             saveChatHistory();
             _chatPullPendingConfirm = true;
-            _chatPullConfirmMsgDiv = msgDiv;
         }
 
         async function _chatCloudPullExecute(msgDiv) {

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -9074,7 +9074,7 @@
             const el = document.getElementById('cloud-status');
             if (!el) return;
             if (showLogin) {
-                const safe = msg.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+                const safe = msg.replace(/[.!?]+$/, '').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
                 el.innerHTML = `${safe}, or <a href="#" onclick="startCloudLogin(event)" style="color:inherit;text-decoration:underline">sign in here</a>`;
             } else {
                 el.textContent = msg;
@@ -9092,7 +9092,7 @@
                     if (event.data === 'santai-signed-in') {
                         window.removeEventListener('message', handler);
                         initCloudStatus();
-                        setCloudStatus('Signed in. Ready to push/pull.', 'success');
+                        setCloudStatus('Signed in. Ready to push to cloud.', 'success');
                         setTimeout(() => setCloudStatus(''), 4000);
                     }
                 };

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -657,24 +657,74 @@
             margin-top: 2px;
         }
 
-        .cloud-section-header {
+        .cloud-split {
+            position: relative;
+            display: flex;
+            gap: 1px;
+        }
+
+        .cloud-split .cloud-main {
+            flex: 1;
+            border-radius: 12px 0 0 12px;
+            justify-content: center;
+            transition: border-radius 0.1s;
+        }
+
+        .cloud-split .cloud-caret {
+            padding: 10px 10px;
+            border-radius: 0 12px 12px 0;
+            border-left: 1px solid rgba(0,0,0,0.08);
+            transition: border-radius 0.1s;
+        }
+
+        .cloud-split .cloud-caret svg {
+            transition: transform 0.2s ease;
+        }
+
+        .cloud-split:has(.cloud-popup.open) .cloud-caret {
+            border-radius: 0 0 12px 0;
+        }
+
+        .cloud-split:has(.cloud-popup.open) .cloud-caret svg {
+            transform: rotate(180deg);
+        }
+
+        .cloud-popup {
+            display: none;
+            position: absolute;
+            bottom: 100%;
+            right: 0;
+            background: rgba(255, 255, 255, 0.7);
+            backdrop-filter: blur(12px);
+            border: 1px solid rgba(0, 0, 0, 0.08);
+            border-bottom: none;
+            border-radius: 12px 12px 0 12px;
+            box-shadow: 0 -4px 16px rgba(0, 0, 0, 0.08);
+            overflow: hidden;
+            z-index: 200;
+            width: max-content;
+        }
+
+        .cloud-popup.open {
+            display: flex;
+            flex-direction: column;
+        }
+
+        .cloud-popup button {
             display: flex;
             align-items: center;
-            gap: 5px;
-            font-size: 11px;
-            font-weight: 600;
-            color: var(--text-muted);
-            text-transform: uppercase;
-            letter-spacing: 0.05em;
+            gap: 3px;
+            padding: 16px 8px 16px 9px;
+            background: none;
+            border: none;
+            font-size: 13px;
+            color: #333;
+            cursor: pointer;
+            white-space: nowrap;
         }
 
-        .cloud-btns {
-            display: flex;
-            gap: 6px;
-        }
-
-        .cloud-btns .btn {
-            flex: 1;
+        .cloud-popup button:hover {
+            background: rgba(0, 0, 0, 0.05);
         }
 
         .cloud-status {
@@ -710,15 +760,6 @@
         .cloud-inline-form input[type="text"]:focus {
             outline: none;
             border-color: var(--accent);
-        }
-
-        .cloud-inline-form label {
-            display: flex;
-            align-items: center;
-            gap: 6px;
-            font-size: 12px;
-            color: var(--text-secondary, var(--text-muted));
-            cursor: pointer;
         }
 
         .cloud-form-row {
@@ -3843,44 +3884,33 @@
                 </div>
                 <!-- Cloud sync -->
                 <div class="cloud-section">
-                    <div class="cloud-section-header">
-                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" style="width:12px;height:12px;stroke-width:2.5;">
-                            <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 15a4.5 4.5 0 004.5 4.5H18a3.75 3.75 0 001.332-7.257 3 3 0 00-3.758-3.848 5.25 5.25 0 00-10.233 2.33A4.502 4.502 0 002.25 15z" />
-                        </svg>
-                        Cloud
-                    </div>
-                    <div class="cloud-btns">
-                        <button class="btn" id="cloud-push-btn" onclick="cloudPushToggle()" disabled title="Run 'santai login' first">
-                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" style="width:15px;height:15px;">
+                    <div class="cloud-split" id="cloud-split">
+                        <button class="btn cloud-main" id="cloud-push-btn" onclick="cloudPushStart()" disabled title="Run 'santai login' first">
+                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" style="width:16px;height:16px;">
                                 <path stroke-linecap="round" stroke-linejoin="round" d="M12 16.5V9.75m0 0l3 3m-3-3l-3 3M6.75 19.5a4.5 4.5 0 01-1.41-8.775 5.25 5.25 0 0110.233-2.33 3 3 0 013.758 3.848A3.752 3.752 0 0118 19.5H6.75z" />
                             </svg>
-                            Push
+                            Push to Cloud
                         </button>
-                        <button class="btn" id="cloud-pull-btn" onclick="cloudPullToggle()" disabled title="Run 'santai login' first">
-                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" style="width:15px;height:15px;">
-                                <path stroke-linecap="round" stroke-linejoin="round" d="M12 7.5h1.5m-1.5 3h1.5m-7.5 3h7.5m-7.5 3h7.5m3-9h3.375c.621 0 1.125.504 1.125 1.125V18a2.25 2.25 0 01-2.25 2.25M16.5 7.5V18a2.25 2.25 0 002.25 2.25M16.5 7.5V4.875c0-.621-.504-1.125-1.125-1.125H4.5A1.125 1.125 0 003.375 6v12c0 .621.504 1.125 1.125 1.125H5.25M9 8.25v2.25M12 8.25v2.25" />
+                        <button class="btn cloud-caret" id="cloud-caret-btn" onclick="toggleCloudMenu(event)" disabled title="More cloud options">
+                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" style="width:14px;height:14px;">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 15.75l7.5-7.5 7.5 7.5" />
                             </svg>
-                            Pull
                         </button>
-                    </div>
-                    <!-- Push options form -->
-                    <div class="cloud-inline-form" id="cloud-push-form">
-                        <label>
-                            <input type="checkbox" id="cloud-push-include-env">
-                            Include .env file
-                        </label>
-                        <div class="cloud-form-row">
-                            <button class="btn btn-primary" onclick="cloudPushConfirm()">Push</button>
-                            <button class="btn" onclick="cloudPushToggle()">Cancel</button>
+                        <div class="cloud-popup" id="cloud-popup">
+                            <button onclick="cloudPullStart()">
+                                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" style="width:16px;height:16px;margin-left:-1px;">
+                                    <path stroke-linecap="round" stroke-linejoin="round" d="M12 7.5V14.25m0 0l-3-3m3 3l3-3M6.75 19.5a4.5 4.5 0 01-1.41-8.775 5.25 5.25 0 0110.233-2.33 3 3 0 013.758 3.848A3.752 3.752 0 0118 19.5H6.75z" />
+                                </svg>
+                                Pull from Cloud
+                            </button>
                         </div>
                     </div>
-                    <!-- Pull name form -->
                     <div class="cloud-inline-form" id="cloud-pull-form">
                         <input type="text" id="cloud-pull-name" placeholder="Project name"
                                onkeydown="if(event.key==='Enter')cloudPullConfirm()">
                         <div class="cloud-form-row">
                             <button class="btn btn-primary" onclick="cloudPullConfirm()">Pull</button>
-                            <button class="btn" onclick="cloudPullToggle()">Cancel</button>
+                            <button class="btn" onclick="cloudPullFormClose()">Cancel</button>
                         </div>
                     </div>
                     <span class="cloud-status" id="cloud-status"></span>
@@ -9059,13 +9089,11 @@
                 const res = await fetch('/api/cloud/status');
                 if (!res.ok) return;
                 const data = await res.json();
-                const pushBtn = document.getElementById('cloud-push-btn');
-                const pullBtn = document.getElementById('cloud-pull-btn');
                 if (data.logged_in) {
-                    pushBtn.disabled = false;
-                    pushBtn.title = `Push to cloud${data.username ? ' (' + data.username + ')' : ''}`;
-                    pullBtn.disabled = false;
-                    pullBtn.title = 'Pull a project from cloud';
+                    const pushBtn = document.getElementById('cloud-push-btn');
+                    const caretBtn = document.getElementById('cloud-caret-btn');
+                    if (pushBtn) { pushBtn.disabled = false; pushBtn.title = `Push to cloud${data.username ? ' (' + data.username + ')' : ''}`; }
+                    if (caretBtn) { caretBtn.disabled = false; caretBtn.title = 'More cloud options'; }
                 } else {
                     setCloudStatus("Not logged in — run 'santai login'", 'error');
                 }
@@ -9081,39 +9109,28 @@
 
         function _setCloudBtnsDisabled(disabled) {
             const pb = document.getElementById('cloud-push-btn');
-            const pu = document.getElementById('cloud-pull-btn');
+            const pc = document.getElementById('cloud-caret-btn');
             if (pb) pb.disabled = disabled;
-            if (pu) pu.disabled = disabled;
+            if (pc) pc.disabled = disabled;
         }
 
-        function cloudPushToggle() {
-            if (_cloudStreaming) return;
-            const pushForm = document.getElementById('cloud-push-form');
-            const pullForm = document.getElementById('cloud-pull-form');
-            const opening = !pushForm.classList.contains('visible');
-            pullForm.classList.remove('visible');
-            pushForm.classList.toggle('visible', opening);
-            if (opening) setCloudStatus('');
+        function toggleCloudMenu(e) {
+            e.stopPropagation();
+            document.getElementById('cloud-popup').classList.toggle('open');
         }
 
-        function cloudPullToggle() {
-            if (_cloudStreaming) return;
-            const pushForm = document.getElementById('cloud-push-form');
-            const pullForm = document.getElementById('cloud-pull-form');
-            const opening = !pullForm.classList.contains('visible');
-            pushForm.classList.remove('visible');
-            pullForm.classList.toggle('visible', opening);
-            if (opening) {
-                document.getElementById('cloud-pull-name').value = '';
-                setCloudStatus('');
-                setTimeout(() => document.getElementById('cloud-pull-name').focus(), 50);
+        function closeCloudMenu() {
+            document.getElementById('cloud-popup').classList.remove('open');
+        }
+
+        document.addEventListener('click', (e) => {
+            if (!document.getElementById('cloud-split').contains(e.target)) {
+                closeCloudMenu();
             }
-        }
+        });
 
-        async function cloudPushConfirm() {
+        async function cloudPushStart() {
             if (_cloudStreaming) return;
-            const includeEnv = document.getElementById('cloud-push-include-env').checked;
-            document.getElementById('cloud-push-form').classList.remove('visible');
             _cloudStreaming = true;
             _setCloudBtnsDisabled(true);
             setCloudStatus('Packaging...');
@@ -9121,7 +9138,7 @@
                 const response = await fetch('/api/cloud/push', {
                     method: 'POST',
                     headers: {'Content-Type': 'application/json'},
-                    body: JSON.stringify({include_env: includeEnv}),
+                    body: JSON.stringify({include_env: false}),
                 });
                 if (!response.ok) {
                     const err = await response.json().catch(() => ({}));
@@ -9135,6 +9152,20 @@
                 _cloudStreaming = false;
                 _setCloudBtnsDisabled(false);
             }
+        }
+
+        function cloudPullStart() {
+            closeCloudMenu();
+            if (_cloudStreaming) return;
+            document.getElementById('cloud-pull-name').value = '';
+            setCloudStatus('');
+            document.getElementById('cloud-pull-form').classList.add('visible');
+            setTimeout(() => document.getElementById('cloud-pull-name').focus(), 50);
+        }
+
+        function cloudPullFormClose() {
+            document.getElementById('cloud-pull-form').classList.remove('visible');
+            setCloudStatus('');
         }
 
         async function cloudPullConfirm() {

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -9146,6 +9146,7 @@
                             if (data.pulled) {
                                 setCloudStatus('Successfully pulled from cloud.', 'success');
                                 refreshTree();
+                                refreshFiles();
                             } else {
                                 setCloudStatus('Successfully saved to the cloud.', 'success');
                             }

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -7994,6 +7994,17 @@
             saveChatHistory();
             chatHideEmptyState();
 
+            // Intercept cloud commands before sending to LLM
+            const _cmdText = userText.trim();
+            if (/^push(\s+to)?(\s+the)?\s+cloud[.!?]*$/i.test(_cmdText)) {
+                await chatCloudPush();
+                return;
+            }
+            if (/^pull(\s+from)?(\s+the)?\s+cloud[.!?]*$/i.test(_cmdText)) {
+                chatCloudPullInit();
+                return;
+            }
+
             await _streamFromMessages();
         }
 
@@ -9197,6 +9208,184 @@
                         }
                     } catch { /* ignore malformed SSE lines */ }
                 }
+            }
+        }
+
+        // --- Chat-triggered cloud operations ---
+
+        async function chatCloudPush() {
+            if (_cloudStreaming) {
+                appendChatMessage('assistant', 'A cloud operation is already in progress.');
+                return;
+            }
+            if (!_cloudLoggedIn) {
+                _chatShowCloudLoginError('push');
+                return;
+            }
+            _cloudStreaming = true;
+            const msgDiv = appendChatMessage('assistant', 'Packaging…');
+            try {
+                const response = await fetch('/api/cloud/push', {
+                    method: 'POST',
+                    headers: {'Content-Type': 'application/json'},
+                    body: JSON.stringify({include_env: false}),
+                });
+                if (!response.ok) {
+                    const err = await response.json().catch(() => ({}));
+                    const text = err.detail || 'Push failed.';
+                    msgDiv.textContent = text;
+                    chatMessages.push({role: 'assistant', content: text});
+                    saveChatHistory();
+                    return;
+                }
+                await _readCloudStreamToChat(response, 'push', msgDiv);
+            } catch {
+                msgDiv.textContent = 'Connection error.';
+                chatMessages.push({role: 'assistant', content: 'Connection error.'});
+                saveChatHistory();
+            } finally {
+                _cloudStreaming = false;
+            }
+        }
+
+        function chatCloudPullInit() {
+            if (_cloudStreaming) {
+                appendChatMessage('assistant', 'A cloud operation is already in progress.');
+                return;
+            }
+            if (!_cloudLoggedIn) {
+                _chatShowCloudLoginError('pull');
+                return;
+            }
+            const msgDiv = appendChatMessage('assistant', '');
+            msgDiv.textContent = 'This will replace your local project files with the cloud version.';
+            const row = document.createElement('div');
+            row.style.cssText = 'display:flex;gap:8px;margin-top:10px;';
+            const confirmBtn = document.createElement('button');
+            confirmBtn.textContent = 'Replace';
+            confirmBtn.className = 'btn btn-primary';
+            const cancelBtn = document.createElement('button');
+            cancelBtn.textContent = 'Cancel';
+            cancelBtn.className = 'btn';
+            row.appendChild(confirmBtn);
+            row.appendChild(cancelBtn);
+            msgDiv.appendChild(row);
+            confirmBtn.onclick = async () => {
+                row.remove();
+                msgDiv.textContent = 'Looking up project…';
+                await _chatCloudPullExecute(msgDiv);
+            };
+            cancelBtn.onclick = () => {
+                msgDiv.textContent = 'Pull cancelled.';
+                chatMessages.push({role: 'assistant', content: 'Pull cancelled.'});
+                saveChatHistory();
+            };
+        }
+
+        async function _chatCloudPullExecute(msgDiv) {
+            _cloudStreaming = true;
+            try {
+                const response = await fetch('/api/cloud/pull', {
+                    method: 'POST',
+                    headers: {'Content-Type': 'application/json'},
+                    body: JSON.stringify({}),
+                });
+                if (!response.ok) {
+                    const err = await response.json().catch(() => ({}));
+                    const text = err.detail || 'Pull failed.';
+                    msgDiv.textContent = text;
+                    chatMessages.push({role: 'assistant', content: text});
+                    saveChatHistory();
+                    return;
+                }
+                await _readCloudStreamToChat(response, 'pull', msgDiv);
+            } catch {
+                msgDiv.textContent = 'Connection error.';
+                chatMessages.push({role: 'assistant', content: 'Connection error.'});
+                saveChatHistory();
+            } finally {
+                _cloudStreaming = false;
+            }
+        }
+
+        async function _readCloudStreamToChat(response, context, msgDiv) {
+            const reader = response.body.getReader();
+            const decoder = new TextDecoder();
+            let buffer = '';
+            while (true) {
+                const {done, value} = await reader.read();
+                if (done) break;
+                buffer += decoder.decode(value, {stream: true});
+                const lines = buffer.split('\n');
+                buffer = lines.pop() || '';
+                for (const line of lines) {
+                    if (!line.startsWith('data: ')) continue;
+                    try {
+                        const data = JSON.parse(line.slice(6));
+                        if (data.type === 'status') {
+                            msgDiv.textContent = data.message;
+                        } else if (data.type === 'done') {
+                            let finalMsg;
+                            if (data.pulled) {
+                                await Promise.all([refreshTree(), refreshFiles()]);
+                                finalMsg = 'Successfully pulled from cloud.';
+                            } else {
+                                finalMsg = 'Successfully saved to the cloud.';
+                            }
+                            msgDiv.textContent = finalMsg;
+                            chatMessages.push({role: 'assistant', content: finalMsg});
+                            saveChatHistory();
+                        } else if (data.type === 'error') {
+                            if (data.login_url) {
+                                const safe = (data.message || 'Not signed in').replace(/[.!?]+$/, '').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+                                msgDiv.innerHTML = `${safe}, or <a href="#" style="color:inherit;text-decoration:underline">sign in here</a>.`;
+                                msgDiv.querySelector('a').addEventListener('click', async (e) => {
+                                    e.preventDefault();
+                                    await _chatStartCloudLogin(context, msgDiv);
+                                });
+                                chatMessages.push({role: 'assistant', content: data.message || 'Not signed in.'});
+                                saveChatHistory();
+                            } else {
+                                const text = data.message || 'Error.';
+                                msgDiv.textContent = text;
+                                chatMessages.push({role: 'assistant', content: text});
+                                saveChatHistory();
+                            }
+                        }
+                    } catch { /* ignore malformed SSE */ }
+                }
+            }
+        }
+
+        function _chatShowCloudLoginError(context) {
+            const msgDiv = appendChatMessage('assistant', '');
+            const action = context === 'pull' ? 'pull from the cloud' : 'push to the cloud';
+            msgDiv.innerHTML = `Not signed in to Santai Cloud, or <a href="#" style="color:inherit;text-decoration:underline">sign in here</a>.`;
+            msgDiv.querySelector('a').addEventListener('click', async (e) => {
+                e.preventDefault();
+                await _chatStartCloudLogin(context, msgDiv);
+            });
+            chatMessages.push({role: 'assistant', content: `Not signed in to Santai Cloud. Sign in to ${action}.`});
+            saveChatHistory();
+        }
+
+        async function _chatStartCloudLogin(context, msgDiv) {
+            try {
+                const res = await fetch('/api/cloud/login-url');
+                const data = await res.json();
+                window.open(data.url, '_blank');
+                const handler = function(event) {
+                    if (event.data === 'santai-signed-in') {
+                        window.removeEventListener('message', handler);
+                        _cloudLoggedIn = true;
+                        initCloudStatus();
+                        const action = context === 'pull' ? 'pull from the cloud' : 'push to the cloud';
+                        msgDiv.textContent = `Signed in. Ready to ${action}.`;
+                    }
+                };
+                window.addEventListener('message', handler);
+            } catch {
+                msgDiv.textContent = 'Could not reach hub to start login.';
             }
         }
 

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -3817,7 +3817,7 @@
                         </button>
                         <button class="btn" id="cloud-pull-btn" onclick="cloudPullStart()">
                             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" style="width:17px;height:17px;flex-shrink:0;display:block;">
-                                <path stroke-linecap="round" stroke-linejoin="round" d="M12 7.5V14.25m0 0l-3-3m3 3l3-3M6.75 19.5a4.5 4.5 0 01-1.41-8.775 5.25 5.25 0 0110.233-2.33 3 3 0 013.758 3.848A3.752 3.752 0 0118 19.5H6.75z" />
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M12 9V15.75m0 0l-3-3m3 3l3-3M6.75 19.5a4.5 4.5 0 01-1.41-8.775 5.25 5.25 0 0110.233-2.33 3 3 0 013.758 3.848A3.752 3.752 0 0118 19.5H6.75z" />
                             </svg>
                             Pull from Cloud
                         </button>

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -9123,9 +9123,11 @@
             } catch { /* ignore — buttons always clickable, backend returns error if needed */ }
         }
 
+        let _cloudStatusTimer = null;
         function setCloudStatus(msg, type, showLogin, context) {
             const el = document.getElementById('cloud-status');
             if (!el) return;
+            if (_cloudStatusTimer) { clearTimeout(_cloudStatusTimer); _cloudStatusTimer = null; }
             if (showLogin) {
                 const ctx = context || 'push';
                 const safe = msg.replace(/[.!?]+$/, '').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
@@ -9134,6 +9136,9 @@
                 el.textContent = msg;
             }
             el.className = 'cloud-status' + (type ? ' ' + type : '');
+            if (type === 'error' && msg) {
+                _cloudStatusTimer = setTimeout(() => setCloudStatus(''), 5000);
+            }
         }
 
         async function startCloudLogin(e, context) {

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -9055,44 +9055,48 @@
         // ── Cloud push / pull ────────────────────────────────────────────────
 
         let _cloudStreaming = false;
+        let _cloudLoggedIn = true;
 
         async function initCloudStatus() {
             try {
                 const res = await fetch('/api/cloud/status');
                 if (!res.ok) return;
                 const data = await res.json();
+                _cloudLoggedIn = !!data.logged_in;
                 if (data.logged_in) {
                     const pushBtn = document.getElementById('cloud-push-btn');
                     if (pushBtn && data.username) pushBtn.title = `Push to cloud (${data.username})`;
-                } else {
-                    setCloudStatus("Not logged in — run 'santai login'", 'error', true);
                 }
             } catch { /* ignore — buttons always clickable, backend returns error if needed */ }
         }
 
-        function setCloudStatus(msg, type, showLogin) {
+        function setCloudStatus(msg, type, showLogin, context) {
             const el = document.getElementById('cloud-status');
             if (!el) return;
             if (showLogin) {
+                const ctx = context || 'push';
                 const safe = msg.replace(/[.!?]+$/, '').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
-                el.innerHTML = `${safe}, or <a href="#" onclick="startCloudLogin(event)" style="color:inherit;text-decoration:underline">sign in here</a>`;
+                el.innerHTML = `${safe}, or <a href="#" onclick="startCloudLogin(event,'${ctx}')" style="color:inherit;text-decoration:underline">sign in here</a>`;
             } else {
                 el.textContent = msg;
             }
             el.className = 'cloud-status' + (type ? ' ' + type : '');
         }
 
-        async function startCloudLogin(e) {
+        async function startCloudLogin(e, context) {
             if (e) e.preventDefault();
+            const ctx = context || 'push';
             try {
                 const res = await fetch('/api/cloud/login-url');
                 const data = await res.json();
-                const popup = window.open(data.url, '_blank');
+                window.open(data.url, '_blank');
                 const handler = function(event) {
                     if (event.data === 'santai-signed-in') {
                         window.removeEventListener('message', handler);
+                        _cloudLoggedIn = true;
                         initCloudStatus();
-                        setCloudStatus('Signed in. Ready to push to cloud.', 'success');
+                        const action = ctx === 'pull' ? 'pull from the cloud' : 'push to the cloud';
+                        setCloudStatus(`Signed in. Ready to ${action}.`, 'success');
                         setTimeout(() => setCloudStatus(''), 4000);
                     }
                 };
@@ -9117,7 +9121,7 @@
                     setCloudStatus(err.detail || 'Push failed', 'error');
                     return;
                 }
-                await _readCloudStream(response);
+                await _readCloudStream(response, 'push');
             } catch {
                 setCloudStatus('Connection error', 'error');
             } finally {
@@ -9127,6 +9131,10 @@
 
         function cloudPullStart() {
             if (_cloudStreaming) return;
+            if (!_cloudLoggedIn) {
+                setCloudStatus("Not logged in — run 'santai login'", 'error', true, 'pull');
+                return;
+            }
             setCloudStatus('');
             document.getElementById('cloud-pull-confirm').classList.add('visible');
         }
@@ -9152,7 +9160,7 @@
                     setCloudStatus(err.detail || 'Pull failed', 'error');
                     return;
                 }
-                await _readCloudStream(response);
+                await _readCloudStream(response, 'pull');
             } catch {
                 setCloudStatus('Connection error', 'error');
             } finally {
@@ -9160,7 +9168,7 @@
             }
         }
 
-        async function _readCloudStream(response) {
+        async function _readCloudStream(response, context) {
             const reader = response.body.getReader();
             const decoder = new TextDecoder();
             let buffer = '';
@@ -9185,7 +9193,7 @@
                             }
                             setTimeout(() => setCloudStatus(''), 4000);
                         } else if (data.type === 'error') {
-                            setCloudStatus(data.message, 'error', !!data.login_url);
+                            setCloudStatus(data.message, 'error', !!data.login_url, context);
                         }
                     } catch { /* ignore malformed SSE lines */ }
                 }

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -9142,10 +9142,8 @@
                         if (data.type === 'status') {
                             setCloudStatus(data.message);
                         } else if (data.type === 'done') {
-                            const msg = data.version !== undefined
-                                ? `✓ Pushed v${data.version}`
-                                : `✓ Pulled to ${data.path}`;
-                            setCloudStatus(msg, 'success');
+                            setCloudStatus('Successfully saved to the cloud', 'success');
+                            setTimeout(() => setCloudStatus(''), 4000);
                         } else if (data.type === 'error') {
                             setCloudStatus(data.message, 'error');
                         }

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -7996,6 +7996,26 @@
 
             const _cmdText = userText.trim();
 
+            // If awaiting post-login action confirmation
+            if (_chatPostLoginPending) {
+                const _pendingAction = _chatPostLoginPending;
+                if (/\b(yes|yeah|yep|yup|ok|okay|sure|go ahead|do it|proceed|confirm|absolutely|definitely|please|sounds good|let's go|go for it|affirmative|correct|right)\b/i.test(_cmdText)) {
+                    _chatPostLoginPending = null;
+                    if (_pendingAction === 'push') {
+                        await chatCloudPush();
+                    } else {
+                        const _removeThinking = showThinkingIndicator();
+                        await new Promise(r => setTimeout(r, 1000));
+                        _removeThinking();
+                        const _pullDiv = appendChatMessage('assistant', 'Looking up your project in the cloud…');
+                        await _chatCloudPullExecute(_pullDiv);
+                    }
+                    return;
+                }
+                _chatPostLoginPending = null;
+                // fall through to LLM
+            }
+
             // If awaiting pull confirmation, check for affirmative before anything else
             if (_chatPullPendingConfirm) {
                 if (/\b(yes|yeah|yep|yup|ok|okay|sure|go ahead|do it|proceed|confirm|absolutely|definitely|please|sounds good|let's go|go for it|affirmative|correct|right)\b/i.test(_cmdText)) {
@@ -9087,6 +9107,7 @@
         let _cloudLoggedIn = true;
         let _chatPullPendingConfirm = false;
         let _chatPullConfirmMsgDiv = null;
+        let _chatPostLoginPending = null; // 'push' | 'pull'
 
         async function initCloudStatus() {
             try {
@@ -9235,7 +9256,7 @@
 
         async function chatCloudPush() {
             if (_cloudStreaming) {
-                appendChatMessage('assistant', 'A cloud operation is already in progress.');
+                appendChatMessage('assistant', "I'm already working on a cloud operation — please wait a moment.");
                 return;
             }
             if (!_cloudLoggedIn) {
@@ -9256,18 +9277,19 @@
                 removeThinking();
                 if (!response.ok) {
                     const err = await response.json().catch(() => ({}));
-                    const text = err.detail || 'Push failed.';
+                    const text = err.detail || "Something went wrong — I couldn't save to the cloud.";
                     appendChatMessage('assistant', text);
                     chatMessages.push({role: 'assistant', content: text});
                     saveChatHistory();
                     return;
                 }
-                const msgDiv = appendChatMessage('assistant', 'Packaging…');
+                const msgDiv = appendChatMessage('assistant', 'Packing up your project…');
                 await _readCloudStreamToChat(response, 'push', msgDiv);
             } catch {
                 removeThinking();
-                appendChatMessage('assistant', 'Connection error.');
-                chatMessages.push({role: 'assistant', content: 'Connection error.'});
+                const text = "Couldn't connect to the cloud. Check your connection and try again.";
+                appendChatMessage('assistant', text);
+                chatMessages.push({role: 'assistant', content: text});
                 saveChatHistory();
             } finally {
                 _cloudStreaming = false;
@@ -9276,7 +9298,7 @@
 
         async function chatCloudPullInit() {
             if (_cloudStreaming) {
-                appendChatMessage('assistant', 'A cloud operation is already in progress.');
+                appendChatMessage('assistant', "I'm already working on a cloud operation — please wait a moment.");
                 return;
             }
             if (!_cloudLoggedIn) {
@@ -9286,7 +9308,7 @@
             const removeThinking = showThinkingIndicator();
             await new Promise(r => setTimeout(r, 1000));
             removeThinking();
-            const msg = 'This will replace your local project files with the latest cloud version. Are you sure?';
+            const msg = 'Just so you know, this will replace your local files with the latest version from the cloud. Want to go ahead?';
             const msgDiv = appendChatMessage('assistant', msg);
             chatMessages.push({role: 'assistant', content: msg});
             saveChatHistory();
@@ -9304,7 +9326,7 @@
                 });
                 if (!response.ok) {
                     const err = await response.json().catch(() => ({}));
-                    const text = err.detail || 'Pull failed.';
+                    const text = err.detail || "Something went wrong — I couldn't pull from the cloud.";
                     msgDiv.textContent = text;
                     chatMessages.push({role: 'assistant', content: text});
                     saveChatHistory();
@@ -9312,8 +9334,9 @@
                 }
                 await _readCloudStreamToChat(response, 'pull', msgDiv);
             } catch {
-                msgDiv.textContent = 'Connection error.';
-                chatMessages.push({role: 'assistant', content: 'Connection error.'});
+                const text = "Couldn't connect to the cloud. Check your connection and try again.";
+                msgDiv.textContent = text;
+                chatMessages.push({role: 'assistant', content: text});
                 saveChatHistory();
             } finally {
                 _cloudStreaming = false;
@@ -9340,25 +9363,24 @@
                             let finalMsg;
                             if (data.pulled) {
                                 await Promise.all([refreshTree(), refreshFiles()]);
-                                finalMsg = 'Successfully pulled from cloud.';
+                                finalMsg = 'Done! Your local files have been updated with the latest version from the cloud.';
                             } else {
-                                finalMsg = 'Successfully saved to the cloud.';
+                                finalMsg = 'Done! Your project has been saved to the cloud.';
                             }
                             msgDiv.textContent = finalMsg;
                             chatMessages.push({role: 'assistant', content: finalMsg});
                             saveChatHistory();
                         } else if (data.type === 'error') {
                             if (data.login_url) {
-                                const safe = (data.message || 'Not signed in').replace(/[.!?]+$/, '').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
-                                msgDiv.innerHTML = `${safe}, or <a href="#" style="color:inherit;text-decoration:underline">sign in here</a>.`;
+                                msgDiv.innerHTML = `You'll need to sign in to do that. <a href="#" style="color:inherit;text-decoration:underline">Sign in here</a>.`;
                                 msgDiv.querySelector('a').addEventListener('click', async (e) => {
                                     e.preventDefault();
                                     await _chatStartCloudLogin(context, msgDiv);
                                 });
-                                chatMessages.push({role: 'assistant', content: data.message || 'Not signed in.'});
+                                chatMessages.push({role: 'assistant', content: "You'll need to sign in to do that."});
                                 saveChatHistory();
                             } else {
-                                const text = data.message || 'Error.';
+                                const text = data.message || 'Something went wrong.';
                                 msgDiv.textContent = text;
                                 chatMessages.push({role: 'assistant', content: text});
                                 saveChatHistory();
@@ -9394,12 +9416,16 @@
                         _cloudLoggedIn = true;
                         initCloudStatus();
                         const action = context === 'pull' ? 'pull from the cloud' : 'push to the cloud';
-                        msgDiv.textContent = `Signed in. Ready to ${action}.`;
+                        const confirmMsg = `You're signed in! Would you still like me to ${action}?`;
+                        msgDiv.textContent = confirmMsg;
+                        chatMessages.push({role: 'assistant', content: confirmMsg});
+                        saveChatHistory();
+                        _chatPostLoginPending = context;
                     }
                 };
                 window.addEventListener('message', handler);
             } catch {
-                msgDiv.textContent = 'Could not reach hub to start login.';
+                msgDiv.textContent = "Couldn't open the sign-in page. Check your connection and try again.";
             }
         }
 

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -647,6 +647,91 @@
             white-space: nowrap;
         }
 
+        .cloud-section {
+            grid-column: 1 / -1;
+            display: flex;
+            flex-direction: column;
+            gap: 6px;
+            padding-top: 8px;
+            border-top: 1px solid rgba(0,0,0,0.07);
+            margin-top: 2px;
+        }
+
+        .cloud-section-header {
+            display: flex;
+            align-items: center;
+            gap: 5px;
+            font-size: 11px;
+            font-weight: 600;
+            color: var(--text-muted);
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+        }
+
+        .cloud-btns {
+            display: flex;
+            gap: 6px;
+        }
+
+        .cloud-btns .btn {
+            flex: 1;
+        }
+
+        .cloud-status {
+            font-size: 11px;
+            color: var(--text-muted);
+            min-height: 14px;
+            line-height: 1.4;
+            word-break: break-word;
+        }
+
+        .cloud-status.error { color: #ef4444; }
+        .cloud-status.success { color: var(--accent); }
+
+        .cloud-inline-form {
+            display: none;
+            flex-direction: column;
+            gap: 6px;
+        }
+
+        .cloud-inline-form.visible { display: flex; }
+
+        .cloud-inline-form input[type="text"] {
+            background: rgba(255,255,255,0.6);
+            border: 1px solid rgba(0,0,0,0.12);
+            border-radius: 8px;
+            padding: 7px 10px;
+            font-size: 12px;
+            color: var(--text-primary);
+            width: 100%;
+            box-sizing: border-box;
+        }
+
+        .cloud-inline-form input[type="text"]:focus {
+            outline: none;
+            border-color: var(--accent);
+        }
+
+        .cloud-inline-form label {
+            display: flex;
+            align-items: center;
+            gap: 6px;
+            font-size: 12px;
+            color: var(--text-secondary, var(--text-muted));
+            cursor: pointer;
+        }
+
+        .cloud-form-row {
+            display: flex;
+            gap: 6px;
+        }
+
+        .cloud-form-row .btn {
+            flex: 1;
+            justify-content: center;
+            font-size: 12px;
+        }
+
         .btn {
             background: rgba(255, 255, 255, 0.7);
             border: none;
@@ -3755,6 +3840,50 @@
                             Folder Upload
                         </button>
                     </div>
+                </div>
+                <!-- Cloud sync -->
+                <div class="cloud-section">
+                    <div class="cloud-section-header">
+                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" style="width:12px;height:12px;stroke-width:2.5;">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 15a4.5 4.5 0 004.5 4.5H18a3.75 3.75 0 001.332-7.257 3 3 0 00-3.758-3.848 5.25 5.25 0 00-10.233 2.33A4.502 4.502 0 002.25 15z" />
+                        </svg>
+                        Cloud
+                    </div>
+                    <div class="cloud-btns">
+                        <button class="btn" id="cloud-push-btn" onclick="cloudPushToggle()" disabled title="Run 'santai login' first">
+                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" style="width:15px;height:15px;">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M12 16.5V9.75m0 0l3 3m-3-3l-3 3M6.75 19.5a4.5 4.5 0 01-1.41-8.775 5.25 5.25 0 0110.233-2.33 3 3 0 013.758 3.848A3.752 3.752 0 0118 19.5H6.75z" />
+                            </svg>
+                            Push
+                        </button>
+                        <button class="btn" id="cloud-pull-btn" onclick="cloudPullToggle()" disabled title="Run 'santai login' first">
+                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" style="width:15px;height:15px;">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M12 7.5h1.5m-1.5 3h1.5m-7.5 3h7.5m-7.5 3h7.5m3-9h3.375c.621 0 1.125.504 1.125 1.125V18a2.25 2.25 0 01-2.25 2.25M16.5 7.5V18a2.25 2.25 0 002.25 2.25M16.5 7.5V4.875c0-.621-.504-1.125-1.125-1.125H4.5A1.125 1.125 0 003.375 6v12c0 .621.504 1.125 1.125 1.125H5.25M9 8.25v2.25M12 8.25v2.25" />
+                            </svg>
+                            Pull
+                        </button>
+                    </div>
+                    <!-- Push options form -->
+                    <div class="cloud-inline-form" id="cloud-push-form">
+                        <label>
+                            <input type="checkbox" id="cloud-push-include-env">
+                            Include .env file
+                        </label>
+                        <div class="cloud-form-row">
+                            <button class="btn btn-primary" onclick="cloudPushConfirm()">Push</button>
+                            <button class="btn" onclick="cloudPushToggle()">Cancel</button>
+                        </div>
+                    </div>
+                    <!-- Pull name form -->
+                    <div class="cloud-inline-form" id="cloud-pull-form">
+                        <input type="text" id="cloud-pull-name" placeholder="Project name"
+                               onkeydown="if(event.key==='Enter')cloudPullConfirm()">
+                        <div class="cloud-form-row">
+                            <button class="btn btn-primary" onclick="cloudPullConfirm()">Pull</button>
+                            <button class="btn" onclick="cloudPullToggle()">Cancel</button>
+                        </div>
+                    </div>
+                    <span class="cloud-status" id="cloud-status"></span>
                 </div>
             </div>
         </aside>
@@ -8920,6 +9049,152 @@
         setupScrollFade('.tree-container');
         setupScrollFade('.panel-content');
         setupScrollFade('.preview-content');
+
+        // ── Cloud push / pull ────────────────────────────────────────────────
+
+        let _cloudStreaming = false;
+
+        async function initCloudStatus() {
+            try {
+                const res = await fetch('/api/cloud/status');
+                if (!res.ok) return;
+                const data = await res.json();
+                const pushBtn = document.getElementById('cloud-push-btn');
+                const pullBtn = document.getElementById('cloud-pull-btn');
+                if (data.logged_in) {
+                    pushBtn.disabled = false;
+                    pushBtn.title = `Push to cloud${data.username ? ' (' + data.username + ')' : ''}`;
+                    pullBtn.disabled = false;
+                    pullBtn.title = 'Pull a project from cloud';
+                } else {
+                    setCloudStatus("Not logged in — run 'santai login'", 'error');
+                }
+            } catch { /* ignore network errors on status check */ }
+        }
+
+        function setCloudStatus(msg, type) {
+            const el = document.getElementById('cloud-status');
+            if (!el) return;
+            el.textContent = msg;
+            el.className = 'cloud-status' + (type ? ' ' + type : '');
+        }
+
+        function _setCloudBtnsDisabled(disabled) {
+            const pb = document.getElementById('cloud-push-btn');
+            const pu = document.getElementById('cloud-pull-btn');
+            if (pb) pb.disabled = disabled;
+            if (pu) pu.disabled = disabled;
+        }
+
+        function cloudPushToggle() {
+            if (_cloudStreaming) return;
+            const pushForm = document.getElementById('cloud-push-form');
+            const pullForm = document.getElementById('cloud-pull-form');
+            const opening = !pushForm.classList.contains('visible');
+            pullForm.classList.remove('visible');
+            pushForm.classList.toggle('visible', opening);
+            if (opening) setCloudStatus('');
+        }
+
+        function cloudPullToggle() {
+            if (_cloudStreaming) return;
+            const pushForm = document.getElementById('cloud-push-form');
+            const pullForm = document.getElementById('cloud-pull-form');
+            const opening = !pullForm.classList.contains('visible');
+            pushForm.classList.remove('visible');
+            pullForm.classList.toggle('visible', opening);
+            if (opening) {
+                document.getElementById('cloud-pull-name').value = '';
+                setCloudStatus('');
+                setTimeout(() => document.getElementById('cloud-pull-name').focus(), 50);
+            }
+        }
+
+        async function cloudPushConfirm() {
+            if (_cloudStreaming) return;
+            const includeEnv = document.getElementById('cloud-push-include-env').checked;
+            document.getElementById('cloud-push-form').classList.remove('visible');
+            _cloudStreaming = true;
+            _setCloudBtnsDisabled(true);
+            setCloudStatus('Packaging...');
+            try {
+                const response = await fetch('/api/cloud/push', {
+                    method: 'POST',
+                    headers: {'Content-Type': 'application/json'},
+                    body: JSON.stringify({include_env: includeEnv}),
+                });
+                if (!response.ok) {
+                    const err = await response.json().catch(() => ({}));
+                    setCloudStatus(err.detail || 'Push failed', 'error');
+                    return;
+                }
+                await _readCloudStream(response);
+            } catch {
+                setCloudStatus('Connection error', 'error');
+            } finally {
+                _cloudStreaming = false;
+                _setCloudBtnsDisabled(false);
+            }
+        }
+
+        async function cloudPullConfirm() {
+            if (_cloudStreaming) return;
+            const name = document.getElementById('cloud-pull-name').value.trim();
+            if (!name) { setCloudStatus('Enter a project name', 'error'); return; }
+            document.getElementById('cloud-pull-form').classList.remove('visible');
+            _cloudStreaming = true;
+            _setCloudBtnsDisabled(true);
+            setCloudStatus('Looking up project...');
+            try {
+                const response = await fetch('/api/cloud/pull', {
+                    method: 'POST',
+                    headers: {'Content-Type': 'application/json'},
+                    body: JSON.stringify({name}),
+                });
+                if (!response.ok) {
+                    const err = await response.json().catch(() => ({}));
+                    setCloudStatus(err.detail || 'Pull failed', 'error');
+                    return;
+                }
+                await _readCloudStream(response);
+            } catch {
+                setCloudStatus('Connection error', 'error');
+            } finally {
+                _cloudStreaming = false;
+                _setCloudBtnsDisabled(false);
+            }
+        }
+
+        async function _readCloudStream(response) {
+            const reader = response.body.getReader();
+            const decoder = new TextDecoder();
+            let buffer = '';
+            while (true) {
+                const {done, value} = await reader.read();
+                if (done) break;
+                buffer += decoder.decode(value, {stream: true});
+                const lines = buffer.split('\n');
+                buffer = lines.pop() || '';
+                for (const line of lines) {
+                    if (!line.startsWith('data: ')) continue;
+                    try {
+                        const data = JSON.parse(line.slice(6));
+                        if (data.type === 'status') {
+                            setCloudStatus(data.message);
+                        } else if (data.type === 'done') {
+                            const msg = data.version !== undefined
+                                ? `✓ Pushed v${data.version}`
+                                : `✓ Pulled to ${data.path}`;
+                            setCloudStatus(msg, 'success');
+                        } else if (data.type === 'error') {
+                            setCloudStatus(data.message, 'error');
+                        }
+                    } catch { /* ignore malformed SSE lines */ }
+                }
+            }
+        }
+
+        initCloudStatus();
     </script>
     <div class="graph-tooltip" id="graph-tooltip"></div>
     <div class="graph-tooltip" id="folder-move-tooltip"></div>

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -9239,7 +9239,7 @@
                 return;
             }
             if (!_cloudLoggedIn) {
-                _chatShowCloudLoginError('push');
+                await _chatShowCloudLoginError('push');
                 return;
             }
             _cloudStreaming = true;
@@ -9280,7 +9280,7 @@
                 return;
             }
             if (!_cloudLoggedIn) {
-                _chatShowCloudLoginError('pull');
+                await _chatShowCloudLoginError('pull');
                 return;
             }
             const removeThinking = showThinkingIndicator();
@@ -9369,15 +9369,17 @@
             }
         }
 
-        function _chatShowCloudLoginError(context) {
+        async function _chatShowCloudLoginError(context) {
+            const removeThinking = showThinkingIndicator();
+            await new Promise(r => setTimeout(r, 1000));
+            removeThinking();
             const msgDiv = appendChatMessage('assistant', '');
-            const action = context === 'pull' ? 'pull from the cloud' : 'push to the cloud';
-            msgDiv.innerHTML = `Not signed in to Santai Cloud, or <a href="#" style="color:inherit;text-decoration:underline">sign in here</a>.`;
+            msgDiv.innerHTML = `You're not currently signed in to Santai. You can <a href="#" style="color:inherit;text-decoration:underline">sign in here</a>.`;
             msgDiv.querySelector('a').addEventListener('click', async (e) => {
                 e.preventDefault();
                 await _chatStartCloudLogin(context, msgDiv);
             });
-            chatMessages.push({role: 'assistant', content: `Not signed in to Santai Cloud. Sign in to ${action}.`});
+            chatMessages.push({role: 'assistant', content: "You're not currently signed in to Santai. You can sign in here."});
             saveChatHistory();
         }
 

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -662,7 +662,7 @@
         .cloud-sync-btns .btn {
             flex: 1;
             justify-content: center;
-            font-size: 11px;
+            font-size: 13px;
             gap: 4px;
             padding: 7px 6px;
             overflow: hidden;

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -670,12 +670,34 @@
             white-space: nowrap;
         }
 
+        #cloud-push-btn {
+            background: var(--accent);
+            color: white;
+            box-shadow: 0 2px 8px rgba(62, 180, 137, 0.3);
+        }
+
+        #cloud-push-btn:hover {
+            background: var(--accent-hover);
+            box-shadow: 0 4px 12px rgba(62, 180, 137, 0.4);
+        }
+
+        #cloud-pull-btn {
+            background: rgba(0, 0, 0, 0.06);
+        }
+
+        #cloud-pull-btn:hover {
+            background: rgba(0, 0, 0, 0.1);
+        }
+
         .cloud-status {
             font-size: 11px;
             color: var(--text-muted);
-            min-height: 14px;
             line-height: 1.4;
             word-break: break-word;
+        }
+
+        .cloud-status:empty {
+            display: none;
         }
 
         .cloud-status.error { color: #ef4444; }

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -7994,8 +7994,24 @@
             saveChatHistory();
             chatHideEmptyState();
 
-            // Intercept cloud commands before sending to LLM
             const _cmdText = userText.trim();
+
+            // If awaiting pull confirmation, check for affirmative before anything else
+            if (_chatPullPendingConfirm) {
+                if (/\b(yes|yeah|yep|yup|ok|okay|sure|go ahead|do it|proceed|confirm|absolutely|definitely|please|sounds good|let's go|go for it|affirmative|correct|right)\b/i.test(_cmdText)) {
+                    _chatPullPendingConfirm = false;
+                    const _confirmDiv = _chatPullConfirmMsgDiv;
+                    _chatPullConfirmMsgDiv = null;
+                    _confirmDiv.textContent = 'Looking up project…';
+                    await _chatCloudPullExecute(_confirmDiv);
+                    return;
+                }
+                // Non-affirmative: clear pending state and let message go to LLM
+                _chatPullPendingConfirm = false;
+                _chatPullConfirmMsgDiv = null;
+            }
+
+            // Intercept cloud commands before sending to LLM
             if (/\b(push|save)(\s+to)?\s+(the\s+)?cloud\b/i.test(_cmdText) && _cmdText.length < 150) {
                 await chatCloudPush();
                 return;
@@ -9067,6 +9083,8 @@
 
         let _cloudStreaming = false;
         let _cloudLoggedIn = true;
+        let _chatPullPendingConfirm = false;
+        let _chatPullConfirmMsgDiv = null;
 
         async function initCloudStatus() {
             try {
@@ -9257,29 +9275,12 @@
                 _chatShowCloudLoginError('pull');
                 return;
             }
-            const msgDiv = appendChatMessage('assistant', '');
-            msgDiv.textContent = 'This will replace your local project files with the cloud version.';
-            const row = document.createElement('div');
-            row.style.cssText = 'display:flex;gap:8px;margin-top:10px;';
-            const confirmBtn = document.createElement('button');
-            confirmBtn.textContent = 'Replace';
-            confirmBtn.className = 'btn btn-primary';
-            const cancelBtn = document.createElement('button');
-            cancelBtn.textContent = 'Cancel';
-            cancelBtn.className = 'btn';
-            row.appendChild(confirmBtn);
-            row.appendChild(cancelBtn);
-            msgDiv.appendChild(row);
-            confirmBtn.onclick = async () => {
-                row.remove();
-                msgDiv.textContent = 'Looking up project…';
-                await _chatCloudPullExecute(msgDiv);
-            };
-            cancelBtn.onclick = () => {
-                msgDiv.textContent = 'Pull cancelled.';
-                chatMessages.push({role: 'assistant', content: 'Pull cancelled.'});
-                saveChatHistory();
-            };
+            const msg = 'This will replace your local project files with the latest cloud version. Are you sure?';
+            const msgDiv = appendChatMessage('assistant', msg);
+            chatMessages.push({role: 'assistant', content: msg});
+            saveChatHistory();
+            _chatPullPendingConfirm = true;
+            _chatPullConfirmMsgDiv = msgDiv;
         }
 
         async function _chatCloudPullExecute(msgDiv) {

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -9076,7 +9076,7 @@
             if (showLogin) {
                 const ctx = context || 'push';
                 const safe = msg.replace(/[.!?]+$/, '').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
-                el.innerHTML = `${safe}, or <a href="#" onclick="startCloudLogin(event,'${ctx}')" style="color:inherit;text-decoration:underline">sign in here</a>`;
+                el.innerHTML = `${safe}, or <a href="#" onclick="startCloudLogin(event,'${ctx}')" style="color:inherit;text-decoration:underline">sign in here</a>.`;
             } else {
                 el.textContent = msg;
             }

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -9144,9 +9144,8 @@
                             setCloudStatus(data.message);
                         } else if (data.type === 'done') {
                             if (data.pulled) {
+                                await Promise.all([refreshTree(), refreshFiles()]);
                                 setCloudStatus('Successfully pulled from cloud.', 'success');
-                                refreshTree();
-                                refreshFiles();
                             } else {
                                 setCloudStatus('Successfully saved to the cloud.', 'success');
                             }

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -741,7 +741,16 @@
         .cloud-form-row .btn {
             flex: 1;
             justify-content: center;
-            font-size: 12px;
+            font-size: 13px;
+            padding: 7px 6px;
+        }
+
+        #cloud-pull-cancel-btn {
+            background: rgba(0, 0, 0, 0.06);
+        }
+
+        #cloud-pull-cancel-btn:hover {
+            background: rgba(0, 0, 0, 0.1);
         }
 
         .btn {
@@ -3832,7 +3841,7 @@
                         <span class="cloud-confirm-msg">Replace local files with the latest cloud version?</span>
                         <div class="cloud-form-row">
                             <button class="btn btn-primary" onclick="cloudPullConfirm()">Replace</button>
-                            <button class="btn" onclick="cloudPullCancel()">Cancel</button>
+                            <button class="btn" id="cloud-pull-cancel-btn" onclick="cloudPullCancel()">Cancel</button>
                         </div>
                     </div>
                     <span class="cloud-status" id="cloud-status"></span>

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -9301,13 +9301,18 @@
                 appendChatMessage('assistant', "I'm already working on a cloud operation — please wait a moment.");
                 return;
             }
+            // Check auth live during the thinking period
+            const removeThinking = showThinkingIndicator();
+            const [statusData] = await Promise.all([
+                fetch('/api/cloud/status').then(r => r.json()).catch(() => ({logged_in: false})),
+                new Promise(r => setTimeout(r, 1000)),
+            ]);
+            removeThinking();
+            _cloudLoggedIn = !!statusData.logged_in;
             if (!_cloudLoggedIn) {
-                await _chatShowCloudLoginError('pull');
+                _chatAppendSignInPrompt('pull');
                 return;
             }
-            const removeThinking = showThinkingIndicator();
-            await new Promise(r => setTimeout(r, 1000));
-            removeThinking();
             const msg = 'Just so you know, this will replace your local files with the latest version from the cloud. Want to go ahead?';
             const msgDiv = appendChatMessage('assistant', msg);
             chatMessages.push({role: 'assistant', content: msg});
@@ -9375,7 +9380,7 @@
                                 msgDiv.innerHTML = `You'll need to sign in to do that. <a href="#" style="color:inherit;text-decoration:underline">Sign in here</a>.`;
                                 msgDiv.querySelector('a').addEventListener('click', async (e) => {
                                     e.preventDefault();
-                                    await _chatStartCloudLogin(context, msgDiv);
+                                    await _chatStartCloudLogin(context);
                                 });
                                 chatMessages.push({role: 'assistant', content: "You'll need to sign in to do that."});
                                 saveChatHistory();
@@ -9391,21 +9396,25 @@
             }
         }
 
-        async function _chatShowCloudLoginError(context) {
-            const removeThinking = showThinkingIndicator();
-            await new Promise(r => setTimeout(r, 1000));
-            removeThinking();
+        function _chatAppendSignInPrompt(context) {
             const msgDiv = appendChatMessage('assistant', '');
             msgDiv.innerHTML = `You're not currently signed in to Santai. You can <a href="#" style="color:inherit;text-decoration:underline">sign in here</a>.`;
             msgDiv.querySelector('a').addEventListener('click', async (e) => {
                 e.preventDefault();
-                await _chatStartCloudLogin(context, msgDiv);
+                await _chatStartCloudLogin(context);
             });
             chatMessages.push({role: 'assistant', content: "You're not currently signed in to Santai. You can sign in here."});
             saveChatHistory();
         }
 
-        async function _chatStartCloudLogin(context, msgDiv) {
+        async function _chatShowCloudLoginError(context) {
+            const removeThinking = showThinkingIndicator();
+            await new Promise(r => setTimeout(r, 1000));
+            removeThinking();
+            _chatAppendSignInPrompt(context);
+        }
+
+        async function _chatStartCloudLogin(context) {
             try {
                 const res = await fetch('/api/cloud/login-url');
                 const data = await res.json();
@@ -9417,7 +9426,7 @@
                         initCloudStatus();
                         const action = context === 'pull' ? 'pull from the cloud' : 'push to the cloud';
                         const confirmMsg = `You're signed in! Would you still like me to ${action}?`;
-                        msgDiv.textContent = confirmMsg;
+                        appendChatMessage('assistant', confirmMsg);
                         chatMessages.push({role: 'assistant', content: confirmMsg});
                         saveChatHistory();
                         _chatPostLoginPending = context;
@@ -9425,7 +9434,7 @@
                 };
                 window.addEventListener('message', handler);
             } catch {
-                msgDiv.textContent = "Couldn't open the sign-in page. Check your connection and try again.";
+                appendChatMessage('assistant', "Couldn't open the sign-in page. Check your connection and try again.");
             }
         }
 


### PR DESCRIPTION
### Summary

This PR adds full Santai cloud syncing to the web UI — push and pull buttons in the file tree, plus natural-language cloud commands in the chat interface — along with a series of fixes required to make the hub API work reliably in production.
<img width="1920" height="1050" alt="Screenshot 2026-05-22 at 2 35 55 PM" src="https://github.com/user-attachments/assets/167e7df5-d7fd-48b3-89ab-02ffb98ff010" />

Cloud sync buttons (sidebar)
- Push and pull buttons appear above the file tree. Push uploads the current project to the cloud; pull replaces local files with the latest cloud version (with a confirm step).
- Auth errors surface inline with a "sign in here" link that opens the hub OAuth flow in a popup and authenticates the CLI session via a /callback endpoint on the local app server, using postMessage to signal completion.
- .env and credentials.json are preserved across pulls and never included in pushes by default.

Chat cloud commands
- Typing "push to cloud", "save to cloud", "pull from cloud", or "load from cloud" (and natural variants like "can you pull from the cloud") in the chat triggers the cloud operation directly, bypassing the LLM.
- Pull shows a conversational confirmation and waits for an affirmative reply before executing.
- All responses use conversational language with a 1-second thinking indicator before each message.
- If not signed in, the chat shows a sign-in prompt; after sign-in, a new message asks if the user still wants to proceed with the original action.
- The LLM system prompt is updated so the model knows cloud sync is available and can guide users.

Image corruption fix
- Cloud storage corrupts raw binary file content on round-trip. Images are now encoded as base64 data URLs before being added to the push zip, and decoded back to binary on pull. Applies to all common image types (.png, .jpg, .jpeg, .gif, .webp, .bmp, .ico).

---
### Test Plan

Cloud push (sidebar button)
- [x] Open a project with at least one .md file, one .png, and one .jpg. Press Push to Cloud. Confirm status updates appear and a success message follows.
<img width="278" height="230" alt="Screenshot 2026-05-22 at 2 36 14 PM" src="https://github.com/user-attachments/assets/dd96955c-00ae-45cd-892c-a5bd017a2f26" />

- [x] With .env present, confirm it is NOT included in the zip (can check S3, or your dashboard on the Hub).
- [x] Create a new file but don't push to the cloud. Then, pull from the cloud and verify that new file disappears and all files from the earlier push are present and images open correctly. Verify each image can be previewed in the file browser without corruption.
- [x] Confirm .env and credentials.json survive a pull if they exist locally.
- [x] Push again immediately. Confirm it updates the existing cloud project rather than creating a duplicate (check S3, or your dashboard on the Hub—there shouldn't be a new KB on a duplicate push).
- [x] Sign out, then press Push to Cloud. Confirm the error shows a "sign in here" link, clicking it opens the hub login popup, and after signing in the status updates to "Ready to push".
<img width="294" height="278" alt="Screenshot 2026-05-22 at 2 38 29 PM" src="https://github.com/user-attachments/assets/5e953a5a-77e7-4d90-9b3f-642f52001da2" />


Cloud pull (sidebar button)
- [x] Press Pull from Cloud → Cancel. Confirm no files change.
- [x] When not signed in, clicking Pull from Cloud should immediately show the auth error (not the confirm form).

Chat cloud commands
- [x] Type "push to cloud" → thinking indicator appears → "Packing up your project…" → "Done! Your project has been saved to the cloud."
- [x] Type "pull from cloud" → thinking → confirmation message → type "yes" → thinking → pull executes → success message.
- [x] Type "pull from cloud" → confirmation appears → type "no" / "never mind" → message passes to LLM instead of executing pull.
- [x] When not signed in, triggering push or pull in chat should show a sign-in message. After signing in, a new message asks "Would you still like me to push/pull?" — type "yes" and confirm the action executes. The original sign-in message must remain visible (not replaced). 
<img width="400" height="501" alt="Screenshot 2026-05-22 at 2 45 04 PM" src="https://github.com/user-attachments/assets/0333570a-e93c-4759-a323-cc125084b72c" />


Regression
- [x] Normal chat messages still route to the LLM correctly.
- [x] File tree refreshes after a successful pull via chat or button.
- [x] `santai whoami` shows the correct username after signing in through the web UI.

_Note: will create a PR after this one is approved for implementing a modal to select which save from cloud (S3) to load. I'm also open to implementing pulling a different way, but I copied the logic used in `santai pull` of pulling down a copy of a Santai project to start with (though this pulls a copy and overwrites the original). We might want to use a diff-based approach instead but not sure if we want to have pull mean one thing in the web ui and another in the terminal._  