### PR TITLE
docs: update documentation to match current CLI structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Interactive AI chat session. Requires an API key in `.env` (see `.env.example`).
 ```bash
 santai chat
 santai chat --agent research
-santai chat --model claude-sonnet-4-20250514
+santai chat --model claude-sonnet-4-6
 ```
 
 ### `santai ui`
@@ -123,6 +123,15 @@ Launch the web dashboard in your browser.
 ```bash
 santai web
 santai web --port 3000
+```
+
+### `santai server`
+
+Launch a headless JSON API server for programmatic access.
+
+```bash
+santai server
+santai server --port 9000 --token my-secret-token
 ```
 
 ### `santai push` / `santai pull`
@@ -196,12 +205,18 @@ src/santai_cli/
 │   ├── auth.py          # santai login/logout/whoami
 │   ├── push.py          # santai push
 │   ├── pull.py          # santai pull
+│   ├── server.py        # santai server
 │   ├── ui.py            # santai ui
 │   └── web.py           # santai web
 ├── core/
 │   ├── project.py       # Project detection, data models, file graph
 │   ├── config.py        # Environment/config loading, API key validation
 │   └── chat.py          # Chat engine (streaming, provider abstraction)
+├── server/
+│   ├── app.py           # FastAPI headless API server
+│   ├── auth.py          # Bearer token authentication
+│   ├── models.py        # Pydantic request/response models
+│   └── routes.py        # API route definitions
 ├── tui/
 │   └── app.py           # Textual TUI application
 └── web/

--- a/docs/commands/chat.md
+++ b/docs/commands/chat.md
@@ -27,17 +27,15 @@ When launched without `--model`, santai presents an interactive numbered list of
 Available models:
 
   Anthropic:
-    1. claude-sonnet-4-20250514 *
-    2. claude-opus-4-20250514
-    3. claude-haiku-4-20250514
+    1. claude-sonnet-4-6 *
+    2. claude-opus-4-7
+    3. claude-haiku-4-5-20251001
 
   OpenAI:
     4. gpt-4o *
-    5. gpt-4o-mini
-    6. o3-mini
-    7. gpt-4.1
-    8. gpt-4.1-mini
-    9. gpt-4.1-nano
+    5. gpt-4.1
+    6. gpt-4.1-mini
+    7. o3-mini
 
 Select a model (number):
 ```
@@ -81,7 +79,7 @@ Start with a specific model:
 
 ```bash
 santai chat --model gpt-4o
