### PR TITLE
feat: add project structure validation, sensitive file protection, and centralize shared constants

### DIFF
--- a/src/santai_cli/commands/cherry_pick.py
+++ b/src/santai_cli/commands/cherry_pick.py
@@ -9,18 +9,9 @@ import typer
 from rich.console import Console
 from rich.table import Table
 
-from santai_cli.core.project import SANTAI_DIRS
+from santai_cli.core.project import IGNORED_DIRECTORIES, SANTAI_DIRS, SENSITIVE_FILES
 
 console = Console()
-
-# Directories to skip when traversing a cherry-picked folder
-IGNORED_DIRECTORIES = {
-    ".git",
-    ".ruff_cache",
-    ".rumdl_cache",
-    "__pycache__",
-    ".venv",
-}
 
 
 def _validate_project(path_str: str, label: str = "Path") -> Path:
@@ -185,6 +176,27 @@ def cherry_pick(
             seen.add(f)
             unique_files.append(f)
     all_files = unique_files
+
+    # -- Sensitive file protection -------------------------------------
+    sensitive_found = [f for f in all_files if f.name in SENSITIVE_FILES]
+    if sensitive_found:
+        console.print(
+            "[yellow]Warning: The following sensitive files were selected:[/yellow]"
+        )
+        for sf in sensitive_found:
+            console.print(f"  [yellow]{sf}[/yellow]")
+        if not typer.confirm(
+            "These files may contain secrets or API keys. "
+            "Include them in the cherry-pick?",
+            default=False,
+        ):
+            all_files = [f for f in all_files if f.name not in SENSITIVE_FILES]
+            if not all_files:
+                console.print(
+                    "[yellow]No files remaining after excluding "
+                    "sensitive files.[/yellow]"
+                )
+                raise typer.Exit(0)
 
     # -- Dry-run: just print and exit ----------------------------------
     if dry_run:

--- a/src/santai_cli/commands/copy.py
+++ b/src/santai_cli/commands/copy.py
@@ -9,23 +9,13 @@ from typing import Annotated
 import typer
 from rich.console import Console
 
+from santai_cli.core.project import (
+    IGNORED_DIRECTORIES,
+    SENSITIVE_FILES,
+    validate_santai_structure,
+)
+
 console = Console()
-
-# Directories to exclude when copying
-IGNORED_DIRECTORIES = {
-    ".git",
-    ".ruff_cache",
-    ".rumdl_cache",
-    "__pycache__",
-    ".venv",
-}
-
-# Files excluded by default (secrets, credentials).
-# Users can opt-in to include .env via --include-env.
-SENSITIVE_FILES = {
-    ".env",
-    "credentials.json",
-}
 
 
 def _make_ignore_fn(
@@ -97,6 +87,18 @@ def copy(
     if not source_path.is_dir():
         console.print(f"[red]Error: Source path '{source}' is not a directory.[/red]")
         raise typer.Exit(1)
+
+    # Validate Santai project structure
+    missing = validate_santai_structure(source_path)
+    if missing:
+        missing_str = ", ".join(f"{d}/" for d in missing)
+        console.print(
+            f"[yellow]Warning: Source '{source}' does not look like a standard "
+            f"Santai project.[/yellow]"
+        )
+        console.print(f"[yellow]Missing directories: {missing_str}[/yellow]")
+        if not typer.confirm("Continue anyway?", default=False):
+            raise typer.Exit(0)
 
     # Resolve destination path
     dest_path = (Path.cwd() / destination).resolve()

--- a/src/santai_cli/commands/merge.py
+++ b/src/santai_cli/commands/merge.py
@@ -10,23 +10,13 @@ from typing import Annotated
 import typer
 from rich.console import Console
 
+from santai_cli.core.project import (
+    IGNORED_DIRECTORIES,
+    SENSITIVE_FILES,
+    validate_santai_structure,
+)
+
 console = Console()
-
-# Directories to exclude when copying/merging
-IGNORED_DIRECTORIES = {
-    ".git",
-    ".ruff_cache",
-    ".rumdl_cache",
-    "__pycache__",
-    ".venv",
-}
-
-# Files excluded by default (secrets, credentials).
-# Users can opt-in to include .env via --include-env.
-SENSITIVE_FILES = {
-    ".env",
-    "credentials.json",
-}
 
 
 def _make_ignore_fn(
@@ -154,6 +144,22 @@ def merge(
     # Validate both sources
     source1_path = _validate_source(source1)
     source2_path = _validate_source(source2)
+
+    # Validate Santai project structure for both sources
+    for label, path_str, src_path in [
+        ("Primary", source1, source1_path),
+        ("Secondary", source2, source2_path),
+    ]:
+        missing = validate_santai_structure(src_path)
+        if missing:
+            missing_str = ", ".join(f"{d}/" for d in missing)
+            console.print(
+                f"[yellow]Warning: {label} source '{path_str}' does not look like "
+                f"a standard Santai project.[/yellow]"
+            )
+            console.print(f"[yellow]Missing directories: {missing_str}[/yellow]")
+            if not typer.confirm("Continue anyway?", default=False):
+                raise typer.Exit(0)
 
     # Resolve destination path
     dest_path = (Path.cwd() / destination).resolve()

--- a/src/santai_cli/commands/push.py
+++ b/src/santai_cli/commands/push.py
@@ -19,24 +19,9 @@ from santai_cli.core.hub import (
     get_backend_url,
     resolve_base_id,
 )
+from santai_cli.core.project import IGNORED_DIRECTORIES, SENSITIVE_FILES
 
 console = Console()
-
-IGNORED_DIRECTORIES = {
-    ".git",
-    ".ruff_cache",
-    ".rumdl_cache",
-    "__pycache__",
-    ".venv",
-    "node_modules",
-}
-
-# Files excluded by default (secrets, credentials).
-# Users can opt-in to include .env via --include-env.
-SENSITIVE_FILES = {
-    ".env",
-    "credentials.json",
-}
 
 MAX_UPLOAD_BYTES = 50 * 1024 * 1024
 

--- a/src/santai_cli/core/project.py
+++ b/src/santai_cli/core/project.py
@@ -26,6 +26,31 @@ SANTAI_FOLDER_DESCRIPTIONS: dict[str, str] = {
     "history": "logs, changelogs, versioned records",
 }
 
+# Directories always excluded from copy/merge/push/cherry-pick operations.
+IGNORED_DIRECTORIES: set[str] = {
+    ".git",
+    ".ruff_cache",
+    ".rumdl_cache",
+    "__pycache__",
+    ".venv",
+    "node_modules",
+}
+
+# Files excluded by default (secrets, credentials).
+# Commands may offer opt-in flags (e.g. --include-env) to override.
+SENSITIVE_FILES: set[str] = {
+    ".env",
+    "credentials.json",
+}
+
+
+def validate_santai_structure(path: Path) -> list[str]:
+    """Return a list of missing SANTAI_DIRS in the given path.
+
+    An empty list means the directory has the expected Santai project layout.
+    """
+    return [d for d in SANTAI_DIRS if not (path / d).is_dir()]
+
 
 @dataclass
 class HistoryEntry:

--- a/src/santai_cli/server/routes.py
+++ b/src/santai_cli/server/routes.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 from fastapi import APIRouter, HTTPException, status
 
-from santai_cli.core.project import SANTAI_DIRS
+from santai_cli.core.project import IGNORED_DIRECTORIES, SANTAI_DIRS, SENSITIVE_FILES
 from santai_cli.server.models import (
     CherryPickRequest,
     CherryPickResponse,
@@ -22,21 +22,6 @@ from santai_cli.server.models import (
 )
 
 router = APIRouter(prefix="/api")
-
-# Directories to exclude when copying
-_IGNORED_DIRECTORIES = {
-    ".git",
-    ".ruff_cache",
-    ".rumdl_cache",
-    "__pycache__",
-    ".venv",
-}
-
-# Sensitive files excluded by default
-_SENSITIVE_FILES = {
-    ".env",
-    "credentials.json",
-}
 
 # Template content for new projects (matches commands/init.py)
 _AGENTS_MD_CONTENT = """\
@@ -104,7 +89,7 @@ def _run_command(cmd: list[str], cwd: Path) -> bool:
 
 def _ignore_fn(directory: str, files: list[str]) -> set[str]:
     """Ignore function for shutil.copytree."""
-    return {f for f in files if f in _IGNORED_DIRECTORIES or f in _SENSITIVE_FILES}
+    return {f for f in files if f in IGNORED_DIRECTORIES or f in SENSITIVE_FILES}
 
 
 def _merge_tree(source: Path, destination: Path) -> tuple[int, int]:
@@ -116,14 +101,14 @@ def _merge_tree(source: Path, destination: Path) -> tuple[int, int]:
     skipped = 0
 
     for dirpath, dirnames, filenames in os.walk(source):
-        dirnames[:] = [d for d in dirnames if d not in _IGNORED_DIRECTORIES]
+        dirnames[:] = [d for d in dirnames if d not in IGNORED_DIRECTORIES]
 
         rel_dir = Path(dirpath).relative_to(source)
         dest_dir = destination / rel_dir
         dest_dir.mkdir(parents=True, exist_ok=True)
 
         for filename in filenames:
-            if filename in _SENSITIVE_FILES:
+            if filename in SENSITIVE_FILES:
                 skipped += 1
                 continue
             dest_file = dest_dir / filename
@@ -255,7 +240,7 @@ def _collect_files(base: Path, target: Path) -> list[Path]:
 
     files: list[Path] = []
     for dirpath, dirnames, filenames in os.walk(target):
-        dirnames[:] = [d for d in dirnames if d not in _IGNORED_DIRECTORIES]
+        dirnames[:] = [d for d in dirnames if d not in IGNORED_DIRECTORIES]
         for fname in filenames:
             full = Path(dirpath) / fname
             files.append(full.relative_to(base))


### PR DESCRIPTION
## Summary

- **Centralize shared constants**: `IGNORED_DIRECTORIES` and `SENSITIVE_FILES` are now defined once in `core/project.py` and imported by all commands (`copy`, `merge`, `cherry-pick`, `push`, `server/routes`). This eliminates the DRY violation where these were duplicated in 5 separate files.

- **Project structure validation**: `copy` and `merge` now validate that source directories have the expected Santai structure (`media/`, `history/`, `notes/`). If any are missing, the user is warned and prompted to confirm before proceeding.

- **Sensitive file protection for cherry-pick**: `cherry-pick` now detects when selected files match `SENSITIVE_FILES` (`.env`, `credentials.json`) and prompts the user before including them. Previously, cherry-pick had no sensitive file awareness.

- **Add `node_modules` to ignored directories**: All commands now consistently exclude `node_modules` (previously only `push` did).

## Files Changed

| File | Change |
|------|--------|
| `src/santai_cli/core/project.py` | Added `IGNORED_DIRECTORIES`, `SENSITIVE_FILES`, `validate_santai_structure()` |
| `src/santai_cli/commands/copy.py` | Import shared constants, add structure validation |
| `src/santai_cli/commands/merge.py` | Import shared constants, add structure validation for both sources |
| `src/santai_cli/commands/cherry_pick.py` | Import shared constants, add sensitive file protection |
| `src/santai_cli/commands/push.py` | Import shared constants, remove local defs |
| `src/santai_cli/server/routes.py` | Import shared constants, remove local defs |

## Testing

Manually tested all operations in a tmp directory:
- `copy` valid project (sensitive files excluded, content preserved)
- `copy` non-santai directory (warning shown, user can override)
- `copy` excludes `node_modules`
- `merge` two valid projects (content combined correctly)
- `merge` with non-santai source (warning shown)
- `cherry-pick` with sensitive files declined (only safe files copied)
- `cherry-pick` with sensitive files accepted (all files copied)
- `cherry-pick` dry-run with sensitive files (prompt before listing)
- All linting (`ruff format`, `ruff check`) and type checking (`ty check`) pass