-santai chat --model claude-sonnet-4-20250514
+santai chat --model claude-sonnet-4-6
 ```
 
 Use an agent profile with a specific model:

--- a/docs/commands/index.md
+++ b/docs/commands/index.md
@@ -13,6 +13,7 @@ Santai CLI provides commands for managing your project. Each command is describe
 | [`santai chat`](chat.md) | Start an interactive AI chat session |
 | [`santai ui`](ui.md) | Launch the TUI dashboard |
 | [`santai web`](web.md) | Launch the web dashboard |
+| [`santai server`](server.md) | Launch the headless API server |
 | [`santai push`](push.md) | Push project to Santai Hub |
 | [`santai pull`](pull.md) | Pull project from Santai Hub |
 | [`santai login`](auth.md) | Authenticate with Santai Hub |

--- a/docs/commands/server.md
+++ b/docs/commands/server.md
@@ -1,0 +1,222 @@
+# santai server
+
+Launch a headless JSON API server for programmatic access to Santai project operations.
+
+## Usage
+
+```bash
+santai server [OPTIONS]
+```
+
+## Options
+
+| Option | Short | Default | Description |
+|--------|-------|---------|-------------|
+| `--host` | `-h` | `127.0.0.1` | Host to bind the server to |
+| `--port` | `-p` | `8080` | Port to run the server on |
+| `--token` | `-t` | None | Bearer token for API authentication |
+
+## Description
+
+The server command starts a FastAPI application that exposes Santai project operations as REST API endpoints. This is useful for integrating Santai into automation pipelines, CI/CD systems, or building custom frontends.
+
+OpenAPI documentation is automatically available at `/docs` when the server is running.
+
+## Authentication
+
+When a token is provided (via `--token` or the `SANTAI_SERVER_TOKEN` environment variable), all API requests must include an `Authorization: Bearer <token>` header.
+
+The CLI flag takes precedence over the environment variable.
+
+**Public paths** that skip authentication:
+
+- `/api/health`
+- `/docs`
+- `/openapi.json`
+- `/redoc`
+
+!!! warning
+    When binding to a non-localhost address (e.g. `0.0.0.0`) without a token, the server logs a warning. Always use authentication when exposing the server on a network.
+
+## API Endpoints
+
+### `GET /api/health`
+
+Health check endpoint. Always returns `{"status": "ok"}`.
+
+### `POST /api/init`
+
+Initialize a new Santai project.
+
+**Request body:**
+
+```json
+{
+  "path": "/path/to/new-project",
+  "name": "my-project"
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `path` | string | Yes | Directory path to create and initialize |
+| `name` | string | No | Project name (defaults to directory name) |
+
+**Response:**
+
+```json
+{
+  "status": "ok",
+  "path": "/absolute/path/to/new-project"
+}
+```
+
+### `POST /api/copy`
+
+Copy a Santai project to a new location with a fresh git history.
+
+**Request body:**
+
+```json
+{
+  "source": "/path/to/source-project",
+  "destination": "/path/to/destination"
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `source` | string | Yes | Source project path |
+| `destination` | string | Yes | Destination path (must not exist) |
+
+**Response:**
+
+```json
+{
+  "status": "ok",
+  "destination": "/absolute/path/to/destination"
+}
+```
+
+### `POST /api/cherry-pick`
+
+Selectively copy files between Santai projects.
+
+**Request body:**
+
+```json
+{
+  "source": "/path/to/source-project",
+  "destination": "/path/to/dest-project",
+  "files": ["notes/idea.md", "media/"],
+  "overwrite": false
+}
+```
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `source` | string | Yes | — | Source project path |
+| `destination` | string | Yes | — | Destination project path |
+| `files` | list[string] | Yes | — | Files or folders to cherry-pick (relative paths) |
+| `overwrite` | boolean | No | `false` | Overwrite existing files at destination |
+
+**Response:**
+
+```json
+{
+  "status": "ok",
+  "copied": ["notes/idea.md", "media/architecture.md"]
+}
+```
+
+### `POST /api/merge`
+
+Merge two Santai projects into a new combined project. The primary project's files take precedence on conflicts.
+
+**Request body:**
+
+```json
+{
+  "primary": "/path/to/primary-project",
+  "secondary": "/path/to/secondary-project",
+  "output": "/path/to/merged-output"
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `primary` | string | Yes | Primary project (its files take precedence) |
+| `secondary` | string | Yes | Secondary project to merge in |
+| `output` | string | Yes | Output directory (must not exist) |
+
+**Response:**
+
+```json
+{
+  "status": "ok",
+  "output": "/absolute/path/to/merged-output"
+}
+```
+
+## Error Responses
+
+All error responses follow this format:
+
+```json
+{
+  "detail": "Description of the error"
+}
+```
+
+Common HTTP status codes:
+
+| Code | Meaning |
+|------|---------|
+| 400 | Bad request (invalid parameters) |
+| 401 | Unauthorized (missing or invalid token) |
+| 404 | Not found (source path doesn't exist) |
+| 409 | Conflict (destination already exists, or directory is not empty) |
+| 500 | Internal server error |
+
+## Examples
+
+Start the server with default settings (localhost only, no auth):
+
+```bash
+santai server
+```
+
+Start on a custom port with authentication:
+
+```bash
+santai server --port 9000 --token my-secret-token
+```
+
+Bind to all interfaces (for network access):
+
+```bash
+santai server --host 0.0.0.0 --token my-secret-token
+```
+
+Use an environment variable for the token:
+
+```bash
+export SANTAI_SERVER_TOKEN=my-secret-token
+santai server --host 0.0.0.0
+```
+
+Make an authenticated API call:
+
+```bash
+curl -X POST http://localhost:8080/api/init \
+  -H "Authorization: Bearer my-secret-token" \
+  -H "Content-Type: application/json" \
+  -d '{"path": "./new-project"}'
+```
+
+Access the interactive API docs:
+
+```bash
+santai server
+# Open http://localhost:8080/docs in your browser
+```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -18,7 +18,7 @@ ANTHROPIC_API_KEY=sk-ant-...
 OPENAI_API_KEY=sk-...
 
 # Optional: override default models
-ANTHROPIC_MODEL=claude-sonnet-4-20250514
+ANTHROPIC_MODEL=claude-sonnet-4-6
 OPENAI_MODEL=gpt-4o
 
 # Optional: custom OpenAI-compatible proxy (e.g. LiteLLM, Azure).
@@ -34,11 +34,12 @@ OPENAI_API_BASE_URL=https://your-proxy-url.example.com/
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `ANTHROPIC_API_KEY` | At least one provider | — | Your Anthropic API key |
-| `ANTHROPIC_MODEL` | No | `claude-sonnet-4-20250514` | Default Anthropic model |
+| `ANTHROPIC_MODEL` | No | `claude-sonnet-4-6` | Default Anthropic model |
 | `OPENAI_API_KEY` | At least one provider | — | Your OpenAI (or OpenAI-compatible) API key |
 | `OPENAI_MODEL` | No | `gpt-4o` | Default OpenAI model |
 | `OPENAI_API_BASE_URL` | No | `https://api.openai.com/v1` | Custom OpenAI-compatible endpoint (e.g. LiteLLM, Azure). When set, `OPENAI_API_KEY` should match the proxy. |
 | `SANTAI_HUB_URL` | No | `https://hub.sant.ai` | Santai Hub URL for push/pull/auth |
+| `SANTAI_SERVER_TOKEN` | No | — | Bearer token for `santai server` API authentication |
 
 You need at least one provider key configured for AI chat. You can configure both to have access to models from both providers.
 
@@ -48,20 +49,18 @@ You need at least one provider key configured for AI chat. You can configure bot
 
 | Model | Notes |
 |-------|-------|
-| `claude-sonnet-4-20250514` | Default |
-| `claude-opus-4-20250514` | |
-| `claude-haiku-4-20250514` | |
+| `claude-sonnet-4-6` | Default |
+| `claude-opus-4-7` | |
+| `claude-haiku-4-5-20251001` | |
 
 ### OpenAI
 
 | Model | Notes |
 |-------|-------|
 | `gpt-4o` | Default |
-| `gpt-4o-mini` | |
-| `o3-mini` | |
 | `gpt-4.1` | |
 | `gpt-4.1-mini` | |
-| `gpt-4.1-nano` | |
+| `o3-mini` | |
 
 ## Overriding the Default Model
 
@@ -69,14 +68,14 @@ Set the `ANTHROPIC_MODEL` or `OPENAI_MODEL` environment variable to change which
 
 ```bash
 # .env
-ANTHROPIC_MODEL=claude-opus-4-20250514
+ANTHROPIC_MODEL=claude-opus-4-7
 OPENAI_MODEL=gpt-4.1
 ```
 
 You can also bypass the interactive picker entirely with the `--model` flag:
 
 ```bash
-santai chat --model gpt-4o-mini
+santai chat --model gpt-4.1-mini
 ```
 
 ## API Key Validation

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -145,7 +145,7 @@ santai chat
 You'll be prompted to select a model. Use `--model` to skip the selection:
 
 ```bash
-santai chat --model claude-sonnet-4-20250514
+santai chat --model claude-sonnet-4-6
 santai chat --model gpt-4o
 ```
 

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -29,7 +29,7 @@ Use the history directory and AI agents to create a decision log:
 
 ```bash
 # Start a chat session with the documentation agent
-santai chat --agent documentation --model claude-sonnet-4-20250514
+santai chat --agent documentation --model claude-sonnet-4-6
 ```
 
 In the chat, ask it to write a history entry:
@@ -198,7 +198,7 @@ Compare responses from different AI models on the same question:
 
 ```bash
 # Ask Anthropic
-santai chat --model claude-sonnet-4-20250514
+santai chat --model claude-sonnet-4-6
 # Ask your question, note the response, then /quit
 
 # Ask OpenAI

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -60,6 +60,7 @@ nav:
       - chat: commands/chat.md
       - ui: commands/ui.md
       - web: commands/web.md
+      - server: commands/server.md
       - push: commands/push.md
       - pull: commands/pull.md
       - Authentication: commands/auth.md

--- a/src/santai_cli/cli.py
+++ b/src/santai_cli/cli.py
@@ -83,7 +83,7 @@ app.command(name="whoami")(auth.whoami)
 # Verbose help output
 # ---------------------------------------------------------------------------
 
-_VERSION = "0.1.0"
+_VERSION = "0.1.1"
 
 _COMMANDS: list[dict[str, str | list[str]]] = [
     {


### PR DESCRIPTION
## Summary

- Add full documentation for the `santai server` command (options, API endpoints, authentication, examples)
- Fix stale model names across all documentation to match `AVAILABLE_MODELS` in `src/santai_cli/core/config.py`
- Add `SANTAI_SERVER_TOKEN` environment variable to the configuration reference
- Update README source layout to include the `server/` directory
- Fix `_VERSION` in `cli.py` to match `pyproject.toml` (`0.1.1`)

## Changes

| File | Change |
|------|--------|
| `docs/commands/server.md` | **New** — Full server command documentation |
| `docs/commands/index.md` | Add `santai server` to command table |
| `mkdocs.yml` | Add server page to navigation |
| `docs/configuration.md` | Fix model names, add `SANTAI_SERVER_TOKEN` |
| `docs/commands/chat.md` | Fix model picker example |
| `docs/getting-started.md` | Fix model reference |
| `docs/use-cases.md` | Fix model references |
| `README.md` | Add server command section, update source layout |
| `src/santai_cli/cli.py` | Fix `_VERSION` to `"0.1.1"` |

## Verification

- `mkdocs build --strict` succeeds with no errors
- All stale model names (`claude-*-20250514`, `gpt-4o-mini`, `gpt-4.1-nano`) removed from docs
- Documentation now matches `AVAILABLE_MODELS` in code: `claude-sonnet-4-6`, `claude-opus-4-7`, `claude-haiku-4-5-20251001`, `gpt-4.1`, `gpt-4.1-mini`, `gpt-4o`, `o3-mini`

Closes #139