### PR TITLE
feat: chat history

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,9 @@ dev = [
     "ruff==0.15.14",
     "ty>=0.0.31",
     "pre-commit>=3.5.0",
+    "pytest>=8.0",
+    "pytest-asyncio>=0.23",
+    "httpx>=0.27",
 ]
 
 [project.scripts]

--- a/src/santai_cli/commands/chat.py
+++ b/src/santai_cli/commands/chat.py
@@ -5,6 +5,7 @@ using Rich for terminal formatting and streaming response display.
 """
 
 import asyncio
+import contextlib
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Annotated
@@ -18,6 +19,13 @@ from rich.prompt import Prompt
 from rich.text import Text
 
 from santai_cli.core.chat import ChatSession, stream_response
+from santai_cli.core.chat_history import (
+    auto_title,
+    list_sessions,
+    load_session,
+    restore_chat_session,
+    save_session,
+)
 from santai_cli.core.config import (
     ChatConfig,
     get_agent_profiles,
@@ -41,6 +49,8 @@ class _ChatState:
     model: str
     agent: str | None
     project: SantaiProject | None = None
+    session_id: str | None = None
+    session_title: str | None = None
 
 
 def chat(
@@ -329,6 +339,7 @@ def _repl_loop(
 
         if full_response is not None:
             state.session.add_assistant_message(full_response)
+            _autosave_session(state)
         else:
             # Remove the user message if the response failed
             state.session.messages.pop()
@@ -360,11 +371,19 @@ def _handle_command(command: str, state: _ChatState) -> str:
                 "[cyan]/clear[/]         Clear conversation history\n"
                 "[cyan]/agent[/]         List agents, or /agent <name> to switch\n"
                 "[cyan]/model[/]         Re-select the model\n"
+                "[cyan]/save[/]          Save this chat (optional: /save <title>)\n"
+                "[cyan]/history[/]       List saved chats and optionally resume one\n"
                 "[cyan]/help[/]          Show this help message",
                 title="Commands",
                 border_style="dim",
             )
         )
+
+    elif cmd == "/save":
+        _cmd_save(state, arg)
+
+    elif cmd == "/history":
+        _cmd_history(state)
 
     elif cmd == "/agent":
         if arg:
@@ -394,6 +413,120 @@ def _handle_command(command: str, state: _ChatState) -> str:
         console.print(f"[red]Unknown command: {cmd}[/]. Type /help for options.\n")
 
     return "continue"
+
+
+def _autosave_session(state: _ChatState) -> None:
+    """Silently save the current session if a project is available."""
+    if state.project is None:
+        return
+    with contextlib.suppress(Exception):
+        state.session_id = save_session(
+            project=state.project,
+            session=state.session,
+            session_id=state.session_id,
+            title=state.session_title,
+            provider=state.provider,
+            model=state.model,
+            agent=state.agent,
+        )
+
+
+def _cmd_save(state: _ChatState, title: str | None) -> None:
+    """Handle the /save command."""
+    if state.project is None:
+        console.print("[yellow]Not in a project — cannot save chat history.[/]\n")
+        return
+    msgs = [
+        {"role": m.role, "content": m.content}
+        for m in state.session.messages
+        if m.role in ("user", "assistant")
+    ]
+    if not msgs:
+        console.print("[dim]Nothing to save yet.[/]\n")
+        return
+    if title:
+        state.session_title = title
+    try:
+        state.session_id = save_session(
+            project=state.project,
+            session=state.session,
+            session_id=state.session_id,
+            title=state.session_title,
+            provider=state.provider,
+            model=state.model,
+            agent=state.agent,
+        )
+        display_title = state.session_title or auto_title(msgs)
+        console.print(f"[green]Saved:[/] {display_title}\n")
+    except Exception as e:
+        console.print(f"[red]Save failed:[/] {e}\n")
+
+
+def _cmd_history(state: _ChatState) -> None:
+    """Handle the /history command — list sessions and optionally resume one."""
+    if state.project is None:
+        console.print("[yellow]Not in a project — no chat history available.[/]\n")
+        return
+    sessions = list_sessions(state.project)
+    if not sessions:
+        console.print("[dim]No saved chats found.[/]\n")
+        return
+
+    console.print("\n[bold]Saved chats:[/]\n")
+    for i, meta in enumerate(sessions[:20], 1):
+        try:
+            dt = meta.updated_at[:10]
+        except Exception:
+            dt = "?"
+        msg_count = f"({meta.message_count} msgs)"
+        console.print(f"  [cyan]{i:2}[/])  [{dt}] {meta.title}  [dim]{msg_count}[/]")
+    console.print()
+
+    selection = Prompt.ask(
+        "Enter number to resume, or press Enter to cancel",
+        default="",
+    ).strip()
+    if not selection:
+        return
+    try:
+        idx = int(selection) - 1
+        if not (0 <= idx < len(sessions[:20])):
+            raise ValueError
+    except ValueError:
+        console.print("[red]Invalid selection.[/]\n")
+        return
+
+    meta = sessions[idx]
+    try:
+        persisted = load_session(state.project, meta.id)
+    except FileNotFoundError:
+        console.print("[red]Session file not found.[/]\n")
+        return
+
+    restored = restore_chat_session(persisted)
+    # Keep the live system_prompt (may include updated repo context)
+    restored.system_prompt = state.session.system_prompt
+    restored.project_root = state.session.project_root
+
+    state.session = restored
+    state.session_id = persisted.id
+    state.session_title = persisted.title
+    state.provider = persisted.provider or state.provider
+    state.model = persisted.model or state.model
+
+    console.print(f"\n[dim]Resumed:[/] {persisted.title}")
+    console.print(f"[dim]({len(persisted.messages)} messages restored)[/]\n")
+
+    # Re-display the last exchange so the user has context
+    user_msgs = [m for m in persisted.messages if m.get("role") == "user"]
+    asst_msgs = [m for m in persisted.messages if m.get("role") == "assistant"]
+    if user_msgs:
+        snippet = user_msgs[-1]["content"][:200]
+        console.print(f"[bold green]You[/] [dim](last)[/]: {snippet}")
+    if asst_msgs:
+        snippet = asst_msgs[-1]["content"][:200]
+        console.print(f"[bold cyan]Assistant[/] [dim](last)[/]: {snippet}")
+    console.print()
 
 
 def _stream_assistant_response(state: _ChatState) -> str | None:

--- a/src/santai_cli/commands/chat.py
+++ b/src/santai_cli/commands/chat.py
@@ -84,6 +84,8 @@ def chat(
     REPL commands:
       /quit     Exit the chat
       /clear    Clear conversation history
+      /save     Save this chat (optional: /save <title>)
+      /history  List saved chats and optionally resume one
       /agent    List or switch agent profiles
       /model    Re-select the model
       /help     Show available commands
@@ -474,10 +476,7 @@ def _cmd_history(state: _ChatState) -> None:
 
     console.print("\n[bold]Saved chats:[/]\n")
     for i, meta in enumerate(sessions[:20], 1):
-        try:
-            dt = meta.updated_at[:10]
-        except Exception:
-            dt = "?"
+        dt = meta.updated_at[:10] if meta.updated_at else "?"
         msg_count = f"({meta.message_count} msgs)"
         console.print(f"  [cyan]{i:2}[/])  [{dt}] {meta.title}  [dim]{msg_count}[/]")
     console.print()

--- a/src/santai_cli/core/chat_history.py
+++ b/src/santai_cli/core/chat_history.py
@@ -94,7 +94,7 @@ def auto_title(messages: list[dict[str, str]]) -> str:
     for msg in messages:
         if msg.get("role") == "user":
             text = msg.get("content", "").strip()
-            return text[:60] + ("…" if len(text) > 60 else "")
+            return text[:40] + ("…" if len(text) > 40 else "")
     return "Untitled chat"
 
 

--- a/src/santai_cli/core/chat_history.py
+++ b/src/santai_cli/core/chat_history.py
@@ -413,6 +413,55 @@ def list_sessions(project: SantaiProject) -> list[ChatSessionMetadata]:
     return entries
 
 
+def rename_session(project: SantaiProject, session_id: str, new_title: str) -> None:
+    """Update a session's title and rename the file to match."""
+    chat_dir = get_chat_history_dir(project)
+    old_path = _find_session_path(chat_dir, session_id)
+    if old_path is None:
+        raise FileNotFoundError(f"Chat session '{session_id}' not found")
+
+    meta, messages = _parse_markdown(old_path.read_text(encoding="utf-8"))
+    now = datetime.now(UTC).isoformat()
+    created_at = meta.get("created_at", now)
+
+    try:
+        date_str = datetime.fromisoformat(created_at).strftime("%m-%d-%Y")
+    except (ValueError, TypeError):
+        date_str = datetime.now(UTC).strftime("%m-%d-%Y")
+
+    base = f"{date_str} - {_sanitize_title(new_title)}"
+    candidate = f"{base}.md"
+
+    if candidate == old_path.name:
+        new_path = old_path
+    else:
+        new_path = chat_dir / candidate
+        if new_path.exists():
+            counter = 2
+            while (chat_dir / f"{base} ({counter}).md").exists():
+                counter += 1
+            new_path = chat_dir / f"{base} ({counter}).md"
+
+    content = _build_markdown(
+        session_id=meta.get("id", session_id),
+        title=new_title,
+        created_at=created_at,
+        updated_at=now,
+        provider=meta.get("provider", ""),
+        model=meta.get("model", ""),
+        agent=meta.get("agent"),
+        messages=messages,
+    )
+
+    new_path.write_text(content, encoding="utf-8")
+    if new_path != old_path:
+        old_path.unlink()
+
+    index = _load_index(chat_dir)
+    index[session_id] = new_path.name
+    _save_index(chat_dir, index)
+
+
 def delete_session(project: SantaiProject, session_id: str) -> None:
     """Delete a session file. Raises FileNotFoundError if missing."""
     chat_dir = get_chat_history_dir(project)

--- a/src/santai_cli/core/chat_history.py
+++ b/src/santai_cli/core/chat_history.py
@@ -39,6 +39,8 @@ from santai_cli.core.project import SantaiProject
 _INVALID_FILENAME_CHARS = re.compile(r'[<>:"/\\|?*\x00-\x1f]')
 _MULTI_DASH = re.compile(r"-{2,}")
 _MULTI_SPACE = re.compile(r" {2,}")
+_FENCED_CODE_BLOCK = re.compile(r"```[^\n]*\n.*?```", re.DOTALL)
+_INDEX_FILE = "_index.json"
 
 
 def get_chat_history_dir(project: SantaiProject) -> Path:
@@ -70,17 +72,60 @@ def _session_filename(title: str, created_at: str, chat_dir: Path) -> str:
     return f"{base} ({counter}).md"
 
 
-def _find_session_path(chat_dir: Path, session_id: str) -> Path | None:
-    """Scan chat_dir for the file whose frontmatter id matches session_id."""
+def _load_index(chat_dir: Path) -> dict[str, str]:
+    """Return the session_id → filename mapping from the index file."""
+    try:
+        return json.loads((chat_dir / _INDEX_FILE).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def _save_index(chat_dir: Path, index: dict[str, str]) -> None:
+    (chat_dir / _INDEX_FILE).write_text(json.dumps(index, indent=2), encoding="utf-8")
+
+
+def _rebuild_index(chat_dir: Path) -> dict[str, str]:
+    """Rebuild the index by scanning all .md files (O(n) fallback)."""
+    index: dict[str, str] = {}
+    id_inline_prefix = "\n---\nid: "
+    id_front_prefix = "---\nid: "
     for path in chat_dir.glob("*.md"):
         try:
             text = path.read_text(encoding="utf-8")
-            id_inline = f"\nid: {session_id}\n"
-            id_first = f"---\nid: {session_id}\n"
-            if id_inline in text or text.startswith(id_first):
-                return path
+            session_id = None
+            if id_inline_prefix in text:
+                start = text.find(id_inline_prefix) + len(id_inline_prefix)
+                end = text.find("\n", start)
+                if end != -1:
+                    session_id = text[start:end].strip()
+            elif text.startswith(id_front_prefix):
+                start = len(id_front_prefix)
+                end = text.find("\n", start)
+                if end != -1:
+                    session_id = text[start:end].strip()
+            if session_id:
+                index[session_id] = path.name
         except OSError:
             continue
+    _save_index(chat_dir, index)
+    return index
+
+
+def _find_session_path(chat_dir: Path, session_id: str) -> Path | None:
+    """Return the Path for a session_id using an index file for O(1) lookup."""
+    index = _load_index(chat_dir)
+    filename = index.get(session_id)
+    if filename:
+        path = chat_dir / filename
+        if path.exists():
+            return path
+    # Index miss or stale entry — rebuild once and retry.
+    index = _rebuild_index(chat_dir)
+    filename = index.get(session_id)
+    if filename:
+        path = chat_dir / filename
+        if path.exists():
+            return path
     return None
 
 
@@ -145,6 +190,25 @@ _MSG_PATTERN = re.compile(
     r"(?:^|\n\n)\*\*(You|Assistant):\*\*\n(.*?)(?=\n\n\*\*(?:You|Assistant):\*\*\n|$)",
     re.DOTALL,
 )
+
+
+def _mask_code_blocks(text: str) -> tuple[str, dict[str, str]]:
+    """Replace fenced code blocks with unique tokens so speaker labels inside
+    code blocks don't confuse the message parser."""
+    replacements: dict[str, str] = {}
+
+    def _sub(m: re.Match) -> str:
+        token = f"\x00CB{len(replacements)}\x00"
+        replacements[token] = m.group(0)
+        return token
+
+    return _FENCED_CODE_BLOCK.sub(_sub, text), replacements
+
+
+def _restore_code_blocks(text: str, replacements: dict[str, str]) -> str:
+    for token, original in replacements.items():
+        text = text.replace(token, original)
+    return text
 
 
 def _build_markdown(
@@ -220,9 +284,11 @@ def _parse_markdown(text: str) -> tuple[dict, list[dict[str, str]]]:
             meta = _parse_meta_block(text[sep_idx + 5 : close_idx])
             body = text[:sep_idx]
 
+    masked_body, code_block_map = _mask_code_blocks(body)
     messages: list[dict[str, str]] = []
-    for match in _MSG_PATTERN.finditer(body.strip()):
-        role_label, content = match.group(1), match.group(2).strip()
+    for match in _MSG_PATTERN.finditer(masked_body.strip()):
+        role_label = match.group(1)
+        content = _restore_code_blocks(match.group(2).strip(), code_block_map)
         if content:
             role = "user" if role_label == "You" else "assistant"
             messages.append({"role": role, "content": content})
@@ -288,6 +354,11 @@ def save_session(
     )
 
     (chat_dir / filename).write_text(content, encoding="utf-8")
+
+    index = _load_index(chat_dir)
+    index[session_id] = filename
+    _save_index(chat_dir, index)
+
     return session_id
 
 
@@ -344,10 +415,14 @@ def list_sessions(project: SantaiProject) -> list[ChatSessionMetadata]:
 
 def delete_session(project: SantaiProject, session_id: str) -> None:
     """Delete a session file. Raises FileNotFoundError if missing."""
-    path = _find_session_path(get_chat_history_dir(project), session_id)
+    chat_dir = get_chat_history_dir(project)
+    path = _find_session_path(chat_dir, session_id)
     if path is None:
         raise FileNotFoundError(f"Chat session '{session_id}' not found")
     path.unlink()
+    index = _load_index(chat_dir)
+    index.pop(session_id, None)
+    _save_index(chat_dir, index)
 
 
 def restore_chat_session(persisted: PersistedChatSession) -> ChatSession:

--- a/src/santai_cli/core/chat_history.py
+++ b/src/santai_cli/core/chat_history.py
@@ -1,12 +1,19 @@
 """Persistence layer for chat sessions.
 
-Saves and loads chat sessions as Markdown files with YAML frontmatter under
+Saves and loads chat sessions as Markdown files under
 <project_root>/history/chat-history/.
 
 Filenames use the pattern: MM-DD-YYYY - Title.md
-The session id in the frontmatter is the stable lookup key.
+The session id in the metadata block is the stable lookup key.
 
-File format:
+File format (transcript first, metadata at the bottom):
+
+    **You:**
+    First user message here.
+
+    **Assistant:**
+    Response here.
+
     ---
     id: 20260527-153042-a1b2
     title: "What is recursion?"
@@ -17,12 +24,6 @@ File format:
     agent: null
     message_count: 4
     ---
-
-    **You:**
-    First user message here.
-
-    **Assistant:**
-    Response here.
 """
 
 import json
@@ -157,7 +158,7 @@ def _build_markdown(
     messages: list[dict[str, str]],
 ) -> str:
     agent_val = "null" if agent is None else agent
-    frontmatter = (
+    metadata_block = (
         "---\n"
         f"id: {session_id}\n"
         f"title: {json.dumps(title, ensure_ascii=False)}\n"
@@ -174,33 +175,50 @@ def _build_markdown(
         label = "You" if msg["role"] == "user" else "Assistant"
         body_parts.append(f"**{label}:**\n{msg['content']}")
     body = "\n\n".join(body_parts)
-    return f"{frontmatter}\n\n{body}\n"
+    if body:
+        return f"{body}\n\n{metadata_block}\n"
+    return f"{metadata_block}\n"
+
+
+def _parse_meta_block(block: str) -> dict:
+    """Parse key: value lines from a raw metadata block string."""
+    meta: dict = {}
+    for line in block.splitlines():
+        if ": " in line:
+            key, _, raw = line.partition(": ")
+            raw = raw.strip()
+            if raw == "null":
+                meta[key.strip()] = None
+            elif raw.isdigit():
+                meta[key.strip()] = int(raw)
+            elif raw.startswith('"'):
+                try:
+                    meta[key.strip()] = json.loads(raw)
+                except (json.JSONDecodeError, ValueError):
+                    meta[key.strip()] = raw.strip('"')
+            else:
+                meta[key.strip()] = raw
+    return meta
 
 
 def _parse_markdown(text: str) -> tuple[dict, list[dict[str, str]]]:
-    """Parse frontmatter and messages from a session Markdown file."""
+    """Parse metadata and messages from a session Markdown file.
+
+    Supports two layouts:
+    - New: transcript first, then ``---\\n{meta}\\n---`` at the bottom.
+    - Old: ``---\\n{meta}\\n---`` frontmatter at the top (backwards compat).
+    """
     meta: dict = {}
     body = text
 
-    if text.startswith("---\n"):
-        end = text.find("\n---\n", 4)
-        if end != -1:
-            for line in text[4:end].splitlines():
-                if ": " in line:
-                    key, _, raw = line.partition(": ")
-                    raw = raw.strip()
-                    if raw == "null":
-                        meta[key.strip()] = None
-                    elif raw.isdigit():
-                        meta[key.strip()] = int(raw)
-                    elif raw.startswith('"'):
-                        try:
-                            meta[key.strip()] = json.loads(raw)
-                        except (json.JSONDecodeError, ValueError):
-                            meta[key.strip()] = raw.strip('"')
-                    else:
-                        meta[key.strip()] = raw
-            body = text[end + 5 :]
+    # Metadata block at the bottom: \n---\n{key: val...}\n---
+    # id: is always the first field, so \n---\nid: locates the opening delimiter.
+    if "\n---\nid: " in text:
+        sep_idx = text.find("\n---\nid: ")
+        close_idx = text.find("\n---", sep_idx + 5)
+        if close_idx != -1:
+            meta = _parse_meta_block(text[sep_idx + 5 : close_idx])
+            body = text[:sep_idx]
 
     messages: list[dict[str, str]] = []
     for match in _MSG_PATTERN.finditer(body.strip()):

--- a/src/santai_cli/core/chat_history.py
+++ b/src/santai_cli/core/chat_history.py
@@ -26,8 +26,11 @@ File format (transcript first, metadata at the bottom):
     ---
 """
 
+import contextlib
 import json
+import os
 import re
+import tempfile
 import uuid
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
@@ -48,10 +51,25 @@ def get_chat_history_dir(project: SantaiProject) -> Path:
     return project.root / "history" / "chat-history"
 
 
+def _atomic_write_text(path: Path, content: str) -> None:
+    """Write content to path atomically via a temp file + os.replace."""
+    fd, tmp = tempfile.mkstemp(dir=path.parent, suffix=".tmp")
+    try:
+        os.write(fd, content.encode("utf-8"))
+        os.close(fd)
+        os.replace(tmp, path)
+    except BaseException:
+        with contextlib.suppress(OSError):
+            os.close(fd)
+        with contextlib.suppress(OSError):
+            os.unlink(tmp)
+        raise
+
+
 def _sanitize_title(title: str) -> str:
     """Strip characters not allowed in filenames and normalise whitespace."""
     cleaned = _INVALID_FILENAME_CHARS.sub("", title)
-    cleaned = _MULTI_SPACE.sub(" ", cleaned).strip(" -")
+    cleaned = _MULTI_SPACE.sub(" ", cleaned).strip(" -.")
     return cleaned[:60] or "Untitled chat"
 
 
@@ -76,13 +94,14 @@ def _session_filename(title: str, created_at: str, chat_dir: Path) -> str:
 def _load_index(chat_dir: Path) -> dict[str, str]:
     """Return the session_id → filename mapping from the index file."""
     try:
-        return json.loads((chat_dir / _INDEX_FILE).read_text(encoding="utf-8"))
+        data = json.loads((chat_dir / _INDEX_FILE).read_text(encoding="utf-8"))
+        return data if isinstance(data, dict) else {}
     except (OSError, json.JSONDecodeError):
         return {}
 
 
 def _save_index(chat_dir: Path, index: dict[str, str]) -> None:
-    (chat_dir / _INDEX_FILE).write_text(json.dumps(index, indent=2), encoding="utf-8")
+    _atomic_write_text(chat_dir / _INDEX_FILE, json.dumps(index, indent=2))
 
 
 def _rebuild_index(chat_dir: Path) -> dict[str, str]:
@@ -352,7 +371,7 @@ def save_session(
         messages=messages,
     )
 
-    (chat_dir / filename).write_text(content, encoding="utf-8")
+    _atomic_write_text(chat_dir / filename, content)
 
     index = _load_index(chat_dir)
     index[session_id] = filename
@@ -419,18 +438,24 @@ def list_sessions(project: SantaiProject) -> list[ChatSessionMetadata]:
 def _load_hidden(chat_dir: Path) -> set[str]:
     """Return the set of session IDs hidden from the history panel."""
     try:
-        return set(json.loads((chat_dir / _HIDDEN_FILE).read_text(encoding="utf-8")))
+        data = json.loads((chat_dir / _HIDDEN_FILE).read_text(encoding="utf-8"))
+        return set(data) if isinstance(data, list) else set()
     except (OSError, json.JSONDecodeError):
         return set()
 
 
 def _save_hidden(chat_dir: Path, hidden: set[str]) -> None:
-    (chat_dir / _HIDDEN_FILE).write_text(json.dumps(sorted(hidden)), encoding="utf-8")
+    _atomic_write_text(chat_dir / _HIDDEN_FILE, json.dumps(sorted(hidden)))
 
 
 def hide_session(project: SantaiProject, session_id: str) -> None:
-    """Hide a session from the history panel without deleting the file."""
+    """Hide a session from the history panel without deleting the file.
+
+    Raises FileNotFoundError if the session does not exist on disk.
+    """
     chat_dir = get_chat_history_dir(project)
+    if _find_session_path(chat_dir, session_id) is None:
+        raise FileNotFoundError(f"Chat session '{session_id}' not found")
     hidden = _load_hidden(chat_dir)
     hidden.add(session_id)
     _save_hidden(chat_dir, hidden)
@@ -484,7 +509,7 @@ def rename_session(project: SantaiProject, session_id: str, new_title: str) -> N
         messages=messages,
     )
 
-    new_path.write_text(content, encoding="utf-8")
+    _atomic_write_text(new_path, content)
     if new_path != old_path:
         old_path.unlink()
 

--- a/src/santai_cli/core/chat_history.py
+++ b/src/santai_cli/core/chat_history.py
@@ -41,6 +41,7 @@ _MULTI_DASH = re.compile(r"-{2,}")
 _MULTI_SPACE = re.compile(r" {2,}")
 _FENCED_CODE_BLOCK = re.compile(r"```[^\n]*\n.*?```", re.DOTALL)
 _INDEX_FILE = "_index.json"
+_HIDDEN_FILE = "_hidden.json"
 
 
 def get_chat_history_dir(project: SantaiProject) -> Path:
@@ -385,18 +386,22 @@ def load_session(project: SantaiProject, session_id: str) -> PersistedChatSessio
 
 
 def list_sessions(project: SantaiProject) -> list[ChatSessionMetadata]:
-    """Return metadata for all saved sessions, newest first."""
+    """Return metadata for all saved sessions, newest first, excluding hidden ones."""
     chat_dir = get_chat_history_dir(project)
     if not chat_dir.is_dir():
         return []
 
+    hidden = _load_hidden(chat_dir)
     entries: list[ChatSessionMetadata] = []
     for path in chat_dir.glob("*.md"):
         try:
             meta, messages = _parse_markdown(path.read_text(encoding="utf-8"))
+            sid = meta.get("id", path.stem)
+            if sid in hidden:
+                continue
             entries.append(
                 ChatSessionMetadata(
-                    id=meta.get("id", path.stem),
+                    id=sid,
                     title=meta.get("title", "Untitled chat"),
                     created_at=meta.get("created_at", ""),
                     updated_at=meta.get("updated_at", ""),
@@ -411,6 +416,34 @@ def list_sessions(project: SantaiProject) -> list[ChatSessionMetadata]:
 
     entries.sort(key=lambda e: e.updated_at, reverse=True)
     return entries
+
+
+def _load_hidden(chat_dir: Path) -> set[str]:
+    """Return the set of session IDs hidden from the history panel."""
+    try:
+        return set(json.loads((chat_dir / _HIDDEN_FILE).read_text(encoding="utf-8")))
+    except (OSError, json.JSONDecodeError):
+        return set()
+
+
+def _save_hidden(chat_dir: Path, hidden: set[str]) -> None:
+    (chat_dir / _HIDDEN_FILE).write_text(json.dumps(sorted(hidden)), encoding="utf-8")
+
+
+def hide_session(project: SantaiProject, session_id: str) -> None:
+    """Hide a session from the history panel without deleting the file."""
+    chat_dir = get_chat_history_dir(project)
+    hidden = _load_hidden(chat_dir)
+    hidden.add(session_id)
+    _save_hidden(chat_dir, hidden)
+
+
+def unhide_session(project: SantaiProject, session_id: str) -> None:
+    """Make a previously hidden session visible again."""
+    chat_dir = get_chat_history_dir(project)
+    hidden = _load_hidden(chat_dir)
+    hidden.discard(session_id)
+    _save_hidden(chat_dir, hidden)
 
 
 def rename_session(project: SantaiProject, session_id: str, new_title: str) -> None:
@@ -472,6 +505,10 @@ def delete_session(project: SantaiProject, session_id: str) -> None:
     index = _load_index(chat_dir)
     index.pop(session_id, None)
     _save_index(chat_dir, index)
+    hidden = _load_hidden(chat_dir)
+    if session_id in hidden:
+        hidden.discard(session_id)
+        _save_hidden(chat_dir, hidden)
 
 
 def restore_chat_session(persisted: PersistedChatSession) -> ChatSession:

--- a/src/santai_cli/core/chat_history.py
+++ b/src/santai_cli/core/chat_history.py
@@ -1,0 +1,345 @@
+"""Persistence layer for chat sessions.
+
+Saves and loads chat sessions as Markdown files with YAML frontmatter under
+<project_root>/history/chat-history/.
+
+Filenames use the pattern: MM-DD-YYYY - Title.md
+The session id in the frontmatter is the stable lookup key.
+
+File format:
+    ---
+    id: 20260527-153042-a1b2
+    title: "What is recursion?"
+    created_at: 2026-05-27T15:30:42+00:00
+    updated_at: 2026-05-27T15:45:10+00:00
+    provider: anthropic
+    model: claude-sonnet-4-6
+    agent: null
+    message_count: 4
+    ---
+
+    **You:**
+    First user message here.
+
+    **Assistant:**
+    Response here.
+"""
+
+import json
+import re
+import uuid
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+
+from santai_cli.core.chat import ChatMessage, ChatSession
+from santai_cli.core.project import SantaiProject
+
+_INVALID_FILENAME_CHARS = re.compile(r'[<>:"/\\|?*\x00-\x1f]')
+_MULTI_DASH = re.compile(r"-{2,}")
+_MULTI_SPACE = re.compile(r" {2,}")
+
+
+def get_chat_history_dir(project: SantaiProject) -> Path:
+    return project.root / "history" / "chat-history"
+
+
+def _sanitize_title(title: str) -> str:
+    """Strip characters not allowed in filenames and normalise whitespace."""
+    cleaned = _INVALID_FILENAME_CHARS.sub("", title)
+    cleaned = _MULTI_SPACE.sub(" ", cleaned).strip(" -")
+    return cleaned[:60] or "Untitled chat"
+
+
+def _session_filename(title: str, created_at: str, chat_dir: Path) -> str:
+    """Return a unique filename stem for a new session."""
+    try:
+        date_str = datetime.fromisoformat(created_at).strftime("%m-%d-%Y")
+    except (ValueError, TypeError):
+        date_str = datetime.now(UTC).strftime("%m-%d-%Y")
+
+    base = f"{date_str} - {_sanitize_title(title)}"
+    candidate = f"{base}.md"
+    if not (chat_dir / candidate).exists():
+        return candidate
+
+    counter = 2
+    while (chat_dir / f"{base} ({counter}).md").exists():
+        counter += 1
+    return f"{base} ({counter}).md"
+
+
+def _find_session_path(chat_dir: Path, session_id: str) -> Path | None:
+    """Scan chat_dir for the file whose frontmatter id matches session_id."""
+    for path in chat_dir.glob("*.md"):
+        try:
+            text = path.read_text(encoding="utf-8")
+            id_inline = f"\nid: {session_id}\n"
+            id_first = f"---\nid: {session_id}\n"
+            if id_inline in text or text.startswith(id_first):
+                return path
+        except OSError:
+            continue
+    return None
+
+
+def generate_session_id() -> str:
+    ts = datetime.now(UTC).strftime("%Y%m%d-%H%M%S")
+    suffix = uuid.uuid4().hex[:4]
+    return f"{ts}-{suffix}"
+
+
+def auto_title(messages: list[dict[str, str]]) -> str:
+    for msg in messages:
+        if msg.get("role") == "user":
+            text = msg.get("content", "").strip()
+            return text[:60] + ("…" if len(text) > 60 else "")
+    return "Untitled chat"
+
+
+@dataclass
+class ChatSessionMetadata:
+    id: str
+    title: str
+    created_at: str
+    updated_at: str
+    provider: str
+    model: str
+    agent: str | None
+    message_count: int
+
+
+@dataclass
+class PersistedChatSession:
+    id: str
+    title: str
+    created_at: str
+    updated_at: str
+    provider: str
+    model: str
+    agent: str | None
+    message_count: int
+    system_prompt: str | None  # not stored; rebuilt from context on resume
+    messages: list[dict[str, str]] = field(default_factory=list)
+    tool_turns: list[dict] = field(default_factory=list)  # not stored in Markdown
+
+    def to_metadata(self) -> ChatSessionMetadata:
+        return ChatSessionMetadata(
+            id=self.id,
+            title=self.title,
+            created_at=self.created_at,
+            updated_at=self.updated_at,
+            provider=self.provider,
+            model=self.model,
+            agent=self.agent,
+            message_count=self.message_count,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Markdown serialisation
+# ---------------------------------------------------------------------------
+
+_MSG_PATTERN = re.compile(
+    r"(?:^|\n\n)\*\*(You|Assistant):\*\*\n(.*?)(?=\n\n\*\*(?:You|Assistant):\*\*\n|$)",
+    re.DOTALL,
+)
+
+
+def _build_markdown(
+    session_id: str,
+    title: str,
+    created_at: str,
+    updated_at: str,
+    provider: str,
+    model: str,
+    agent: str | None,
+    messages: list[dict[str, str]],
+) -> str:
+    agent_val = "null" if agent is None else agent
+    frontmatter = (
+        "---\n"
+        f"id: {session_id}\n"
+        f"title: {json.dumps(title, ensure_ascii=False)}\n"
+        f"created_at: {created_at}\n"
+        f"updated_at: {updated_at}\n"
+        f"provider: {provider}\n"
+        f"model: {model}\n"
+        f"agent: {agent_val}\n"
+        f"message_count: {len(messages)}\n"
+        "---"
+    )
+    body_parts = []
+    for msg in messages:
+        label = "You" if msg["role"] == "user" else "Assistant"
+        body_parts.append(f"**{label}:**\n{msg['content']}")
+    body = "\n\n".join(body_parts)
+    return f"{frontmatter}\n\n{body}\n"
+
+
+def _parse_markdown(text: str) -> tuple[dict, list[dict[str, str]]]:
+    """Parse frontmatter and messages from a session Markdown file."""
+    meta: dict = {}
+    body = text
+
+    if text.startswith("---\n"):
+        end = text.find("\n---\n", 4)
+        if end != -1:
+            for line in text[4:end].splitlines():
+                if ": " in line:
+                    key, _, raw = line.partition(": ")
+                    raw = raw.strip()
+                    if raw == "null":
+                        meta[key.strip()] = None
+                    elif raw.isdigit():
+                        meta[key.strip()] = int(raw)
+                    elif raw.startswith('"'):
+                        try:
+                            meta[key.strip()] = json.loads(raw)
+                        except (json.JSONDecodeError, ValueError):
+                            meta[key.strip()] = raw.strip('"')
+                    else:
+                        meta[key.strip()] = raw
+            body = text[end + 5 :]
+
+    messages: list[dict[str, str]] = []
+    for match in _MSG_PATTERN.finditer(body.strip()):
+        role_label, content = match.group(1), match.group(2).strip()
+        if content:
+            role = "user" if role_label == "You" else "assistant"
+            messages.append({"role": role, "content": content})
+
+    return meta, messages
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def save_session(
+    project: SantaiProject,
+    session: ChatSession,
+    session_id: str | None,
+    title: str | None,
+    provider: str,
+    model: str,
+    agent: str | None,
+) -> str:
+    """Write a chat session to disk as Markdown. Returns the session_id."""
+    chat_dir = get_chat_history_dir(project)
+    chat_dir.mkdir(parents=True, exist_ok=True)
+
+    messages = [
+        {"role": m.role, "content": m.content}
+        for m in session.messages
+        if m.role in ("user", "assistant")
+    ]
+
+    now = datetime.now(UTC).isoformat()
+
+    computed_title = title or auto_title(messages)
+
+    if session_id is None:
+        session_id = generate_session_id()
+        created_at = now
+        filename = _session_filename(computed_title, now, chat_dir)
+    else:
+        existing_path = _find_session_path(chat_dir, session_id)
+        if existing_path is not None:
+            try:
+                raw = existing_path.read_text(encoding="utf-8")
+                existing_meta, _ = _parse_markdown(raw)
+                created_at = existing_meta.get("created_at", now)
+            except OSError:
+                created_at = now
+            filename = existing_path.name  # keep the original filename
+        else:
+            created_at = now
+            filename = _session_filename(computed_title, now, chat_dir)
+
+    content = _build_markdown(
+        session_id=session_id,
+        title=computed_title,
+        created_at=created_at,
+        updated_at=now,
+        provider=provider,
+        model=model,
+        agent=agent,
+        messages=messages,
+    )
+
+    (chat_dir / filename).write_text(content, encoding="utf-8")
+    return session_id
+
+
+def load_session(project: SantaiProject, session_id: str) -> PersistedChatSession:
+    """Load a chat session from disk. Raises FileNotFoundError if missing."""
+    path = _find_session_path(get_chat_history_dir(project), session_id)
+    if path is None:
+        raise FileNotFoundError(f"Chat session '{session_id}' not found")
+
+    meta, messages = _parse_markdown(path.read_text(encoding="utf-8"))
+    return PersistedChatSession(
+        id=meta.get("id", session_id),
+        title=meta.get("title", "Untitled chat"),
+        created_at=meta.get("created_at", ""),
+        updated_at=meta.get("updated_at", ""),
+        provider=meta.get("provider", ""),
+        model=meta.get("model", ""),
+        agent=meta.get("agent"),
+        message_count=meta.get("message_count", len(messages)),
+        system_prompt=None,
+        messages=messages,
+        tool_turns=[],
+    )
+
+
+def list_sessions(project: SantaiProject) -> list[ChatSessionMetadata]:
+    """Return metadata for all saved sessions, newest first."""
+    chat_dir = get_chat_history_dir(project)
+    if not chat_dir.is_dir():
+        return []
+
+    entries: list[ChatSessionMetadata] = []
+    for path in chat_dir.glob("*.md"):
+        try:
+            meta, messages = _parse_markdown(path.read_text(encoding="utf-8"))
+            entries.append(
+                ChatSessionMetadata(
+                    id=meta.get("id", path.stem),
+                    title=meta.get("title", "Untitled chat"),
+                    created_at=meta.get("created_at", ""),
+                    updated_at=meta.get("updated_at", ""),
+                    provider=meta.get("provider", ""),
+                    model=meta.get("model", ""),
+                    agent=meta.get("agent"),
+                    message_count=meta.get("message_count", len(messages)),
+                )
+            )
+        except OSError:
+            continue
+
+    entries.sort(key=lambda e: e.updated_at, reverse=True)
+    return entries
+
+
+def delete_session(project: SantaiProject, session_id: str) -> None:
+    """Delete a session file. Raises FileNotFoundError if missing."""
+    path = _find_session_path(get_chat_history_dir(project), session_id)
+    if path is None:
+        raise FileNotFoundError(f"Chat session '{session_id}' not found")
+    path.unlink()
+
+
+def restore_chat_session(persisted: PersistedChatSession) -> ChatSession:
+    """Reconstruct a ChatSession from a PersistedChatSession for resumption."""
+    session = ChatSession()
+    for msg in persisted.messages:
+        role = msg.get("role", "")
+        content = msg.get("content", "")
+        if role == "user":
+            session.messages.append(ChatMessage(role="user", content=content))
+        elif role == "assistant":
+            session.messages.append(ChatMessage(role="assistant", content=content))
+    return session

--- a/src/santai_cli/core/chat_history.py
+++ b/src/santai_cli/core/chat_history.py
@@ -439,7 +439,9 @@ def _load_hidden(chat_dir: Path) -> set[str]:
     """Return the set of session IDs hidden from the history panel."""
     try:
         data = json.loads((chat_dir / _HIDDEN_FILE).read_text(encoding="utf-8"))
-        return set(data) if isinstance(data, list) else set()
+        return (
+            {s for s in data if isinstance(s, str)} if isinstance(data, list) else set()
+        )
     except (OSError, json.JSONDecodeError):
         return set()
 

--- a/src/santai_cli/core/chat_history.py
+++ b/src/santai_cli/core/chat_history.py
@@ -88,22 +88,10 @@ def _save_index(chat_dir: Path, index: dict[str, str]) -> None:
 def _rebuild_index(chat_dir: Path) -> dict[str, str]:
     """Rebuild the index by scanning all .md files (O(n) fallback)."""
     index: dict[str, str] = {}
-    id_inline_prefix = "\n---\nid: "
-    id_front_prefix = "---\nid: "
     for path in chat_dir.glob("*.md"):
         try:
-            text = path.read_text(encoding="utf-8")
-            session_id = None
-            if id_inline_prefix in text:
-                start = text.find(id_inline_prefix) + len(id_inline_prefix)
-                end = text.find("\n", start)
-                if end != -1:
-                    session_id = text[start:end].strip()
-            elif text.startswith(id_front_prefix):
-                start = len(id_front_prefix)
-                end = text.find("\n", start)
-                if end != -1:
-                    session_id = text[start:end].strip()
+            meta, _ = _parse_markdown(path.read_text(encoding="utf-8"))
+            session_id = meta.get("id", "")
             if session_id:
                 index[session_id] = path.name
         except OSError:
@@ -224,7 +212,7 @@ def _build_markdown(
 ) -> str:
     agent_val = "null" if agent is None else agent
     metadata_block = (
-        "---\n"
+        "<!-- santai\n"
         f"id: {session_id}\n"
         f"title: {json.dumps(title, ensure_ascii=False)}\n"
         f"created_at: {created_at}\n"
@@ -233,7 +221,7 @@ def _build_markdown(
         f"model: {model}\n"
         f"agent: {agent_val}\n"
         f"message_count: {len(messages)}\n"
-        "---"
+        "-->"
     )
     body_parts = []
     for msg in messages:
@@ -266,19 +254,29 @@ def _parse_meta_block(block: str) -> dict:
     return meta
 
 
+_META_OPEN = "<!-- santai\n"
+_META_CLOSE = "\n-->"
+
+
 def _parse_markdown(text: str) -> tuple[dict, list[dict[str, str]]]:
     """Parse metadata and messages from a session Markdown file.
 
-    Supports two layouts:
-    - New: transcript first, then ``---\\n{meta}\\n---`` at the bottom.
-    - Old: ``---\\n{meta}\\n---`` frontmatter at the top (backwards compat).
+    Supports three layouts (newest first):
+    - HTML comment: transcript, then ``<!-- santai\\n{meta}\\n-->``.
+    - Legacy dash block: transcript, then ``---\\n{meta}\\n---``.
+    - Old frontmatter: ``---\\n{meta}\\n---`` at the very top.
     """
     meta: dict = {}
     body = text
 
-    # Metadata block at the bottom: \n---\n{key: val...}\n---
-    # id: is always the first field, so \n---\nid: locates the opening delimiter.
-    if "\n---\nid: " in text:
+    if _META_OPEN in text:
+        sep_idx = text.find(_META_OPEN)
+        close_idx = text.find(_META_CLOSE, sep_idx)
+        if close_idx != -1:
+            meta = _parse_meta_block(text[sep_idx + len(_META_OPEN) : close_idx])
+            body = text[:sep_idx]
+    elif "\n---\nid: " in text:
+        # Legacy: dash-delimited block at the bottom.
         sep_idx = text.find("\n---\nid: ")
         close_idx = text.find("\n---", sep_idx + 5)
         if close_idx != -1:

--- a/src/santai_cli/core/project.py
+++ b/src/santai_cli/core/project.py
@@ -120,6 +120,10 @@ class SantaiProject:
     def notes_path(self) -> Path:
         return self.root / "notes"
 
+    @property
+    def chat_history_path(self) -> Path:
+        return self.root / "history" / "chat-history"
+
 
 def get_project(path: Path | None = None) -> SantaiProject | None:
     """Get the Santai project at the given path or current directory.

--- a/src/santai_cli/core/project.py
+++ b/src/santai_cli/core/project.py
@@ -156,7 +156,11 @@ def _get_all_files(path: Path) -> list[FileInfo]:
 
     files = []
     for f in path.rglob("*"):
-        if f.is_file():
+        if (
+            f.is_file()
+            and not f.name.startswith(".")
+            and f.name not in _UI_HIDDEN_NAMES
+        ):
             stat = f.stat()
             files.append(
                 FileInfo(
@@ -339,6 +343,11 @@ WIKILINK_PATTERN = re.compile(r"\[\[([^\]|]+)(?:\|([^\]]+))?\]\]")
 
 _SKIP_DIRS = frozenset({"__pycache__", "node_modules", ".venv", "venv", ".git"})
 
+# Internal files that should never appear in any UI listing (graph, recent files, etc.)
+_UI_HIDDEN_NAMES: frozenset[str] = frozenset(
+    {"rumdl.toml", "_index.json", "_hidden.json"}
+)
+
 # Project meta-files that should never appear as graph nodes
 _GRAPH_EXCLUDE_NAMES_LOWER = frozenset(
     {
@@ -346,8 +355,8 @@ _GRAPH_EXCLUDE_NAMES_LOWER = frozenset(
         "claude.md",
         "readme.md",
         "readme.rst",
-        "rumdl.toml",
     }
+    | {n.lower() for n in _UI_HIDDEN_NAMES}
 )
 
 

--- a/src/santai_cli/core/project.py
+++ b/src/santai_cli/core/project.py
@@ -748,6 +748,8 @@ def get_file_graph(project: SantaiProject) -> FileGraph:
         ".csv",
     }
 
+    chat_history_dir = project.chat_history_path
+
     # Known santai subdirectories
     for dir_name in SANTAI_DIRS:
         dir_path = project.root / dir_name
@@ -756,6 +758,8 @@ def get_file_graph(project: SantaiProject) -> FileGraph:
 
         for file_path in dir_path.rglob("*"):
             if not file_path.is_file() or file_path.name.startswith("."):
+                continue
+            if file_path.is_relative_to(chat_history_dir):
                 continue
             _add_file_to_graph(
                 file_path,

--- a/src/santai_cli/web/app.py
+++ b/src/santai_cli/web/app.py
@@ -34,7 +34,7 @@ TEMPLATES_DIR = Path(__file__).parent / "templates"
 STATIC_DIR = Path(__file__).parent / "static"
 
 # Files hidden from all file-tree listings (in addition to dotfiles).
-_HIDDEN_FILES: set[str] = {"rumdl.toml"}
+_HIDDEN_FILES: set[str] = {"rumdl.toml", "_index.json", "_hidden.json"}
 
 
 class RenameRequest(BaseModel):

--- a/src/santai_cli/web/app.py
+++ b/src/santai_cli/web/app.py
@@ -1497,34 +1497,13 @@ def create_app(project: SantaiProject) -> FastAPI:
     async def chat_history_update_title(
         session_id: str, req: UpdateTitleRequest
     ) -> dict[str, str]:
-        """Update the title of a saved chat session."""
-        from santai_cli.core.chat_history import (
-            _build_markdown,
-            _find_session_path,
-            _parse_markdown,
-            get_chat_history_dir,
-        )
+        """Update the title of a saved chat session and rename the file to match."""
+        from santai_cli.core.chat_history import rename_session
 
-        path = _find_session_path(get_chat_history_dir(project), session_id)
-        if path is None:
-            raise HTTPException(status_code=404, detail="Session not found")
         try:
-            from datetime import UTC, datetime
-
-            meta, messages = _parse_markdown(path.read_text(encoding="utf-8"))
-            path.write_text(
-                _build_markdown(
-                    session_id=meta.get("id", session_id),
-                    title=req.title,
-                    created_at=meta.get("created_at", ""),
-                    updated_at=datetime.now(UTC).isoformat(),
-                    provider=meta.get("provider", ""),
-                    model=meta.get("model", ""),
-                    agent=meta.get("agent"),
-                    messages=messages,
-                ),
-                encoding="utf-8",
-            )
+            rename_session(project, session_id, req.title)
+        except FileNotFoundError:
+            raise HTTPException(status_code=404, detail="Session not found") from None
         except OSError as e:
             raise HTTPException(status_code=500, detail=str(e)) from e
         return {"status": "updated"}

--- a/src/santai_cli/web/app.py
+++ b/src/santai_cli/web/app.py
@@ -34,7 +34,9 @@ TEMPLATES_DIR = Path(__file__).parent / "templates"
 STATIC_DIR = Path(__file__).parent / "static"
 
 # Files hidden from all file-tree listings (in addition to dotfiles).
-_HIDDEN_FILES: set[str] = {"rumdl.toml", "_index.json", "_hidden.json"}
+from santai_cli.core.project import _UI_HIDDEN_NAMES  # noqa: E402
+
+_HIDDEN_FILES: set[str] = set(_UI_HIDDEN_NAMES)
 
 
 class RenameRequest(BaseModel):
@@ -66,6 +68,7 @@ class ChatRequest(BaseModel):
     provider: str
     model: str
     agent: str | None = None
+    session_context: str | None = None
 
 
 class SettingsRequest(BaseModel):
@@ -1368,6 +1371,10 @@ def create_app(project: SantaiProject) -> FastAPI:
         # Inject repository context
         repo_context = build_repo_context(project)
         system_prompt = inject_repo_context(system_prompt, repo_context)
+
+        if req.session_context:
+            note = f"\n\n[Session context: {req.session_context}]"
+            system_prompt = (system_prompt + note) if system_prompt else note.strip()
 
         session = ChatSession(system_prompt=system_prompt, project_root=project.root)
         for msg in req.messages:

--- a/src/santai_cli/web/app.py
+++ b/src/santai_cli/web/app.py
@@ -1571,7 +1571,11 @@ def create_app(project: SantaiProject) -> FastAPI:
                     system=system_instruction,
                     messages=[{"role": "user", "content": user_prompt}],
                 )
-                title = _clean_title(msg.content[0].text)
+                block = msg.content[0]
+                raw_text = (
+                    block.text if isinstance(block, _anthropic.types.TextBlock) else ""
+                )
+                title = _clean_title(raw_text)
             else:
                 import openai as _openai
 

--- a/src/santai_cli/web/app.py
+++ b/src/santai_cli/web/app.py
@@ -96,7 +96,6 @@ class SaveSessionRequest(BaseModel):
     model: str
     agent: str | None = None
     messages: list[dict[str, str]]
-    tool_turns: list[dict] = []
 
 
 class UpdateTitleRequest(BaseModel):
@@ -1446,7 +1445,7 @@ def create_app(project: SantaiProject) -> FastAPI:
         from santai_cli.core.chat import ChatMessage, ChatSession
         from santai_cli.core.chat_history import save_session
 
-        session = ChatSession(tool_turns=req.tool_turns)
+        session = ChatSession()
         for msg in req.messages:
             role = msg.get("role", "")
             content = msg.get("content", "")
@@ -1505,7 +1504,10 @@ def create_app(project: SantaiProject) -> FastAPI:
         """Hide a session from the history panel without deleting the file."""
         from santai_cli.core.chat_history import hide_session
 
-        hide_session(project, session_id)
+        try:
+            hide_session(project, session_id)
+        except FileNotFoundError:
+            raise HTTPException(status_code=404, detail="Session not found") from None
         return {"status": "hidden"}
 
     @app.post("/api/chat/history/{session_id}/unhide")

--- a/src/santai_cli/web/app.py
+++ b/src/santai_cli/web/app.py
@@ -86,6 +86,20 @@ class SmartPlaceRequest(BaseModel):
     content: str = ""
 
 
+class SaveSessionRequest(BaseModel):
+    session_id: str | None = None
+    title: str | None = None
+    provider: str
+    model: str
+    agent: str | None = None
+    messages: list[dict[str, str]]
+    tool_turns: list[dict] = []
+
+
+class UpdateTitleRequest(BaseModel):
+    title: str
+
+
 _IMAGE_MIME: dict[str, str] = {
     ".png": "image/png",
     ".jpg": "image/jpeg",
@@ -1392,6 +1406,122 @@ def create_app(project: SantaiProject) -> FastAPI:
                 "X-Accel-Buffering": "no",
             },
         )
+
+    @app.get("/api/chat/history")
+    async def chat_history_list() -> list[dict[str, Any]]:
+        """Return metadata for all saved chat sessions, newest first."""
+        from santai_cli.core.chat_history import list_sessions
+
+        sessions = list_sessions(project)
+        return [
+            {
+                "id": s.id,
+                "title": s.title,
+                "created_at": s.created_at,
+                "updated_at": s.updated_at,
+                "provider": s.provider,
+                "model": s.model,
+                "agent": s.agent,
+                "message_count": s.message_count,
+            }
+            for s in sessions
+        ]
+
+    @app.post("/api/chat/history")
+    async def chat_history_save(req: SaveSessionRequest) -> dict[str, str]:
+        """Save or update a chat session. Returns the session_id."""
+        from santai_cli.core.chat import ChatMessage, ChatSession
+        from santai_cli.core.chat_history import save_session
+
+        session = ChatSession(tool_turns=req.tool_turns)
+        for msg in req.messages:
+            role = msg.get("role", "")
+            content = msg.get("content", "")
+            if role == "user":
+                session.messages.append(ChatMessage(role="user", content=content))
+            elif role == "assistant":
+                session.messages.append(ChatMessage(role="assistant", content=content))
+
+        session_id = save_session(
+            project=project,
+            session=session,
+            session_id=req.session_id,
+            title=req.title,
+            provider=req.provider,
+            model=req.model,
+            agent=req.agent,
+        )
+        return {"session_id": session_id}
+
+    @app.get("/api/chat/history/{session_id}")
+    async def chat_history_load(session_id: str) -> dict[str, Any]:
+        """Return the full chat session including messages."""
+        from santai_cli.core.chat_history import load_session
+
+        try:
+            s = load_session(project, session_id)
+        except FileNotFoundError:
+            raise HTTPException(status_code=404, detail="Session not found") from None
+        return {
+            "id": s.id,
+            "title": s.title,
+            "created_at": s.created_at,
+            "updated_at": s.updated_at,
+            "provider": s.provider,
+            "model": s.model,
+            "agent": s.agent,
+            "message_count": s.message_count,
+            "system_prompt": s.system_prompt,
+            "messages": s.messages,
+            "tool_turns": s.tool_turns,
+        }
+
+    @app.delete("/api/chat/history/{session_id}")
+    async def chat_history_delete(session_id: str) -> dict[str, str]:
+        """Delete a chat session."""
+        from santai_cli.core.chat_history import delete_session
+
+        try:
+            delete_session(project, session_id)
+        except FileNotFoundError:
+            raise HTTPException(status_code=404, detail="Session not found") from None
+        return {"status": "deleted"}
+
+    @app.patch("/api/chat/history/{session_id}/title")
+    async def chat_history_update_title(
+        session_id: str, req: UpdateTitleRequest
+    ) -> dict[str, str]:
+        """Update the title of a saved chat session."""
+        from santai_cli.core.chat_history import (
+            _build_markdown,
+            _find_session_path,
+            _parse_markdown,
+            get_chat_history_dir,
+        )
+
+        path = _find_session_path(get_chat_history_dir(project), session_id)
+        if path is None:
+            raise HTTPException(status_code=404, detail="Session not found")
+        try:
+            from datetime import UTC, datetime
+
+            meta, messages = _parse_markdown(path.read_text(encoding="utf-8"))
+            path.write_text(
+                _build_markdown(
+                    session_id=meta.get("id", session_id),
+                    title=req.title,
+                    created_at=meta.get("created_at", ""),
+                    updated_at=datetime.now(UTC).isoformat(),
+                    provider=meta.get("provider", ""),
+                    model=meta.get("model", ""),
+                    agent=meta.get("agent"),
+                    messages=messages,
+                ),
+                encoding="utf-8",
+            )
+        except OSError as e:
+            raise HTTPException(status_code=500, detail=str(e)) from e
+        return {"status": "updated"}
 
     @app.get("/api/settings")
     async def get_settings() -> dict[str, Any]:

--- a/src/santai_cli/web/app.py
+++ b/src/santai_cli/web/app.py
@@ -1493,6 +1493,14 @@ def create_app(project: SantaiProject) -> FastAPI:
             raise HTTPException(status_code=404, detail="Session not found") from None
         return {"status": "deleted"}
 
+    @app.post("/api/chat/history/{session_id}/hide")
+    async def chat_history_hide(session_id: str) -> dict[str, str]:
+        """Hide a session from the history panel without deleting the file."""
+        from santai_cli.core.chat_history import hide_session
+
+        hide_session(project, session_id)
+        return {"status": "hidden"}
+
     @app.patch("/api/chat/history/{session_id}/title")
     async def chat_history_update_title(
         session_id: str, req: UpdateTitleRequest

--- a/src/santai_cli/web/app.py
+++ b/src/santai_cli/web/app.py
@@ -1548,7 +1548,7 @@ def create_app(project: SantaiProject) -> FastAPI:
         )
 
         system_instruction = (
-            "Respond with ONLY a short title (3-6 words). "
+            "Respond with ONLY a short title (2-4 words, 30 characters max). "
             "No explanation, no punctuation at the end, no quotes."
         )
         user_prompt = (
@@ -1558,7 +1558,7 @@ def create_app(project: SantaiProject) -> FastAPI:
         def _clean_title(raw: str) -> str:
             """Extract the first line and reject anything that looks conversational."""
             cleaned = raw.split("\n")[0].strip().strip("\"'*# ")
-            return cleaned if 2 <= len(cleaned) <= 70 else ""
+            return cleaned if 2 <= len(cleaned) <= 40 else ""
 
         try:
             if req.provider == "anthropic" and not provider_config.base_url:

--- a/src/santai_cli/web/app.py
+++ b/src/santai_cli/web/app.py
@@ -100,6 +100,12 @@ class UpdateTitleRequest(BaseModel):
     title: str
 
 
+class GenerateTitleRequest(BaseModel):
+    messages: list[dict[str, str]]
+    provider: str
+    model: str
+
+
 _IMAGE_MIME: dict[str, str] = {
     ".png": "image/png",
     ".jpg": "image/jpeg",
@@ -1522,6 +1528,70 @@ def create_app(project: SantaiProject) -> FastAPI:
         except OSError as e:
             raise HTTPException(status_code=500, detail=str(e)) from e
         return {"status": "updated"}
+
+    @app.post("/api/chat/generate-title")
+    async def chat_generate_title(req: GenerateTitleRequest) -> dict[str, str]:
+        """Generate a concise smart title for a chat session using the LLM."""
+        from santai_cli.core.chat_history import auto_title
+        from santai_cli.core.config import load_config
+
+        config = load_config(project.root)
+        if req.provider not in config.providers:
+            from santai_cli.core.chat_history import auto_title as _at
+
+            return {"title": _at(req.messages)}
+
+        provider_config = config.providers[req.provider]
+
+        first_user = next(
+            (m.get("content", "") for m in req.messages if m.get("role") == "user"), ""
+        )
+
+        system_instruction = (
+            "Respond with ONLY a short title (3-6 words). "
+            "No explanation, no punctuation at the end, no quotes."
+        )
+        user_prompt = (
+            f"Give a short title for this conversation:\n\nUser: {first_user[:300]}"
+        )
+
+        def _clean_title(raw: str) -> str:
+            """Extract the first line and reject anything that looks conversational."""
+            cleaned = raw.split("\n")[0].strip().strip("\"'*# ")
+            return cleaned if 2 <= len(cleaned) <= 70 else ""
+
+        try:
+            if req.provider == "anthropic" and not provider_config.base_url:
+                import anthropic as _anthropic
+
+                client = _anthropic.AsyncAnthropic(api_key=provider_config.api_key)
+                msg = await client.messages.create(
+                    model=req.model,
+                    max_tokens=30,
+                    system=system_instruction,
+                    messages=[{"role": "user", "content": user_prompt}],
+                )
+                title = _clean_title(msg.content[0].text)
+            else:
+                import openai as _openai
+
+                kw: dict = {"api_key": provider_config.api_key}
+                if provider_config.base_url:
+                    kw["base_url"] = provider_config.base_url
+                client = _openai.AsyncOpenAI(**kw)
+                completion = await client.chat.completions.create(
+                    model=req.model,
+                    max_tokens=30,
+                    messages=[
+                        {"role": "system", "content": system_instruction},
+                        {"role": "user", "content": user_prompt},
+                    ],
+                )
+                title = _clean_title(completion.choices[0].message.content or "")
+        except Exception:
+            title = ""
+
+        return {"title": title or auto_title(req.messages)}
 
     @app.get("/api/settings")
     async def get_settings() -> dict[str, Any]:

--- a/src/santai_cli/web/app.py
+++ b/src/santai_cli/web/app.py
@@ -1508,6 +1508,14 @@ def create_app(project: SantaiProject) -> FastAPI:
         hide_session(project, session_id)
         return {"status": "hidden"}
 
+    @app.post("/api/chat/history/{session_id}/unhide")
+    async def chat_history_unhide(session_id: str) -> dict[str, str]:
+        """Unhide a session so it reappears in the history panel."""
+        from santai_cli.core.chat_history import unhide_session
+
+        unhide_session(project, session_id)
+        return {"status": "visible"}
+
     @app.patch("/api/chat/history/{session_id}/title")
     async def chat_history_update_title(
         session_id: str, req: UpdateTitleRequest

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -1256,6 +1256,7 @@
             flex: 1;
             overflow: hidden;
             min-height: 0;
+            position: relative;
         }
 
         /* Empty preview state */
@@ -1607,6 +1608,148 @@
         }
 
         /* Chat fullscreen button (matches preview-fullscreen-btn style) */
+        .chat-history-icon-btn {
+            background: transparent;
+            border: none;
+            border-radius: 8px;
+            width: 28px;
+            height: 28px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            cursor: pointer;
+            flex-shrink: 0;
+            transition: background 0.15s, color 0.15s;
+            color: var(--text-muted);
+        }
+
+        .chat-history-icon-btn:hover {
+            background: rgba(0, 0, 0, 0.06);
+            color: var(--text-primary);
+        }
+
+        .chat-history-icon-btn.active {
+            background: rgba(99, 102, 241, 0.12);
+            color: #6366f1;
+        }
+
+        .chat-history-icon-btn svg {
+            width: 14px;
+            height: 14px;
+            stroke: currentColor;
+            stroke-width: 2;
+        }
+
+        [data-theme="simple"] .chat-history-icon-btn:hover {
+            background: #f1f3f5;
+        }
+
+        [data-theme="simple"] .chat-history-icon-btn.active {
+            background: #e0e7ff;
+        }
+
+        .chat-history-panel {
+            position: absolute;
+            inset: 0;
+            z-index: 10;
+            background: var(--glass-bg, rgba(255,255,255,0.92));
+            backdrop-filter: blur(8px);
+            display: flex;
+            flex-direction: column;
+            border-radius: inherit;
+            overflow: hidden;
+        }
+        .chat-history-header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            padding: 10px 12px 8px;
+            border-bottom: 1px solid rgba(0,0,0,0.08);
+            font-weight: 600;
+            font-size: 13px;
+            flex-shrink: 0;
+        }
+        .chat-history-close-btn {
+            background: none;
+            border: none;
+            cursor: pointer;
+            color: var(--text-secondary, #666);
+            font-size: 16px;
+            line-height: 1;
+            padding: 2px 6px;
+            border-radius: 5px;
+        }
+        .chat-history-close-btn:hover { background: rgba(0,0,0,0.07); }
+        .chat-history-new-btn {
+            display: flex;
+            align-items: center;
+            gap: 6px;
+            width: calc(100% - 16px);
+            margin: 8px 8px 4px;
+            padding: 7px 10px;
+            background: rgba(99,102,241,0.08);
+            border: 1px dashed rgba(99,102,241,0.3);
+            border-radius: 7px;
+            font-size: 12px;
+            font-family: inherit;
+            color: #6366f1;
+            cursor: pointer;
+            transition: background 0.12s;
+            flex-shrink: 0;
+        }
+        .chat-history-new-btn:hover { background: rgba(99,102,241,0.14); }
+        .chat-history-list {
+            flex: 1;
+            overflow-y: auto;
+            padding: 4px 8px 8px;
+        }
+        .chat-history-empty {
+            text-align: center;
+            color: var(--text-secondary, #888);
+            font-size: 12px;
+            padding: 24px 0;
+        }
+        .chat-history-item {
+            display: flex;
+            align-items: flex-start;
+            gap: 6px;
+            padding: 7px 8px;
+            border-radius: 7px;
+            cursor: pointer;
+            transition: background 0.12s;
+        }
+        .chat-history-item:hover { background: rgba(0,0,0,0.05); }
+        .chat-history-item-body {
+            flex: 1;
+            min-width: 0;
+        }
+        .chat-history-item-title {
+            font-size: 12px;
+            font-weight: 500;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+        }
+        .chat-history-item-meta {
+            font-size: 10px;
+            color: var(--text-secondary, #888);
+            margin-top: 2px;
+        }
+        .chat-history-delete-btn {
+            background: none;
+            border: none;
+            cursor: pointer;
+            color: var(--text-secondary, #aaa);
+            font-size: 13px;
+            padding: 2px 4px;
+            border-radius: 4px;
+            flex-shrink: 0;
+            opacity: 0;
+            transition: opacity 0.12s;
+        }
+        .chat-history-item:hover .chat-history-delete-btn { opacity: 1; }
+        .chat-history-delete-btn:hover { background: rgba(239,68,68,0.12); color: #ef4444; }
+
         .chat-fullscreen-btn {
             background: transparent;
             backdrop-filter: none;
@@ -3797,6 +3940,7 @@
                 padding-right: 18px;
             }
         }
+
     </style>
 </head>
 <body>
@@ -4105,8 +4249,28 @@
                             <div class="chat-custom-select-list" id="chat-model-select-list"></div>
                             <select id="chat-model-select" style="display:none;"></select>
                         </div>
+                        <button class="chat-history-icon-btn" id="chat-history-icon-btn" onclick="toggleChatHistoryPanel()" title="Chat history">
+                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                <polyline points="1 4 1 10 7 10" />
+                                <path d="M3.51 15a9 9 0 102.13-9.36L1 10" />
+                                <line x1="12" y1="7" x2="12" y2="12" />
+                                <polyline points="12 12 15 14" />
+                            </svg>
+                        </button>
                         <button class="chat-ctrl-btn" onclick="clearChat()">Clear</button>
                     </div>
+                </div>
+                <!-- Chat history overlay panel -->
+                <div class="chat-history-panel" id="chat-history-panel" style="display:none;">
+                    <div class="chat-history-header">
+                        <span>Chat History</span>
+                        <button class="chat-history-close-btn" onclick="toggleChatHistoryPanel()" title="Close">✕</button>
+                    </div>
+                    <button class="chat-history-new-btn" onclick="startNewChat(); toggleChatHistoryPanel();">
+                        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+                        New chat
+                    </button>
+                    <div class="chat-history-list" id="chat-history-list"></div>
                 </div>
                 <!-- Messages container (position:relative for scroll btn) -->
                 <div style="flex:1;min-height:0;position:relative;display:flex;flex-direction:column;">
@@ -7156,6 +7320,10 @@
         const CHAT_STORAGE_KEY = 'santai-chat-messages';
         const CHAT_TOKEN_KEY = 'santai-chat-messages-token';
 
+        // --- Persistent session tracking ---
+        let _currentChatSessionId = null;
+        let _currentChatSessionTitle = null;
+
         function saveChatHistory() {
             try {
                 const token = document.querySelector('meta[name="startup-token"]')?.content;
@@ -7816,6 +7984,197 @@
             showAgentWelcome(agent);
         }
 
+        // --- Chat History Panel ---
+
+        function toggleChatHistoryPanel() {
+            const panel = document.getElementById('chat-history-panel');
+            const btn = document.getElementById('chat-history-icon-btn');
+            if (!panel) return;
+            const isOpen = panel.style.display !== 'none';
+            if (isOpen) {
+                panel.style.display = 'none';
+                btn?.classList.remove('active');
+            } else {
+                panel.style.display = 'flex';
+                btn?.classList.add('active');
+                loadChatHistorySessions();
+            }
+        }
+
+        async function loadChatHistorySessions() {
+            const listEl = document.getElementById('chat-history-list');
+            if (!listEl) return;
+            listEl.innerHTML = '<div class="chat-history-empty">Loading…</div>';
+            try {
+                const res = await fetch('/api/chat/history');
+                if (!res.ok) throw new Error('Failed to load');
+                const sessions = await res.json();
+                if (sessions.length === 0) {
+                    listEl.innerHTML = '<div class="chat-history-empty">No saved chats yet.</div>';
+                    return;
+                }
+                listEl.innerHTML = '';
+                sessions.forEach(s => {
+                    const item = document.createElement('div');
+                    item.className = 'chat-history-item';
+                    const dateStr = s.updated_at ? s.updated_at.slice(0, 10) : '';
+                    const msgStr = s.message_count === 1 ? '1 msg' : `${s.message_count} msgs`;
+                    item.innerHTML = `
+                        <div class="chat-history-item-body" onclick="resumeChatSession('${s.id}')">
+                            <div class="chat-history-item-title">${_escapeHtml(s.title)}</div>
+                            <div class="chat-history-item-meta">${dateStr} · ${msgStr}${s.agent ? ' · ' + _escapeHtml(s.agent) : ''}</div>
+                        </div>
+                        <button class="chat-history-delete-btn" onclick="deleteChatSession('${s.id}', event)" title="Delete">✕</button>
+                    `;
+                    listEl.appendChild(item);
+                });
+            } catch {
+                listEl.innerHTML = '<div class="chat-history-empty">Could not load history.</div>';
+            }
+        }
+
+        async function resumeChatSession(sessionId) {
+            try {
+                const res = await fetch(`/api/chat/history/${sessionId}`);
+                if (!res.ok) throw new Error('Session not found');
+                const session = await res.json();
+
+                // Abort any in-flight stream
+                if (_chatAbortController) { _chatAbortController.abort(); _chatAbortController = null; }
+                _chatEpoch++;
+                chatStreaming = false;
+
+                // Clear current chat state
+                chatMessages = [];
+                const messagesEl = document.getElementById('chat-messages');
+                if (messagesEl) messagesEl.innerHTML = '';
+
+                // Restore messages
+                (session.messages || []).forEach(m => {
+                    if (m.role === 'user' || m.role === 'assistant') {
+                        chatMessages.push({role: m.role, content: m.content});
+                        appendChatMessage(m.role, m.content);
+                    }
+                });
+                saveChatHistory();
+
+                _currentChatSessionId = session.id;
+                _currentChatSessionTitle = session.title;
+
+                // Restore model/provider if available
+                if (session.provider && session.model) {
+                    _tryRestoreModel(session.provider, session.model);
+                }
+                if (session.agent) {
+                    _tryRestoreAgent(session.agent);
+                }
+
+                chatHideEmptyState();
+                // Close the history panel if it's open
+                const _histPanel = document.getElementById('chat-history-panel');
+                if (_histPanel && _histPanel.style.display !== 'none') toggleChatHistoryPanel();
+
+                const inputEl = document.getElementById('chat-input');
+                const sendBtn = document.getElementById('chat-send-btn');
+                if (inputEl) inputEl.disabled = false;
+                if (sendBtn) sendBtn.disabled = false;
+                chatUpdateSendBtn();
+
+                // Scroll to bottom
+                setTimeout(chatScrollToBottom, 50);
+            } catch (e) {
+                console.error('resumeChatSession error:', e);
+            }
+        }
+
+        async function deleteChatSession(sessionId, event) {
+            if (event) event.stopPropagation();
+            try {
+                await fetch(`/api/chat/history/${sessionId}`, {method: 'DELETE'});
+                if (_currentChatSessionId === sessionId) {
+                    _currentChatSessionId = null;
+                    _currentChatSessionTitle = null;
+                }
+                loadChatHistorySessions();
+            } catch (e) {
+                console.error('deleteChatSession error:', e);
+            }
+        }
+
+        async function saveCurrentChatSession() {
+            if (chatMessages.length === 0) return;
+            const modelSelect = document.getElementById('chat-model-select');
+            const modelValue = modelSelect ? modelSelect.value : '';
+            let provider = '', model = '';
+            if (modelValue) {
+                try { const p = JSON.parse(modelValue); provider = p.provider || ''; model = p.model || ''; } catch {}
+            }
+            const agent = document.getElementById('chat-agent-select')?.value || null;
+            try {
+                const res = await fetch('/api/chat/history', {
+                    method: 'POST',
+                    headers: {'Content-Type': 'application/json'},
+                    body: JSON.stringify({
+                        session_id: _currentChatSessionId,
+                        title: _currentChatSessionTitle,
+                        provider,
+                        model,
+                        agent: agent || null,
+                        messages: chatMessages,
+                        tool_turns: [],
+                    })
+                });
+                if (res.ok) {
+                    const data = await res.json();
+                    _currentChatSessionId = data.session_id;
+                }
+            } catch {}
+        }
+
+        function startNewChat() {
+            // Save current session before clearing if there are messages
+            if (chatMessages.length > 0) {
+                saveCurrentChatSession();
+            }
+            _currentChatSessionId = null;
+            _currentChatSessionTitle = null;
+            clearChat();
+        }
+
+        function _escapeHtml(str) {
+            return String(str).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
+        }
+
+        function _tryRestoreModel(provider, model) {
+            const sel = document.getElementById('chat-model-select');
+            if (!sel) return;
+            for (const opt of sel.options) {
+                try {
+                    const p = JSON.parse(opt.value);
+                    if (p.provider === provider && p.model === model) {
+                        sel.value = opt.value;
+                        // Also update the visible button label
+                        const btn = document.getElementById('chat-model-select-btn');
+                        if (btn) btn.textContent = opt.textContent;
+                        return;
+                    }
+                } catch {}
+            }
+        }
+
+        function _tryRestoreAgent(agentName) {
+            const sel = document.getElementById('chat-agent-select');
+            if (!sel) return;
+            for (const opt of sel.options) {
+                if (opt.value === agentName) {
+                    sel.value = agentName;
+                    const btn = document.getElementById('chat-agent-select-btn');
+                    if (btn) btn.textContent = opt.textContent;
+                    return;
+                }
+            }
+        }
+
         // Stream a response using the current chatMessages state and selected model/agent.
         // Call after pushing the user message into chatMessages and showing it in the UI.
         async function _streamFromMessages() {
@@ -7945,6 +8304,7 @@
                 if (fullResponse) {
                     chatMessages.push({role: 'assistant', content: fullResponse});
                     saveChatHistory();
+                    saveCurrentChatSession();
                 }
 
             } catch (e) {

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -8206,17 +8206,21 @@
                         item.className = 'chat-history-item' + (s.id === _currentChatSessionId ? ' active' : '');
                         const msgStr = s.message_count === 1 ? '1 msg' : `${s.message_count} msgs`;
                         item.innerHTML = `
-                            <div class="chat-history-item-body" onclick="resumeChatSession('${s.id}')">
+                            <div class="chat-history-item-body">
                                 <div class="chat-history-item-title">${_escapeHtml(s.title)}</div>
                                 <div class="chat-history-item-meta">${msgStr}${s.agent ? ' · ' + _escapeHtml(s.agent) : ''}</div>
                             </div>
                             <div class="chat-history-item-actions">
-                                <button class="chat-history-edit-btn" onclick="startRenameSession(event,'${s.id}')" title="Rename">
+                                <button class="chat-history-edit-btn" title="Rename">
                                     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931z" /></svg>
                                 </button>
-                                <button class="chat-history-delete-btn" onclick="hideChatSession('${s.id}',event)" title="Remove from history">✕</button>
+                                <button class="chat-history-delete-btn" title="Remove from history">✕</button>
                             </div>
                         `;
+                        // Attach handlers via addEventListener so session IDs never appear in HTML strings
+                        item.querySelector('.chat-history-item-body').addEventListener('click', () => resumeChatSession(s.id));
+                        item.querySelector('.chat-history-edit-btn').addEventListener('click', (e) => startRenameSession(e, s.id));
+                        item.querySelector('.chat-history-delete-btn').addEventListener('click', (e) => hideChatSession(s.id, e));
                         listEl.appendChild(item);
                     });
                 });
@@ -8414,14 +8418,17 @@
                         model,
                         agent: agent || null,
                         messages: chatMessages,
-                        tool_turns: [],
                     })
                 });
                 if (res.ok) {
                     const data = await res.json();
                     _currentChatSessionId = data.session_id;
+                } else {
+                    console.error('saveCurrentChatSession: server error', res.status);
                 }
-            } catch {}
+            } catch (e) {
+                console.error('saveCurrentChatSession error:', e);
+            }
         }
 
         async function startNewChat() {

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -8205,7 +8205,7 @@
                             <button class="chat-history-edit-btn" onclick="startRenameSession(event,'${s.id}')" title="Rename">
                                 <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931z" /></svg>
                             </button>
-                            <button class="chat-history-delete-btn" onclick="deleteChatSession('${s.id}',event)" title="Delete chat">✕</button>
+                            <button class="chat-history-delete-btn" onclick="hideChatSession('${s.id}',event)" title="Remove from history">✕</button>
                         `;
                         listEl.appendChild(item);
                     });
@@ -8269,14 +8269,12 @@
             }
         }
 
-        async function deleteChatSession(sessionId, event) {
+        async function hideChatSession(sessionId, event) {
             if (event) event.stopPropagation();
-            if (!confirm('Delete this chat? This cannot be undone.')) return;
             try {
-                const res = await fetch(`/api/chat/history/${sessionId}`, { method: 'DELETE' });
-                if (!res.ok) throw new Error('Delete failed');
+                await fetch(`/api/chat/history/${sessionId}/hide`, { method: 'POST' });
             } catch (e) {
-                console.error('deleteChatSession error:', e);
+                console.error('hideChatSession error:', e);
                 return;
             }
             if (_currentChatSessionId === sessionId) {

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -7446,6 +7446,7 @@
         // --- Persistent session tracking ---
         let _currentChatSessionId = null;
         let _currentChatSessionTitle = null;
+        let _pendingWelcomeMessage = null; // flushed into chatMessages on first real send
 
         function saveChatHistory() {
             try {
@@ -7536,7 +7537,7 @@
             const titleEl = document.getElementById('chat-assistant-title');
             if (titleEl) titleEl.textContent = cfg.title;
             appendChatMessage('assistant', cfg.welcome);
-            chatMessages.push({ role: 'assistant', content: cfg.welcome });
+            _pendingWelcomeMessage = cfg.welcome;
             if (cfg.chips && cfg.chips.length) {
                 const messagesEl = document.getElementById('chat-messages');
                 const wrap = document.createElement('div');
@@ -8102,6 +8103,7 @@
             _chatEpoch++;             // invalidate any in-flight stream
             _currentChatSessionId = null;
             _currentChatSessionTitle = null;
+            _pendingWelcomeMessage = null;
             _titleGenEpoch++;
             chatMessages = [];
             chatStreaming = false;
@@ -8242,6 +8244,7 @@
 
                 _currentChatSessionId = session.id;
                 _currentChatSessionTitle = session.title;
+                _pendingWelcomeMessage = null;
 
                 // Restore model/provider if available
                 if (session.provider && session.model) {
@@ -8626,6 +8629,10 @@
             inputEl.value = '';
             chatInputResize(inputEl);
             appendChatMessage('user', userText);
+            if (_pendingWelcomeMessage) {
+                chatMessages.push({ role: 'assistant', content: _pendingWelcomeMessage });
+                _pendingWelcomeMessage = null;
+            }
             chatMessages.push({role: 'user', content: userText});
             saveChatHistory();
             chatHideEmptyState();

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -1683,21 +1683,20 @@
         .chat-history-new-btn {
             display: flex;
             align-items: center;
-            gap: 6px;
-            width: calc(100% - 16px);
-            margin: 8px 8px 4px;
-            padding: 7px 10px;
-            background: rgba(99,102,241,0.08);
-            border: 1px dashed rgba(99,102,241,0.3);
-            border-radius: 7px;
+            gap: 4px;
+            padding: 3px 8px;
+            background: rgba(34,197,94,0.1);
+            border: 1px solid rgba(34,197,94,0.35);
+            border-radius: 5px;
             font-size: 12px;
             font-family: inherit;
-            color: #6366f1;
+            color: #16a34a;
             cursor: pointer;
             transition: background 0.12s;
             flex-shrink: 0;
+            font-weight: 500;
         }
-        .chat-history-new-btn:hover { background: rgba(99,102,241,0.14); }
+        .chat-history-new-btn:hover { background: rgba(34,197,94,0.18); }
         .chat-history-list {
             flex: 1;
             overflow-y: auto;
@@ -1719,6 +1718,23 @@
             transition: background 0.12s;
         }
         .chat-history-item:hover { background: rgba(0,0,0,0.05); }
+        .chat-history-delete-btn {
+            background: none;
+            border: none;
+            cursor: pointer;
+            color: var(--text-secondary, #aaa);
+            font-size: 13px;
+            padding: 2px 4px;
+            border-radius: 4px;
+            flex-shrink: 0;
+            opacity: 0;
+            transition: opacity 0.12s;
+        }
+        .chat-history-item:hover .chat-history-delete-btn { opacity: 1; }
+        .chat-history-delete-btn:hover { background: rgba(239,68,68,0.12); color: #ef4444; }
+        .chat-history-item.active { background: rgba(34,197,94,0.1); }
+        .chat-history-item.active .chat-history-item-title { color: #16a34a; }
+        .chat-history-item.active:hover { background: rgba(34,197,94,0.15); }
         .chat-history-item-body {
             flex: 1;
             min-width: 0;
@@ -1735,20 +1751,6 @@
             color: var(--text-secondary, #888);
             margin-top: 2px;
         }
-        .chat-history-delete-btn {
-            background: none;
-            border: none;
-            cursor: pointer;
-            color: var(--text-secondary, #aaa);
-            font-size: 13px;
-            padding: 2px 4px;
-            border-radius: 4px;
-            flex-shrink: 0;
-            opacity: 0;
-            transition: opacity 0.12s;
-        }
-        .chat-history-item:hover .chat-history-delete-btn { opacity: 1; }
-        .chat-history-delete-btn:hover { background: rgba(239,68,68,0.12); color: #ef4444; }
 
         .chat-fullscreen-btn {
             background: transparent;
@@ -4231,11 +4233,21 @@
                                 </svg>
                                 Settings
                             </button>
+                            <div style="display:flex;align-items:center;gap:2px;margin-left:4px;">
+                            <button class="chat-history-icon-btn" id="chat-history-icon-btn" onclick="toggleChatHistoryPanel()" title="Chat history">
+                                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                    <polyline points="1 4 1 10 7 10" />
+                                    <path d="M3.51 15a9 9 0 102.13-9.36L1 10" />
+                                    <line x1="12" y1="7" x2="12" y2="12" />
+                                    <polyline points="12 12 15 14" />
+                                </svg>
+                            </button>
                             <button class="chat-fullscreen-btn" id="chat-fullscreen-btn" onclick="toggleChatFullscreen()" title="Toggle fullscreen">
                                 <svg id="chat-fullscreen-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                                     <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 3.75v4.5m0-4.5h4.5m-4.5 0L9 9M3.75 20.25v-4.5m0 4.5h4.5m-4.5 0L9 15M20.25 3.75h-4.5m4.5 0v4.5m0-4.5L15 9m5.25 11.25h-4.5m4.5 0v-4.5m0 4.5L15 15" />
                                 </svg>
                             </button>
+                            </div>
                         </div>
                     </div>
                     <div class="chat-header-controls">
@@ -4249,14 +4261,6 @@
                             <div class="chat-custom-select-list" id="chat-model-select-list"></div>
                             <select id="chat-model-select" style="display:none;"></select>
                         </div>
-                        <button class="chat-history-icon-btn" id="chat-history-icon-btn" onclick="toggleChatHistoryPanel()" title="Chat history">
-                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                                <polyline points="1 4 1 10 7 10" />
-                                <path d="M3.51 15a9 9 0 102.13-9.36L1 10" />
-                                <line x1="12" y1="7" x2="12" y2="12" />
-                                <polyline points="12 12 15 14" />
-                            </svg>
-                        </button>
                         <button class="chat-ctrl-btn" onclick="clearChat()">Clear</button>
                     </div>
                 </div>
@@ -4264,12 +4268,14 @@
                 <div class="chat-history-panel" id="chat-history-panel" style="display:none;">
                     <div class="chat-history-header">
                         <span>Chat History</span>
-                        <button class="chat-history-close-btn" onclick="toggleChatHistoryPanel()" title="Close">✕</button>
+                        <div style="display:flex;align-items:center;gap:6px;">
+                            <button class="chat-history-new-btn" onclick="startNewChat(); toggleChatHistoryPanel();">
+                                <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+                                New Chat
+                            </button>
+                            <button class="chat-history-close-btn" onclick="toggleChatHistoryPanel()" title="Close">✕</button>
+                        </div>
                     </div>
-                    <button class="chat-history-new-btn" onclick="startNewChat(); toggleChatHistoryPanel();">
-                        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
-                        New chat
-                    </button>
                     <div class="chat-history-list" id="chat-history-list"></div>
                 </div>
                 <!-- Messages container (position:relative for scroll btn) -->
@@ -7986,6 +7992,8 @@
 
         // --- Chat History Panel ---
 
+        let _historyPollTimer = null;
+
         function toggleChatHistoryPanel() {
             const panel = document.getElementById('chat-history-panel');
             const btn = document.getElementById('chat-history-icon-btn');
@@ -7994,29 +8002,42 @@
             if (isOpen) {
                 panel.style.display = 'none';
                 btn?.classList.remove('active');
+                clearInterval(_historyPollTimer);
+                _historyPollTimer = null;
+                _lastSessionsRenderKey = '';
             } else {
                 panel.style.display = 'flex';
                 btn?.classList.add('active');
                 loadChatHistorySessions();
+                _historyPollTimer = setInterval(loadChatHistorySessions, 1000);
             }
         }
+
+        let _lastSessionsRenderKey = '';
 
         async function loadChatHistorySessions() {
             const listEl = document.getElementById('chat-history-list');
             if (!listEl) return;
-            listEl.innerHTML = '<div class="chat-history-empty">Loading…</div>';
+            // Only show loading spinner on first open (list is empty)
+            if (!listEl.children.length) listEl.innerHTML = '<div class="chat-history-empty">Loading…</div>';
             try {
                 const res = await fetch('/api/chat/history');
                 if (!res.ok) throw new Error('Failed to load');
                 const sessions = await res.json();
-                if (sessions.length === 0) {
+                const hidden = _getHiddenSessions();
+                const visible = sessions.filter(s => !hidden.has(s.id));
+                // Skip re-render if nothing changed (prevents flashing on poll)
+                const renderKey = visible.map(s => `${s.id}|${s.updated_at}|${s.title}|${s.id === _currentChatSessionId}`).join(',');
+                if (renderKey === _lastSessionsRenderKey) return;
+                _lastSessionsRenderKey = renderKey;
+                if (visible.length === 0) {
                     listEl.innerHTML = '<div class="chat-history-empty">No saved chats yet.</div>';
                     return;
                 }
                 listEl.innerHTML = '';
-                sessions.forEach(s => {
+                visible.forEach(s => {
                     const item = document.createElement('div');
-                    item.className = 'chat-history-item';
+                    item.className = 'chat-history-item' + (s.id === _currentChatSessionId ? ' active' : '');
                     const dateStr = s.updated_at ? s.updated_at.slice(0, 10) : '';
                     const msgStr = s.message_count === 1 ? '1 msg' : `${s.message_count} msgs`;
                     item.innerHTML = `
@@ -8024,7 +8045,7 @@
                             <div class="chat-history-item-title">${_escapeHtml(s.title)}</div>
                             <div class="chat-history-item-meta">${dateStr} · ${msgStr}${s.agent ? ' · ' + _escapeHtml(s.agent) : ''}</div>
                         </div>
-                        <button class="chat-history-delete-btn" onclick="deleteChatSession('${s.id}', event)" title="Delete">✕</button>
+                        <button class="chat-history-delete-btn" onclick="hideChatSession('${s.id}', event)" title="Remove from history">✕</button>
                     `;
                     listEl.appendChild(item);
                 });
@@ -8087,18 +8108,49 @@
             }
         }
 
-        async function deleteChatSession(sessionId, event) {
+        const _HIDDEN_SESSIONS_KEY = 'santai-hidden-sessions';
+
+        function _getHiddenSessions() {
+            try { return new Set(JSON.parse(localStorage.getItem(_HIDDEN_SESSIONS_KEY) || '[]')); }
+            catch { return new Set(); }
+        }
+
+        function hideChatSession(sessionId, event) {
             if (event) event.stopPropagation();
-            try {
-                await fetch(`/api/chat/history/${sessionId}`, {method: 'DELETE'});
-                if (_currentChatSessionId === sessionId) {
-                    _currentChatSessionId = null;
-                    _currentChatSessionTitle = null;
-                }
-                loadChatHistorySessions();
-            } catch (e) {
-                console.error('deleteChatSession error:', e);
+            const hidden = _getHiddenSessions();
+            hidden.add(sessionId);
+            localStorage.setItem(_HIDDEN_SESSIONS_KEY, JSON.stringify([...hidden]));
+            if (_currentChatSessionId === sessionId) {
+                _currentChatSessionId = null;
+                _currentChatSessionTitle = null;
             }
+            loadChatHistorySessions();
+        }
+
+        let _titleGenEpoch = 0;
+
+        async function generateSmartTitle() {
+            const myEpoch = ++_titleGenEpoch;
+            if (chatMessages.length < 2) return;
+            const modelSelect = document.getElementById('chat-model-select');
+            const modelValue = modelSelect ? modelSelect.value : '';
+            let provider = '', model = '';
+            if (modelValue) {
+                try { const p = JSON.parse(modelValue); provider = p.provider || ''; model = p.model || ''; } catch {}
+            }
+            if (!provider || !model) return;
+            try {
+                const res = await fetch('/api/chat/generate-title', {
+                    method: 'POST',
+                    headers: {'Content-Type': 'application/json'},
+                    body: JSON.stringify({ messages: chatMessages.filter(m => m.role === 'user' || m.role === 'assistant').slice(0, 2), provider, model }),
+                });
+                if (res.ok) {
+                    const data = await res.json();
+                    // Discard result if a new chat started while we were waiting
+                    if (data.title && myEpoch === _titleGenEpoch) _currentChatSessionTitle = data.title;
+                }
+            } catch {}
         }
 
         async function saveCurrentChatSession() {
@@ -8110,13 +8162,22 @@
                 try { const p = JSON.parse(modelValue); provider = p.provider || ''; model = p.model || ''; } catch {}
             }
             const agent = document.getElementById('chat-agent-select')?.value || null;
+            // Derive a fallback title client-side so the backend never falls back to "Untitled chat"
+            let titleToSave = _currentChatSessionTitle;
+            if (!titleToSave) {
+                const firstUser = chatMessages.find(m => m.role === 'user');
+                if (firstUser) {
+                    const t = firstUser.content.trim();
+                    titleToSave = t.slice(0, 60) + (t.length > 60 ? '…' : '');
+                }
+            }
             try {
                 const res = await fetch('/api/chat/history', {
                     method: 'POST',
                     headers: {'Content-Type': 'application/json'},
                     body: JSON.stringify({
                         session_id: _currentChatSessionId,
-                        title: _currentChatSessionTitle,
+                        title: titleToSave || null,
                         provider,
                         model,
                         agent: agent || null,
@@ -8131,10 +8192,10 @@
             } catch {}
         }
 
-        function startNewChat() {
-            // Save current session before clearing if there are messages
+        async function startNewChat() {
+            _titleGenEpoch++; // invalidate any in-flight title generation
             if (chatMessages.length > 0) {
-                saveCurrentChatSession();
+                await saveCurrentChatSession(); // wait for save to complete before resetting state
             }
             _currentChatSessionId = null;
             _currentChatSessionTitle = null;
@@ -8304,7 +8365,12 @@
                 if (fullResponse) {
                     chatMessages.push({role: 'assistant', content: fullResponse});
                     saveChatHistory();
-                    saveCurrentChatSession();
+                    // Generate a smart title on the first exchange, then save
+                    if (!_currentChatSessionTitle && _currentChatSessionId === null) {
+                        generateSmartTitle().then(() => saveCurrentChatSession());
+                    } else {
+                        saveCurrentChatSession();
+                    }
                 }
 
             } catch (e) {

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -8253,6 +8253,10 @@
                 _currentChatSessionId = session.id;
                 _currentChatSessionTitle = session.title;
                 _pendingWelcomeMessage = null;
+
+                // Ensure the session is visible in the history panel (in case it was hidden)
+                fetch(`/api/chat/history/${sessionId}/unhide`, { method: 'POST' }).catch(() => {});
+                loadChatHistorySessions();
                 if (session.updated_at) {
                     const d = new Date(session.updated_at);
                     const dateStr = d.toLocaleDateString('en-US', {month:'long', day:'numeric', year:'numeric'});

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -1768,6 +1768,66 @@
             color: var(--text-secondary, #888);
             margin-top: 2px;
         }
+        .chat-history-search-wrap {
+            padding: 6px 8px 0;
+            flex-shrink: 0;
+        }
+        .chat-history-search {
+            width: 100%;
+            box-sizing: border-box;
+            padding: 5px 8px;
+            border: 1px solid rgba(0,0,0,0.12);
+            border-radius: 6px;
+            font-size: 12px;
+            font-family: inherit;
+            background: transparent;
+            color: var(--text-primary);
+            outline: none;
+        }
+        .chat-history-search:focus { border-color: rgba(99,102,241,0.5); }
+        .chat-history-group-label {
+            font-size: 10px;
+            font-weight: 600;
+            color: var(--text-secondary, #888);
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            padding: 8px 8px 3px;
+        }
+        .chat-history-item-title-row {
+            display: flex;
+            align-items: center;
+            gap: 3px;
+        }
+        .chat-history-edit-btn {
+            background: none;
+            border: none;
+            cursor: pointer;
+            color: var(--text-secondary, #aaa);
+            padding: 1px 3px;
+            border-radius: 3px;
+            flex-shrink: 0;
+            opacity: 0;
+            transition: opacity 0.12s;
+            display: flex;
+            align-items: center;
+            line-height: 1;
+            font-size: 12px;
+        }
+        .chat-history-item:hover .chat-history-edit-btn { opacity: 1; }
+        .chat-history-edit-btn:hover { background: rgba(99,102,241,0.12); color: #6366f1; }
+        .chat-history-rename-input {
+            font-size: 12px;
+            font-weight: 500;
+            border: 1px solid rgba(99,102,241,0.5);
+            border-radius: 3px;
+            padding: 0 4px;
+            min-width: 0;
+            flex: 1;
+            background: var(--glass-bg, #fff);
+            color: var(--text-primary);
+            outline: none;
+            font-family: inherit;
+        }
 
         .chat-fullscreen-btn {
             background: transparent;
@@ -4296,6 +4356,9 @@
                             </button>
                             <button class="chat-history-close-btn" onclick="toggleChatHistoryPanel()" title="Close">✕</button>
                         </div>
+                    </div>
+                    <div class="chat-history-search-wrap">
+                        <input type="text" class="chat-history-search" id="chat-history-search" placeholder="Search chats…" oninput="_lastSessionsRenderKey=''; loadChatHistorySessions()">
                     </div>
                     <div class="chat-history-list" id="chat-history-list"></div>
                 </div>
@@ -8065,49 +8128,82 @@
                 clearInterval(_historyPollTimer);
                 _historyPollTimer = null;
                 _lastSessionsRenderKey = '';
+                const _searchEl = document.getElementById('chat-history-search');
+                if (_searchEl) _searchEl.value = '';
             } else {
                 panel.style.display = 'flex';
                 btn?.classList.add('active');
                 loadChatHistorySessions();
-                _historyPollTimer = setInterval(loadChatHistorySessions, 1000);
+                _historyPollTimer = setInterval(loadChatHistorySessions, 2500);
             }
         }
 
         let _lastSessionsRenderKey = '';
 
+        function _chatDateGroup(isoString) {
+            if (!isoString) return 3;
+            const now = new Date();
+            const d = new Date(isoString);
+            const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+            const yesterdayStart = new Date(+todayStart - 86400000);
+            const weekStart = new Date(+todayStart - 7 * 86400000);
+            if (d >= todayStart) return 0;
+            if (d >= yesterdayStart) return 1;
+            if (d >= weekStart) return 2;
+            return 3;
+        }
+
         async function loadChatHistorySessions() {
             const listEl = document.getElementById('chat-history-list');
             if (!listEl) return;
-            // Only show loading spinner on first open (list is empty)
             if (!listEl.children.length) listEl.innerHTML = '<div class="chat-history-empty">Loading…</div>';
             try {
                 const res = await fetch('/api/chat/history');
                 if (!res.ok) throw new Error('Failed to load');
                 const sessions = await res.json();
-                const hidden = _getHiddenSessions();
-                const visible = sessions.filter(s => !hidden.has(s.id));
-                // Skip re-render if nothing changed (prevents flashing on poll)
-                const renderKey = visible.map(s => `${s.id}|${s.updated_at}|${s.title}|${s.id === _currentChatSessionId}`).join(',');
+
+                const searchEl = document.getElementById('chat-history-search');
+                const query = searchEl ? searchEl.value.trim().toLowerCase() : '';
+                const filtered = query ? sessions.filter(s => s.title.toLowerCase().includes(query)) : sessions;
+
+                // Skip re-render if nothing changed
+                const renderKey = filtered.map(s => `${s.id}|${s.updated_at}|${s.title}|${s.id === _currentChatSessionId}`).join(',') + '|' + query;
                 if (renderKey === _lastSessionsRenderKey) return;
                 _lastSessionsRenderKey = renderKey;
-                if (visible.length === 0) {
-                    listEl.innerHTML = '<div class="chat-history-empty">No saved chats yet.</div>';
+
+                if (filtered.length === 0) {
+                    listEl.innerHTML = `<div class="chat-history-empty">${query ? 'No results.' : 'No saved chats yet.'}</div>`;
                     return;
                 }
+
                 listEl.innerHTML = '';
-                visible.forEach(s => {
-                    const item = document.createElement('div');
-                    item.className = 'chat-history-item' + (s.id === _currentChatSessionId ? ' active' : '');
-                    const dateStr = s.updated_at ? s.updated_at.slice(0, 10) : '';
-                    const msgStr = s.message_count === 1 ? '1 msg' : `${s.message_count} msgs`;
-                    item.innerHTML = `
-                        <div class="chat-history-item-body" onclick="resumeChatSession('${s.id}')">
-                            <div class="chat-history-item-title">${_escapeHtml(s.title)}</div>
-                            <div class="chat-history-item-meta">${dateStr} · ${msgStr}${s.agent ? ' · ' + _escapeHtml(s.agent) : ''}</div>
-                        </div>
-                        <button class="chat-history-delete-btn" onclick="hideChatSession('${s.id}', event)" title="Remove from history">✕</button>
-                    `;
-                    listEl.appendChild(item);
+                const groupLabels = ['Today', 'Yesterday', 'Last 7 days', 'Older'];
+                const groups = [[], [], [], []];
+                filtered.forEach(s => groups[_chatDateGroup(s.updated_at)].push(s));
+
+                groups.forEach((groupSessions, gi) => {
+                    if (groupSessions.length === 0) return;
+                    const headerEl = document.createElement('div');
+                    headerEl.className = 'chat-history-group-label';
+                    headerEl.textContent = groupLabels[gi];
+                    listEl.appendChild(headerEl);
+
+                    groupSessions.forEach(s => {
+                        const item = document.createElement('div');
+                        item.className = 'chat-history-item' + (s.id === _currentChatSessionId ? ' active' : '');
+                        const msgStr = s.message_count === 1 ? '1 msg' : `${s.message_count} msgs`;
+                        item.innerHTML = `
+                            <div class="chat-history-item-body" onclick="resumeChatSession('${s.id}')">
+                                <div class="chat-history-item-title-row">
+                                    <div class="chat-history-item-title">${_escapeHtml(s.title)}</div>
+                                    <button class="chat-history-edit-btn" onclick="startRenameSession(event,'${s.id}')" title="Rename">✎</button>
+                                </div>
+                                <div class="chat-history-item-meta">${msgStr}${s.agent ? ' · ' + _escapeHtml(s.agent) : ''}</div>
+                            </div>
+                            <button class="chat-history-delete-btn" onclick="deleteChatSession('${s.id}',event)" title="Delete chat">✕</button>
+                        `;
+                        listEl.appendChild(item);
+                    });
                 });
             } catch {
                 listEl.innerHTML = '<div class="chat-history-empty">Could not load history.</div>';
@@ -8168,23 +8264,69 @@
             }
         }
 
-        const _HIDDEN_SESSIONS_KEY = 'santai-hidden-sessions';
-
-        function _getHiddenSessions() {
-            try { return new Set(JSON.parse(localStorage.getItem(_HIDDEN_SESSIONS_KEY) || '[]')); }
-            catch { return new Set(); }
-        }
-
-        function hideChatSession(sessionId, event) {
+        async function deleteChatSession(sessionId, event) {
             if (event) event.stopPropagation();
-            const hidden = _getHiddenSessions();
-            hidden.add(sessionId);
-            localStorage.setItem(_HIDDEN_SESSIONS_KEY, JSON.stringify([...hidden]));
+            if (!confirm('Delete this chat? This cannot be undone.')) return;
+            try {
+                const res = await fetch(`/api/chat/history/${sessionId}`, { method: 'DELETE' });
+                if (!res.ok) throw new Error('Delete failed');
+            } catch (e) {
+                console.error('deleteChatSession error:', e);
+                return;
+            }
             if (_currentChatSessionId === sessionId) {
                 _currentChatSessionId = null;
                 _currentChatSessionTitle = null;
             }
+            _lastSessionsRenderKey = '';
             loadChatHistorySessions();
+        }
+
+        function startRenameSession(event, sessionId) {
+            event.stopPropagation();
+            const row = event.currentTarget.closest('.chat-history-item-title-row');
+            if (!row) return;
+            const titleEl = row.querySelector('.chat-history-item-title');
+            if (!titleEl) return;
+            const currentTitle = titleEl.textContent;
+
+            const input = document.createElement('input');
+            input.type = 'text';
+            input.className = 'chat-history-rename-input';
+            input.value = currentTitle;
+            titleEl.replaceWith(input);
+            input.focus();
+            input.select();
+
+            let cancelled = false;
+
+            async function commitRename() {
+                if (cancelled) return;
+                const newTitle = input.value.trim();
+                if (!newTitle || newTitle === currentTitle) {
+                    input.replaceWith(titleEl);
+                    return;
+                }
+                try {
+                    const res = await fetch(`/api/chat/history/${sessionId}/title`, {
+                        method: 'PATCH',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ title: newTitle }),
+                    });
+                    if (res.ok) {
+                        titleEl.textContent = newTitle;
+                        if (_currentChatSessionId === sessionId) _currentChatSessionTitle = newTitle;
+                        _lastSessionsRenderKey = '';
+                    }
+                } catch {}
+                input.replaceWith(titleEl);
+            }
+
+            input.addEventListener('blur', commitRename);
+            input.addEventListener('keydown', (e) => {
+                if (e.key === 'Enter') { e.preventDefault(); input.blur(); }
+                if (e.key === 'Escape') { cancelled = true; input.replaceWith(titleEl); }
+            });
         }
 
         function resumeChatFromPreview() {

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -1793,26 +1793,20 @@
             letter-spacing: 0.05em;
             padding: 8px 8px 3px;
         }
-        .chat-history-item-title-row {
-            display: flex;
-            align-items: center;
-            gap: 3px;
-        }
         .chat-history-edit-btn {
             background: none;
             border: none;
             cursor: pointer;
             color: var(--text-secondary, #aaa);
-            padding: 1px 3px;
-            border-radius: 3px;
+            padding: 2px 4px;
+            border-radius: 4px;
             flex-shrink: 0;
             opacity: 0;
             transition: opacity 0.12s;
             display: flex;
             align-items: center;
-            line-height: 1;
-            font-size: 12px;
         }
+        .chat-history-edit-btn svg { width: 12px; height: 12px; stroke-width: 1.5; }
         .chat-history-item:hover .chat-history-edit-btn { opacity: 1; }
         .chat-history-edit-btn:hover { background: rgba(99,102,241,0.12); color: #6366f1; }
         .chat-history-rename-input {
@@ -8194,12 +8188,12 @@
                         const msgStr = s.message_count === 1 ? '1 msg' : `${s.message_count} msgs`;
                         item.innerHTML = `
                             <div class="chat-history-item-body" onclick="resumeChatSession('${s.id}')">
-                                <div class="chat-history-item-title-row">
-                                    <div class="chat-history-item-title">${_escapeHtml(s.title)}</div>
-                                    <button class="chat-history-edit-btn" onclick="startRenameSession(event,'${s.id}')" title="Rename">✎</button>
-                                </div>
+                                <div class="chat-history-item-title">${_escapeHtml(s.title)}</div>
                                 <div class="chat-history-item-meta">${msgStr}${s.agent ? ' · ' + _escapeHtml(s.agent) : ''}</div>
                             </div>
+                            <button class="chat-history-edit-btn" onclick="startRenameSession(event,'${s.id}')" title="Rename">
+                                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931z" /></svg>
+                            </button>
                             <button class="chat-history-delete-btn" onclick="deleteChatSession('${s.id}',event)" title="Delete chat">✕</button>
                         `;
                         listEl.appendChild(item);
@@ -8284,9 +8278,9 @@
 
         function startRenameSession(event, sessionId) {
             event.stopPropagation();
-            const row = event.currentTarget.closest('.chat-history-item-title-row');
-            if (!row) return;
-            const titleEl = row.querySelector('.chat-history-item-title');
+            const item = event.currentTarget.closest('.chat-history-item');
+            if (!item) return;
+            const titleEl = item.querySelector('.chat-history-item-title');
             if (!titleEl) return;
             const currentTitle = titleEl.textContent;
 

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -1300,7 +1300,7 @@
             overflow: hidden;
             text-overflow: ellipsis;
             margin-bottom: 2px;
-            display: inline;
+            display: block;
         }
 
         .preview-title span {
@@ -1315,6 +1315,23 @@
             gap: 8px;
             flex-shrink: 0;
         }
+
+        .chat-history-resume-btn {
+            display: inline-flex;
+            align-items: center;
+            gap: 5px;
+            padding: 4px 10px;
+            background: rgba(34,197,94,0.1);
+            border: 1px solid rgba(34,197,94,0.35);
+            border-radius: 6px;
+            font-size: 12px;
+            font-family: inherit;
+            font-weight: 500;
+            color: #16a34a;
+            cursor: pointer;
+            transition: background 0.12s;
+        }
+        .chat-history-resume-btn:hover { background: rgba(34,197,94,0.18); }
 
         .preview-open-new-window {
             background: none;
@@ -4164,6 +4181,10 @@
                         <span id="preview-size">0 KB</span>
                     </div>
                     <div class="preview-header-actions">
+                        <button class="chat-history-resume-btn" id="preview-resume-chat-btn" onclick="resumeChatFromPreview()" title="Resume this chat" style="display:none;">
+                            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="1 4 1 10 7 10"/><path d="M3.51 15a9 9 0 102.13-9.36L1 10"/></svg>
+                            Resume Chat
+                        </button>
                         <button class="preview-open-new-window" id="preview-open-new-window-btn" onclick="openPreviewInNewTab()" title="Open in new window">
                             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                                 <path stroke-linecap="round" stroke-linejoin="round" d="M13.5 6H5.25A2.25 2.25 0 003 8.25v10.5A2.25 2.25 0 005.25 21h10.5A2.25 2.25 0 0018 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" />
@@ -4507,6 +4528,8 @@
         let previewPath = null;
         let previewHistory = []; // paths navigated via markdown links, for back-button
         let previewReturnClusterId = null; // set when a file is opened from a cluster list
+        let _previewPollTimer = null;
+        let _previewLastContent = null;
         function hasPreviewContent() {
             const header = document.getElementById('preview-file-header');
             return Boolean(header) && header.style.display !== 'none';
@@ -4558,6 +4581,9 @@
 
         // File Preview Functions
         async function openFilePreview(path, historyMode = 'clear') {
+            clearInterval(_previewPollTimer);
+            _previewPollTimer = null;
+            _previewLastContent = null;
             if (historyMode === 'push') {
                 if (previewPath) previewHistory.push(previewPath);
             } else if (historyMode === 'clear') {
@@ -4590,6 +4616,21 @@
 
                 document.getElementById('preview-filename').textContent = data.name;
                 document.getElementById('preview-size').textContent = data.size_formatted;
+
+                // Show Resume Chat button for chat-history .md files
+                const resumeBtn = document.getElementById('preview-resume-chat-btn');
+                const isChatHistory = path.includes('history/chat-history/') && path.endsWith('.md');
+                if (isChatHistory && data.content) {
+                    const idMatch = data.content.match(/\nid:\s*([^\n]+)/);
+                    if (idMatch) {
+                        resumeBtn._sessionId = idMatch[1].trim();
+                        resumeBtn.style.display = 'inline-flex';
+                    } else {
+                        resumeBtn.style.display = 'none';
+                    }
+                } else {
+                    resumeBtn.style.display = 'none';
+                }
 
                 if (!data.preview) {
                     content.innerHTML = `
@@ -4660,6 +4701,10 @@
                 } else if (data.type === 'image') {
                     content.innerHTML = `<img class="preview-image" src="${data.url}" alt="${data.name}">`;
                 }
+                _previewLastContent = data.content ?? null;
+                if (!_previewPollTimer) {
+                    _previewPollTimer = setInterval(_pollPreviewContent, 2000);
+                }
             } catch (err) {
                 content.innerHTML = `
                     <div class="preview-message">
@@ -4670,6 +4715,18 @@
                     </div>
                 `;
             }
+        }
+
+        async function _pollPreviewContent() {
+            if (!previewPath) return;
+            try {
+                const res = await fetch(`/api/files/content?path=${encodeURIComponent(previewPath)}`);
+                if (!res.ok) return;
+                const data = await res.json();
+                const newContent = data.content ?? null;
+                if (newContent === _previewLastContent) return;
+                openFilePreview(previewPath, 'replace');
+            } catch { /* ignore poll errors */ }
         }
 
         function resizeGraphIfFullscreen() {
@@ -4687,6 +4744,9 @@
         }
 
         function resetPreviewState() {
+            clearInterval(_previewPollTimer);
+            _previewPollTimer = null;
+            _previewLastContent = null;
             previewPath = null;
             previewHistory = [];
             updateTreePreviewState();
@@ -8127,6 +8187,11 @@
             loadChatHistorySessions();
         }
 
+        function resumeChatFromPreview() {
+            const btn = document.getElementById('preview-resume-chat-btn');
+            if (btn && btn._sessionId) resumeChatSession(btn._sessionId);
+        }
+
         let _titleGenEpoch = 0;
 
         async function generateSmartTitle() {
@@ -8168,7 +8233,7 @@
                 const firstUser = chatMessages.find(m => m.role === 'user');
                 if (firstUser) {
                     const t = firstUser.content.trim();
-                    titleToSave = t.slice(0, 60) + (t.length > 60 ? '…' : '');
+                    titleToSave = t.slice(0, 40) + (t.length > 40 ? '…' : '');
                 }
             }
             try {

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -1744,10 +1744,8 @@
             padding: 2px 4px;
             border-radius: 4px;
             flex-shrink: 0;
-            opacity: 0;
-            transition: opacity 0.12s;
         }
-        .chat-history-item:hover .chat-history-delete-btn { opacity: 1; }
+        .chat-history-item:hover .chat-history-item-actions { opacity: 1; }
         .chat-history-delete-btn:hover { background: rgba(239,68,68,0.12); color: #ef4444; }
         .chat-history-item.active { background: rgba(34,197,94,0.1); }
         .chat-history-item.active .chat-history-item-title { color: #16a34a; }
@@ -1793,6 +1791,15 @@
             letter-spacing: 0.05em;
             padding: 8px 8px 3px;
         }
+        .chat-history-item-actions {
+            display: flex;
+            align-items: center;
+            gap: 1px;
+            flex-shrink: 0;
+            align-self: flex-start;
+            opacity: 0;
+            transition: opacity 0.12s;
+        }
         .chat-history-edit-btn {
             background: none;
             border: none;
@@ -1801,14 +1808,11 @@
             padding: 2px 4px;
             border-radius: 4px;
             flex-shrink: 0;
-            opacity: 0;
-            transition: opacity 0.12s;
             display: flex;
             align-items: center;
         }
         .chat-history-edit-btn svg { width: 12px; height: 12px; stroke-width: 1.5; }
-        .chat-history-item:hover .chat-history-edit-btn { opacity: 1; }
-        .chat-history-edit-btn:hover { background: rgba(99,102,241,0.12); color: #6366f1; }
+        .chat-history-edit-btn:hover { background: rgba(34,197,94,0.12); color: #16a34a; }
         .chat-history-rename-input {
             font-size: 12px;
             font-weight: 500;
@@ -7447,6 +7451,7 @@
         let _currentChatSessionId = null;
         let _currentChatSessionTitle = null;
         let _pendingWelcomeMessage = null; // flushed into chatMessages on first real send
+        let _sessionContext = null; // injected into system prompt on resumed sessions
 
         function saveChatHistory() {
             try {
@@ -8104,6 +8109,7 @@
             _currentChatSessionId = null;
             _currentChatSessionTitle = null;
             _pendingWelcomeMessage = null;
+            _sessionContext = null;
             _titleGenEpoch++;
             chatMessages = [];
             chatStreaming = false;
@@ -8204,10 +8210,12 @@
                                 <div class="chat-history-item-title">${_escapeHtml(s.title)}</div>
                                 <div class="chat-history-item-meta">${msgStr}${s.agent ? ' · ' + _escapeHtml(s.agent) : ''}</div>
                             </div>
-                            <button class="chat-history-edit-btn" onclick="startRenameSession(event,'${s.id}')" title="Rename">
-                                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931z" /></svg>
-                            </button>
-                            <button class="chat-history-delete-btn" onclick="hideChatSession('${s.id}',event)" title="Remove from history">✕</button>
+                            <div class="chat-history-item-actions">
+                                <button class="chat-history-edit-btn" onclick="startRenameSession(event,'${s.id}')" title="Rename">
+                                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931z" /></svg>
+                                </button>
+                                <button class="chat-history-delete-btn" onclick="hideChatSession('${s.id}',event)" title="Remove from history">✕</button>
+                            </div>
                         `;
                         listEl.appendChild(item);
                     });
@@ -8245,6 +8253,13 @@
                 _currentChatSessionId = session.id;
                 _currentChatSessionTitle = session.title;
                 _pendingWelcomeMessage = null;
+                if (session.updated_at) {
+                    const d = new Date(session.updated_at);
+                    const dateStr = d.toLocaleDateString('en-US', {month:'long', day:'numeric', year:'numeric'});
+                    _sessionContext = `This conversation was last active on ${dateStr}.`;
+                } else {
+                    _sessionContext = null;
+                }
 
                 // Restore model/provider if available
                 if (session.provider && session.model) {
@@ -8482,7 +8497,8 @@
                         messages: chatMessages,
                         provider: selected.provider,
                         model: selected.model,
-                        agent: agent
+                        agent: agent,
+                        session_context: _sessionContext || undefined
                     })
                 });
 

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -4336,7 +4336,7 @@
                             <div class="chat-custom-select-list" id="chat-model-select-list"></div>
                             <select id="chat-model-select" style="display:none;"></select>
                         </div>
-                        <button class="chat-ctrl-btn" onclick="clearChat()">Clear</button>
+                        <button class="chat-ctrl-btn" onclick="clearChatBtn()">Clear</button>
                     </div>
                 </div>
                 <!-- Chat history overlay panel -->
@@ -8089,9 +8089,20 @@
             };
         }
 
+        async function clearChatBtn() {
+            _titleGenEpoch++;
+            if (chatMessages.length > 0) await saveCurrentChatSession();
+            _currentChatSessionId = null;
+            _currentChatSessionTitle = null;
+            clearChat();
+        }
+
         function clearChat() {
             if (_chatAbortController) { _chatAbortController.abort(); _chatAbortController = null; }
             _chatEpoch++;             // invalidate any in-flight stream
+            _currentChatSessionId = null;
+            _currentChatSessionTitle = null;
+            _titleGenEpoch++;
             chatMessages = [];
             chatStreaming = false;
             try { localStorage.removeItem(CHAT_STORAGE_KEY); localStorage.removeItem(CHAT_TOKEN_KEY); } catch {}

--- a/tests/test_chat_history.py
+++ b/tests/test_chat_history.py
@@ -1,0 +1,352 @@
+"""Tests for chat history persistence (save, load, list, delete, resume)."""
+
+from pathlib import Path
+
+import pytest
+
+from santai_cli.core.chat import ChatSession
+from santai_cli.core.chat_history import (
+    auto_title,
+    delete_session,
+    generate_session_id,
+    get_chat_history_dir,
+    list_sessions,
+    load_session,
+    restore_chat_session,
+    save_session,
+)
+from santai_cli.core.project import SantaiProject
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_project(tmp_path: Path) -> SantaiProject:
+    return SantaiProject(root=tmp_path, name=tmp_path.name)
+
+
+def _make_session(user: str = "hello", assistant: str = "world") -> ChatSession:
+    s = ChatSession(system_prompt="test prompt")
+    s.add_user_message(user)
+    s.add_assistant_message(assistant)
+    return s
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: core module
+# ---------------------------------------------------------------------------
+
+
+def test_auto_title_uses_first_user_message():
+    msgs = [{"role": "user", "content": "What is the capital of France?"}]
+    assert auto_title(msgs) == "What is the capital of France?"
+
+
+def test_auto_title_truncates_at_60_chars():
+    long_msg = "A" * 80
+    result = auto_title([{"role": "user", "content": long_msg}])
+    assert result == "A" * 60 + "…"
+    assert len(result) == 61  # 60 chars + ellipsis (U+2026, 1 code point)
+
+
+def test_auto_title_skips_non_user_messages():
+    msgs = [
+        {"role": "assistant", "content": "hi"},
+        {"role": "user", "content": "my question"},
+    ]
+    assert auto_title(msgs) == "my question"
+
+
+def test_auto_title_fallback_on_empty():
+    assert auto_title([]) == "Untitled chat"
+
+
+def test_generate_session_id_format():
+    sid = generate_session_id()
+    parts = sid.split("-")
+    assert len(parts) == 3  # YYYYMMDD, HHMMSS, 4hexchars
+    assert len(parts[0]) == 8
+    assert len(parts[1]) == 6
+    assert len(parts[2]) == 4
+
+
+def test_save_creates_chat_history_dir(tmp_path: Path):
+    project = _make_project(tmp_path)
+    session = _make_session()
+    assert not get_chat_history_dir(project).exists()
+    save_session(project, session, None, None, "anthropic", "claude-3-5-sonnet", None)
+    assert get_chat_history_dir(project).is_dir()
+
+
+def test_save_and_load_round_trip(tmp_path: Path):
+    project = _make_project(tmp_path)
+    session = _make_session("Tell me a joke", "Why did the chicken cross the road?")
+    sid = save_session(
+        project, session, None, "My Chat", "anthropic", "claude-sonnet-4-6", "code"
+    )
+
+    loaded = load_session(project, sid)
+    assert loaded.id == sid
+    assert loaded.title == "My Chat"
+    assert loaded.provider == "anthropic"
+    assert loaded.model == "claude-sonnet-4-6"
+    assert loaded.agent == "code"
+    assert loaded.message_count == 2
+    assert len(loaded.messages) == 2
+    assert loaded.messages[0] == {"role": "user", "content": "Tell me a joke"}
+    assert loaded.messages[1]["role"] == "assistant"
+
+
+def test_save_auto_generates_title_from_messages(tmp_path: Path):
+    project = _make_project(tmp_path)
+    session = _make_session("What is recursion?")
+    sid = save_session(
+        project, session, None, None, "anthropic", "claude-sonnet-4-6", None
+    )
+    loaded = load_session(project, sid)
+    assert loaded.title == "What is recursion?"
+
+
+def test_update_session_overwrites_no_duplicate(tmp_path: Path):
+    project = _make_project(tmp_path)
+    session = _make_session()
+    sid = save_session(project, session, None, None, "anthropic", "model", None)
+
+    # Save again with same id
+    session.add_user_message("follow-up")
+    session.add_assistant_message("answer")
+    save_session(project, session, sid, None, "anthropic", "model", None)
+
+    chat_dir = get_chat_history_dir(project)
+    files = list(chat_dir.glob("*.md"))
+    assert len(files) == 1
+    loaded = load_session(project, sid)
+    assert loaded.message_count == 4
+
+
+def test_save_preserves_created_at_on_update(tmp_path: Path):
+    project = _make_project(tmp_path)
+    session = _make_session()
+    sid = save_session(project, session, None, None, "anthropic", "model", None)
+    first = load_session(project, sid)
+    original_created_at = first.created_at
+
+    session.add_user_message("more")
+    session.add_assistant_message("data")
+    save_session(project, session, sid, None, "anthropic", "model", None)
+    updated = load_session(project, sid)
+    assert updated.created_at == original_created_at
+
+
+def test_list_sessions_returns_newest_first(tmp_path: Path):
+    import time
+
+    project = _make_project(tmp_path)
+    for i in range(3):
+        s = _make_session(f"question {i}")
+        save_session(project, s, None, f"Chat {i}", "anthropic", "model", None)
+        time.sleep(0.01)  # ensure distinct updated_at timestamps
+
+    sessions = list_sessions(project)
+    assert len(sessions) == 3
+    # Newest first: updated_at should be descending
+    for j in range(len(sessions) - 1):
+        assert sessions[j].updated_at >= sessions[j + 1].updated_at
+
+
+def test_list_sessions_empty_when_no_dir(tmp_path: Path):
+    project = _make_project(tmp_path)
+    assert list_sessions(project) == []
+
+
+def test_delete_session(tmp_path: Path):
+    project = _make_project(tmp_path)
+    session = _make_session()
+    sid = save_session(project, session, None, None, "anthropic", "model", None)
+
+    delete_session(project, sid)
+    with pytest.raises(FileNotFoundError):
+        load_session(project, sid)
+
+
+def test_delete_session_raises_when_missing(tmp_path: Path):
+    project = _make_project(tmp_path)
+    with pytest.raises(FileNotFoundError):
+        delete_session(project, "nonexistent-id")
+
+
+def test_load_session_raises_when_missing(tmp_path: Path):
+    project = _make_project(tmp_path)
+    with pytest.raises(FileNotFoundError):
+        load_session(project, "nonexistent-id")
+
+
+def test_restore_chat_session(tmp_path: Path):
+    project = _make_project(tmp_path)
+    original = _make_session("question", "answer")
+    sid = save_session(project, original, None, None, "anthropic", "model", None)
+
+    persisted = load_session(project, sid)
+    restored = restore_chat_session(persisted)
+
+    assert len(restored.messages) == 2
+    assert restored.messages[0].role == "user"
+    assert restored.messages[0].content == "question"
+    assert restored.messages[1].role == "assistant"
+    assert restored.messages[1].content == "answer"
+
+
+def test_chat_history_path_on_project(tmp_path: Path):
+    project = _make_project(tmp_path)
+    assert project.chat_history_path == tmp_path / "history" / "chat-history"
+
+
+def test_get_chat_history_dir(tmp_path: Path):
+    project = _make_project(tmp_path)
+    assert get_chat_history_dir(project) == tmp_path / "history" / "chat-history"
+
+
+# ---------------------------------------------------------------------------
+# Integration tests: web API endpoints
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def web_client(tmp_path: Path):
+    """Create a FastAPI test client with a temporary project."""
+    from fastapi.testclient import TestClient
+
+    from santai_cli.web.app import create_app
+
+    project = SantaiProject(root=tmp_path, name=tmp_path.name)
+    app = create_app(project)
+    return TestClient(app), project
+
+
+def test_api_list_empty(web_client):
+    client, _ = web_client
+    resp = client.get("/api/chat/history")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+def test_api_save_and_list(web_client):
+    client, _ = web_client
+    payload = {
+        "provider": "anthropic",
+        "model": "claude-sonnet-4-6",
+        "messages": [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi there!"},
+        ],
+    }
+    save_resp = client.post("/api/chat/history", json=payload)
+    assert save_resp.status_code == 200
+    sid = save_resp.json()["session_id"]
+    assert sid
+
+    list_resp = client.get("/api/chat/history")
+    assert list_resp.status_code == 200
+    sessions = list_resp.json()
+    assert len(sessions) == 1
+    assert sessions[0]["id"] == sid
+    assert sessions[0]["title"] == "Hello"
+    assert sessions[0]["message_count"] == 2
+
+
+def test_api_load_session(web_client):
+    client, _ = web_client
+    payload = {
+        "provider": "anthropic",
+        "model": "claude-sonnet-4-6",
+        "agent": "code",
+        "messages": [
+            {"role": "user", "content": "Explain recursion"},
+            {"role": "assistant", "content": "Recursion is…"},
+        ],
+    }
+    sid = client.post("/api/chat/history", json=payload).json()["session_id"]
+
+    resp = client.get(f"/api/chat/history/{sid}")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["id"] == sid
+    assert data["agent"] == "code"
+    assert len(data["messages"]) == 2
+    assert data["messages"][0]["content"] == "Explain recursion"
+
+
+def test_api_load_missing_returns_404(web_client):
+    client, _ = web_client
+    resp = client.get("/api/chat/history/does-not-exist")
+    assert resp.status_code == 404
+
+
+def test_api_delete_session(web_client):
+    client, _ = web_client
+    payload = {
+        "provider": "openai",
+        "model": "gpt-4o",
+        "messages": [{"role": "user", "content": "hi"}],
+    }
+    sid = client.post("/api/chat/history", json=payload).json()["session_id"]
+    del_resp = client.delete(f"/api/chat/history/{sid}")
+    assert del_resp.status_code == 200
+
+    get_resp = client.get(f"/api/chat/history/{sid}")
+    assert get_resp.status_code == 404
+
+
+def test_api_delete_missing_returns_404(web_client):
+    client, _ = web_client
+    resp = client.delete("/api/chat/history/nonexistent")
+    assert resp.status_code == 404
+
+
+def test_api_update_title(web_client):
+    client, _ = web_client
+    payload = {
+        "provider": "anthropic",
+        "model": "claude-sonnet-4-6",
+        "messages": [{"role": "user", "content": "Original title from message"}],
+    }
+    sid = client.post("/api/chat/history", json=payload).json()["session_id"]
+
+    patch_resp = client.patch(
+        f"/api/chat/history/{sid}/title", json={"title": "My Custom Title"}
+    )
+    assert patch_resp.status_code == 200
+
+    loaded = client.get(f"/api/chat/history/{sid}").json()
+    assert loaded["title"] == "My Custom Title"
+
+
+def test_api_update_with_existing_session_id(web_client):
+    client, _ = web_client
+    payload = {
+        "provider": "anthropic",
+        "model": "claude-sonnet-4-6",
+        "messages": [{"role": "user", "content": "First message"}],
+    }
+    sid = client.post("/api/chat/history", json=payload).json()["session_id"]
+
+    # Update with same session_id (should overwrite, not create new)
+    payload2 = {
+        "session_id": sid,
+        "provider": "anthropic",
+        "model": "claude-sonnet-4-6",
+        "messages": [
+            {"role": "user", "content": "First message"},
+            {"role": "assistant", "content": "Response"},
+            {"role": "user", "content": "Follow-up"},
+        ],
+    }
+    resp2 = client.post("/api/chat/history", json=payload2)
+    assert resp2.status_code == 200
+    assert resp2.json()["session_id"] == sid
+
+    list_resp = client.get("/api/chat/history")
+    assert len(list_resp.json()) == 1  # still only one session
+    loaded = client.get(f"/api/chat/history/{sid}").json()
+    assert loaded["message_count"] == 3

--- a/tests/test_chat_history.py
+++ b/tests/test_chat_history.py
@@ -8,6 +8,8 @@ from santai_cli.core.chat import ChatSession
 from santai_cli.core.chat_history import (
     _mask_code_blocks,
     _parse_markdown,
+    _sanitize_title,
+    _session_filename,
     auto_title,
     delete_session,
     generate_session_id,
@@ -507,3 +509,107 @@ def test_api_update_with_existing_session_id(web_client):
     assert len(list_resp.json()) == 1  # still only one session
     loaded = client.get(f"/api/chat/history/{sid}").json()
     assert loaded["message_count"] == 3
+
+
+# ---------------------------------------------------------------------------
+# _sanitize_title
+# ---------------------------------------------------------------------------
+
+
+def test_sanitize_title_empty_returns_untitled():
+    assert _sanitize_title("") == "Untitled chat"
+
+
+def test_sanitize_title_all_punct_returns_untitled():
+    assert _sanitize_title("---...") == "Untitled chat"
+
+
+def test_sanitize_title_strips_leading_dot():
+    assert not _sanitize_title(". hidden").startswith(".")
+
+
+def test_sanitize_title_truncates_at_60():
+    long = "a" * 80
+    assert len(_sanitize_title(long)) == 60
+
+
+def test_sanitize_title_collapses_spaces():
+    assert _sanitize_title("hello   world") == "hello world"
+
+
+# ---------------------------------------------------------------------------
+# _session_filename collision counter
+# ---------------------------------------------------------------------------
+
+
+def test_session_filename_collision_counter(tmp_path: Path):
+    chat_dir = tmp_path
+    created_at = "2026-01-15T12:00:00+00:00"
+    first = _session_filename("My Chat", created_at, chat_dir)
+    assert first == "01-15-2026 - My Chat.md"
+
+    # Simulate the first file existing
+    (chat_dir / first).touch()
+    second = _session_filename("My Chat", created_at, chat_dir)
+    assert second == "01-15-2026 - My Chat (2).md"
+
+    (chat_dir / second).touch()
+    third = _session_filename("My Chat", created_at, chat_dir)
+    assert third == "01-15-2026 - My Chat (3).md"
+
+
+# ---------------------------------------------------------------------------
+# Old-format round-trip (legacy --- block migrates to HTML comment on save)
+# ---------------------------------------------------------------------------
+
+
+def test_old_format_roundtrip(tmp_path: Path):
+    """Old --- metadata block loads and re-saves in HTML comment format."""
+    project = _make_project(tmp_path)
+    chat_dir = get_chat_history_dir(project)
+    chat_dir.mkdir(parents=True, exist_ok=True)
+
+    old_content = (
+        "**You:**\nHello\n\n"
+        "**Assistant:**\nHi there\n\n"
+        '---\nid: legacy-id-0001\ntitle: "Old format"\n'
+        "created_at: 2026-01-01T00:00:00+00:00\n"
+        "updated_at: 2026-01-01T00:00:00+00:00\n"
+        "provider: anthropic\nmodel: m\nagent: null\n"
+        "message_count: 2\n---\n"
+    )
+    (chat_dir / "01-01-2026 - Old format.md").write_text(old_content, encoding="utf-8")
+
+    # Load via the public API
+    loaded = load_session(project, "legacy-id-0001")
+    assert loaded.id == "legacy-id-0001"
+    assert loaded.title == "Old format"
+    assert len(loaded.messages) == 2
+
+    # Re-save — the new file should use HTML comment format
+    session = restore_chat_session(loaded)
+    save_session(
+        project,
+        session,
+        "legacy-id-0001",
+        loaded.title,
+        loaded.provider,
+        loaded.model,
+        loaded.agent,
+    )
+    files = list(chat_dir.glob("*.md"))
+    assert len(files) == 1
+    new_content = files[0].read_text(encoding="utf-8")
+    assert "<!-- santai" in new_content
+    assert "---\nid:" not in new_content
+
+
+# ---------------------------------------------------------------------------
+# hide_session validates existence
+# ---------------------------------------------------------------------------
+
+
+def test_hide_session_raises_for_missing_session(tmp_path: Path):
+    project = _make_project(tmp_path)
+    with pytest.raises(FileNotFoundError):
+        hide_session(project, "nonexistent-id")

--- a/tests/test_chat_history.py
+++ b/tests/test_chat_history.py
@@ -15,6 +15,7 @@ from santai_cli.core.chat_history import (
     get_chat_history_dir,
     list_sessions,
     load_session,
+    rename_session,
     restore_chat_session,
     save_session,
 )
@@ -256,6 +257,46 @@ def test_index_entry_removed_on_delete(tmp_path: Path):
     chat_dir = get_chat_history_dir(project)
     index = json.loads((chat_dir / "_index.json").read_text())
     assert sid not in index
+
+
+def test_rename_session_renames_file(tmp_path: Path):
+    project = _make_project(tmp_path)
+    session = _make_session("original question")
+    sid = save_session(project, session, None, "Old Title", "anthropic", "model", None)
+
+    chat_dir = get_chat_history_dir(project)
+    old_files = list(chat_dir.glob("*.md"))
+    assert any("Old-Title" in f.name or "Old Title" in f.name for f in old_files)
+
+    rename_session(project, sid, "New Title")
+
+    new_files = list(chat_dir.glob("*.md"))
+    assert len(new_files) == 1
+    assert "New Title" in new_files[0].name
+    assert not any("Old Title" in f.name for f in new_files)
+
+    loaded = load_session(project, sid)
+    assert loaded.title == "New Title"
+
+
+def test_rename_session_same_sanitized_name_updates_in_place(tmp_path: Path):
+    project = _make_project(tmp_path)
+    session = _make_session()
+    sid = save_session(
+        project, session, None, "Hello World", "anthropic", "model", None
+    )
+
+    chat_dir = get_chat_history_dir(project)
+    original_files = list(chat_dir.glob("*.md"))
+    assert len(original_files) == 1
+    original_name = original_files[0].name
+
+    # Extra space sanitizes to same base name — should not create a duplicate
+    rename_session(project, sid, "Hello  World")
+
+    files = list(chat_dir.glob("*.md"))
+    assert len(files) == 1
+    assert files[0].name == original_name
 
 
 def test_rebuild_index_finds_existing_files(tmp_path: Path):

--- a/tests/test_chat_history.py
+++ b/tests/test_chat_history.py
@@ -8,7 +8,6 @@ from santai_cli.core.chat import ChatSession
 from santai_cli.core.chat_history import (
     _mask_code_blocks,
     _parse_markdown,
-    _rebuild_index,
     auto_title,
     delete_session,
     generate_session_id,
@@ -225,14 +224,17 @@ def test_code_block_masking_ignores_speaker_labels_inside_fences():
 
 def test_parse_markdown_code_block_not_split(tmp_path: Path):
     """A message containing a fenced code block with speaker labels is parsed intact."""
+    code_block = "```\n**You:** Hello!\n**Assistant:** Hi!\n```"
     content_with_block = (
         "**You:**\nHow do I greet someone?\n\n"
-        "**Assistant:**\nHere is an example:\n\n```\n**You:** Hello!\n**Assistant:** Hi!\n```\n\n"
-        '---\nid: test-id-0001\ntitle: "test"\ncreated_at: 2026-01-01T00:00:00+00:00\n'
-        "updated_at: 2026-01-01T00:00:00+00:00\nprovider: anthropic\nmodel: m\nagent: null\n"
+        f"**Assistant:**\nHere is an example:\n\n{code_block}\n\n"
+        '---\nid: test-id-0001\ntitle: "test"\n'
+        "created_at: 2026-01-01T00:00:00+00:00\n"
+        "updated_at: 2026-01-01T00:00:00+00:00\n"
+        "provider: anthropic\nmodel: m\nagent: null\n"
         "message_count: 2\n---\n"
     )
-    meta, messages = _parse_markdown(content_with_block)
+    _meta, messages = _parse_markdown(content_with_block)
     assert len(messages) == 2
     assert messages[1]["role"] == "assistant"
     assert "```" in messages[1]["content"]

--- a/tests/test_chat_history.py
+++ b/tests/test_chat_history.py
@@ -6,6 +6,9 @@ import pytest
 
 from santai_cli.core.chat import ChatSession
 from santai_cli.core.chat_history import (
+    _mask_code_blocks,
+    _parse_markdown,
+    _rebuild_index,
     auto_title,
     delete_session,
     generate_session_id,
@@ -205,6 +208,68 @@ def test_chat_history_path_on_project(tmp_path: Path):
 def test_get_chat_history_dir(tmp_path: Path):
     project = _make_project(tmp_path)
     assert get_chat_history_dir(project) == tmp_path / "history" / "chat-history"
+
+
+def test_code_block_masking_ignores_speaker_labels_inside_fences():
+    """Speaker labels inside fenced code blocks must not split the message."""
+    masked, replacements = _mask_code_blocks(
+        "```\n**You:** example\n**Assistant:** reply\n```"
+    )
+    assert "**You:**" not in masked
+    assert "**Assistant:**" not in masked
+    assert len(replacements) == 1
+
+
+def test_parse_markdown_code_block_not_split(tmp_path: Path):
+    """A message containing a fenced code block with speaker labels is parsed intact."""
+    content_with_block = (
+        "**You:**\nHow do I greet someone?\n\n"
+        "**Assistant:**\nHere is an example:\n\n```\n**You:** Hello!\n**Assistant:** Hi!\n```\n\n"
+        '---\nid: test-id-0001\ntitle: "test"\ncreated_at: 2026-01-01T00:00:00+00:00\n'
+        "updated_at: 2026-01-01T00:00:00+00:00\nprovider: anthropic\nmodel: m\nagent: null\n"
+        "message_count: 2\n---\n"
+    )
+    meta, messages = _parse_markdown(content_with_block)
+    assert len(messages) == 2
+    assert messages[1]["role"] == "assistant"
+    assert "```" in messages[1]["content"]
+    assert "**You:** Hello!" in messages[1]["content"]
+
+
+def test_index_file_created_on_save(tmp_path: Path):
+    project = _make_project(tmp_path)
+    session = _make_session()
+    save_session(project, session, None, None, "anthropic", "model", None)
+
+    chat_dir = get_chat_history_dir(project)
+    assert (chat_dir / "_index.json").exists()
+
+
+def test_index_entry_removed_on_delete(tmp_path: Path):
+    import json
+
+    project = _make_project(tmp_path)
+    session = _make_session()
+    sid = save_session(project, session, None, None, "anthropic", "model", None)
+    delete_session(project, sid)
+
+    chat_dir = get_chat_history_dir(project)
+    index = json.loads((chat_dir / "_index.json").read_text())
+    assert sid not in index
+
+
+def test_rebuild_index_finds_existing_files(tmp_path: Path):
+    project = _make_project(tmp_path)
+    session = _make_session()
+    sid = save_session(project, session, None, None, "anthropic", "model", None)
+
+    # Delete the index to simulate a missing/stale index
+    chat_dir = get_chat_history_dir(project)
+    (chat_dir / "_index.json").unlink()
+
+    # load_session should still work by rebuilding the index
+    loaded = load_session(project, sid)
+    assert loaded.id == sid
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_chat_history.py
+++ b/tests/test_chat_history.py
@@ -43,11 +43,11 @@ def test_auto_title_uses_first_user_message():
     assert auto_title(msgs) == "What is the capital of France?"
 
 
-def test_auto_title_truncates_at_60_chars():
+def test_auto_title_truncates_at_40_chars():
     long_msg = "A" * 80
     result = auto_title([{"role": "user", "content": long_msg}])
-    assert result == "A" * 60 + "…"
-    assert len(result) == 61  # 60 chars + ellipsis (U+2026, 1 code point)
+    assert result == "A" * 40 + "…"
+    assert len(result) == 41  # 40 chars + ellipsis (U+2026, 1 code point)
 
 
 def test_auto_title_skips_non_user_messages():

--- a/tests/test_chat_history.py
+++ b/tests/test_chat_history.py
@@ -13,11 +13,13 @@ from santai_cli.core.chat_history import (
     delete_session,
     generate_session_id,
     get_chat_history_dir,
+    hide_session,
     list_sessions,
     load_session,
     rename_session,
     restore_chat_session,
     save_session,
+    unhide_session,
 )
 from santai_cli.core.project import SantaiProject
 
@@ -297,6 +299,53 @@ def test_rename_session_same_sanitized_name_updates_in_place(tmp_path: Path):
     files = list(chat_dir.glob("*.md"))
     assert len(files) == 1
     assert files[0].name == original_name
+
+
+def test_hide_session_excludes_from_list(tmp_path: Path):
+    project = _make_project(tmp_path)
+    s1 = _make_session("question one")
+    s2 = _make_session("question two")
+    sid1 = save_session(project, s1, None, "Chat 1", "anthropic", "model", None)
+    sid2 = save_session(project, s2, None, "Chat 2", "anthropic", "model", None)
+
+    hide_session(project, sid1)
+
+    visible = list_sessions(project)
+    ids = [s.id for s in visible]
+    assert sid1 not in ids
+    assert sid2 in ids
+
+    # File still exists on disk
+    chat_dir = get_chat_history_dir(project)
+    assert len(list(chat_dir.glob("*.md"))) == 2
+
+
+def test_unhide_session_restores_to_list(tmp_path: Path):
+    project = _make_project(tmp_path)
+    session = _make_session()
+    sid = save_session(project, session, None, None, "anthropic", "model", None)
+
+    hide_session(project, sid)
+    assert all(s.id != sid for s in list_sessions(project))
+
+    unhide_session(project, sid)
+    assert any(s.id == sid for s in list_sessions(project))
+
+
+def test_delete_session_cleans_hidden_set(tmp_path: Path):
+    project = _make_project(tmp_path)
+    session = _make_session()
+    sid = save_session(project, session, None, None, "anthropic", "model", None)
+
+    hide_session(project, sid)
+    delete_session(project, sid)
+
+    # After real delete, hidden set should no longer contain the id
+    chat_dir = get_chat_history_dir(project)
+    import json
+
+    hidden = set(json.loads((chat_dir / "_hidden.json").read_text()))
+    assert sid not in hidden
 
 
 def test_rebuild_index_finds_existing_files(tmp_path: Path):

--- a/uv.lock
+++ b/uv.lock
@@ -228,6 +228,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "jinja2"
 version = "3.1.6"
 source = { registry = "https://pypi.org/simple" }
@@ -456,12 +465,30 @@ wheels = [
 ]
 
 [[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
 name = "platformdirs"
 version = "4.9.6"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9f/4a/0883b8e3802965322523f0b200ecf33d31f10991d0401162f4b23c698b42/platformdirs-4.9.6.tar.gz", hash = "sha256:3bfa75b0ad0db84096ae777218481852c0ebc6c727b3168c1b9e0118e458cf0a", size = 29400, upload-time = "2026-04-09T00:04:10.812Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/75/a6/a0a304dc33b49145b21f4808d763822111e67d1c3a32b524a1baf947b6e1/platformdirs-4.9.6-py3-none-any.whl", hash = "sha256:e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917", size = 21348, upload-time = "2026-04-09T00:04:09.463Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
 ]
 
 [[package]]
@@ -576,6 +603,35 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/7c/d36d04db312ecf4298932ef77e6e4a9e8ad017906e24e34f0b0c361a2473/pytest_asyncio-1.4.0.tar.gz", hash = "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42", size = 58514, upload-time = "2026-05-26T09:56:04.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/e2/08a497ef684b88559c9cc5f4ad53a37e7b99e727094a86d6ea32536d5d3c/pytest_asyncio-1.4.0-py3-none-any.whl", hash = "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1", size = 16930, upload-time = "2026-05-26T09:56:02.576Z" },
+]
+
+[[package]]
 name = "python-discovery"
 version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
@@ -667,27 +723,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.15.13"
+version = "0.15.14"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/24/21/a7d5c126d5b557715ef81098f3db2fe20f622a039ff2e626af28d674ab80/ruff-0.15.13.tar.gz", hash = "sha256:f9d89f17f7ba7fb2ed42921f0df75da797a9a5d71bc39049e2c687cf2baf44b7", size = 4678180, upload-time = "2026-05-14T13:44:37.869Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/8a/8bce2894573e9dae6ff4d77fe34ad727d79b9e6238ad288c5638990d90f6/ruff-0.15.14.tar.gz", hash = "sha256:48e866b165be4a9bdbf310f7d3c9a07edef2fe8cd63ffeb4e00bb590506ebf9f", size = 4700910, upload-time = "2026-05-21T14:34:55.177Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c6/61/11d458dc6ac22504fd8e237b29dfd40504c7fbbcc8930402cfe51a8e63ed/ruff-0.15.13-py3-none-linux_armv6l.whl", hash = "sha256:444b580fc72fd6887e650acd3e575e18cdc79dbcf42fb4030b491057921f61f8", size = 10738279, upload-time = "2026-05-14T13:44:18.7Z" },
-    { url = "https://files.pythonhosted.org/packages/86/ca/caa871ee7be718c45256fada4e16a218ee3e33f0c4a46b729a60a24912e6/ruff-0.15.13-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:6590d009e7cb7ebf36f83dbdd44a3fa48a0994ff6f1cdc1b08006abe58f98dc7", size = 11124798, upload-time = "2026-05-14T13:44:06.427Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/19/43f5f2e568dddde567fc41f8471f9432c09563e19d3e617a48cfa52f8f0a/ruff-0.15.13-py3-none-macosx_11_0_arm64.whl", hash = "sha256:1c26d2f66163deeb6e08d8b39fbbe983ce3c71cea06a6d7591cfd1421793c629", size = 10460761, upload-time = "2026-05-14T13:44:04.375Z" },
-    { url = "https://files.pythonhosted.org/packages/99/df/cf938cd6de3003178f03ad7c1ea2a6c099468c03a35037985070b37e76be/ruff-0.15.13-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9dbd6f94b434f896308e4d57fb7bfde0d02b99f7a64b3bdab0fdfa6a864203a5", size = 10804451, upload-time = "2026-05-14T13:44:25.221Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/7d/5d0973129b154ded2225729169d7068f26b467760b146493fde138415f23/ruff-0.15.13-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bf3259f3be4d181bda591da5db2571aed6853c6a048157756448020bc6c5cd22", size = 10534285, upload-time = "2026-05-14T13:44:08.888Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/e3/6b999bbc66cd51e5f073842bc2a3995e99c5e0e72e16b15e7261f7abf57a/ruff-0.15.13-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ae9c17e5eb4430c154e76abc25d79a318190f5a997f38fb6b114416c5319ffc9", size = 11312063, upload-time = "2026-05-14T13:44:11.274Z" },
-    { url = "https://files.pythonhosted.org/packages/af/5a/642639e9f5db04f1e97fbd6e091c6fd20725bdf072fb114d00eefb9e6eb8/ruff-0.15.13-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2e2e39bff6c341f4b577a21b801326fab0b11847f48fcaa83f00a113c9b3cb55", size = 12183079, upload-time = "2026-05-14T13:44:01.634Z" },
-    { url = "https://files.pythonhosted.org/packages/19/4c/7585735f6b53b0f12de13618b2f7d250a844f018822efc899df2e7b8295f/ruff-0.15.13-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e8d9a8e08013542e94d3220bc5b62cc3e5ef87c5f74bff367d3fac14fab013e6", size = 11440833, upload-time = "2026-05-14T13:43:59.043Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/31/bf1a0803d077e679cfeee5f2f67290a0fa79c7385b5d9a8c17b9db2c48f0/ruff-0.15.13-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cc411dfebe5eebe55ce041c6ae080eb7668955e866daa2fbb16692a784f1c4ca", size = 11434486, upload-time = "2026-05-14T13:44:27.761Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/4e/62c9b999875d4f14db80f277c030578f5e249c9852d65b7ac7ad0b43c041/ruff-0.15.13-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:768494eb08b9cee54e2fd27969966f74db5a57f6eaa7a90fcb3306af34dfc4bd", size = 11385189, upload-time = "2026-05-14T13:44:13.704Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/89/7e959047a104df3eb12863447c110140191fc5b6c4f379ea2e803fcdb0e4/ruff-0.15.13-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:fb75f9a3a7e42ffe117d734494e6c5e5cb3565d66e12612cb63d0e572a41a5b6", size = 10781380, upload-time = "2026-05-14T13:43:56.734Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/52/5fd18f3b88cab63e88aa11516b3b4e1e5f720e5c330f8dbe5c26210f41f8/ruff-0.15.13-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:8cb74dd33bb2f6613faf7fc03b660053b5ac4f80e706d5788c6335e2a8048d51", size = 10540605, upload-time = "2026-05-14T13:44:20.748Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/e0/9e35f338990d3e41a82875ff7053ffe97541dae81c9d02143177f381d572/ruff-0.15.13-py3-none-musllinux_1_2_i686.whl", hash = "sha256:7ef823f817fcd191dc934e984be9cf4094f808effa16f2542ad8e821ba02bbf2", size = 11036554, upload-time = "2026-05-14T13:44:16.256Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/13/070fb048c24080fba188f66371e2a92785be257ad02242066dc7255ac6e9/ruff-0.15.13-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:f345a13937bd7f09f6f5d19fa0721b0c103e00e7f62bc67089a8e5e037719e0b", size = 11528133, upload-time = "2026-05-14T13:44:22.808Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/8c/b1e1666aef7fc6555094d73ae6cd981701781ae85b97ceefc0eebd0b4668/ruff-0.15.13-py3-none-win32.whl", hash = "sha256:4044f94208b3b05ba0fc4a4abd0558cf4d6459bd18325eead7fd8cc66f909b41", size = 10721455, upload-time = "2026-05-14T13:44:35.697Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/a6/870a3e8a50590bb92be184ad928c2922f088b00d9dc5c5ec7b924ee08c22/ruff-0.15.13-py3-none-win_amd64.whl", hash = "sha256:7064884d442b7d477b4e7473d12da7f08851d2b1982763c5d3f388a19468a1a4", size = 11900409, upload-time = "2026-05-14T13:44:30.389Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/36/9c015cd052fca743dae8cb2aeb16b551444787467db42ceab0fc968865af/ruff-0.15.13-py3-none-win_arm64.whl", hash = "sha256:2471da9bd1068c8c064b5fd9c0c4b6dddffd6369cb1cd68b29993b1709ff1b21", size = 11179336, upload-time = "2026-05-14T13:44:33.026Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/c8/74a92c6ff9fcfb4f1f947126d3ebee8389276e161ecc85de5bda7cda51bd/ruff-0.15.14-py3-none-linux_armv6l.whl", hash = "sha256:8dd2db9416e487c8d4b01fa7056bb02c4d05969d4f8d17a08c229c2f4ff3c108", size = 10739177, upload-time = "2026-05-21T14:34:37.332Z" },
+    { url = "https://files.pythonhosted.org/packages/45/91/254a35c20acc38a7223c9d2d594af12e794432464f2cdeb52af1dc4a892d/ruff-0.15.14-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:be4ff55af755bd71a00ab3dc6bd7ffc467bd76e0df6881e286c2e3d23e8fb43b", size = 11144969, upload-time = "2026-05-21T14:34:43.978Z" },
+    { url = "https://files.pythonhosted.org/packages/56/9e/d13e40f83b8d0a94430e6778ce1d94a43b38cf2efe63278bdd2b4c65abbf/ruff-0.15.14-py3-none-macosx_11_0_arm64.whl", hash = "sha256:48d5909d7d06276ce7dde6d32bfa4b0d4cb2651145cd8ee4b440722cbc77832f", size = 10478207, upload-time = "2026-05-21T14:34:48.378Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/f1/b15a7839fa4f332f8acec78e20564f26bb2d866e3d21710b877fd0263000/ruff-0.15.14-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ca8cbfa94c4f90984a67561978602746d4cd27103568f745fa90eee3f0d4107d", size = 10818459, upload-time = "2026-05-21T14:34:22.318Z" },
+    { url = "https://files.pythonhosted.org/packages/45/33/53d651177f84f94b400a0e27f8824eeada3dddc9d5ee8aeb048f4352a520/ruff-0.15.14-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9a6bbc0333f1ab053423bcbf6226477d266ca7cec7738c4c8e3f55647803f3c4", size = 10541800, upload-time = "2026-05-21T14:34:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/a6/868f87e0bf9786ed24b5d0d0ad8676b8a94fd1912f42cddf9cfc7857818a/ruff-0.15.14-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8a24a4f7605d7003a6674d4387651effd939dead3fddd0f36561eb77a9a2e542", size = 11342149, upload-time = "2026-05-21T14:34:46.365Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/8b/38cd5c19faffdcc05a408d2b78edccc69492ab9720eadb49ea15ef80d768/ruff-0.15.14-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:049b5326e53ed80978f2fc041a280603f69dd6b0c95464342a2bb4572d9d9e2f", size = 12212563, upload-time = "2026-05-21T14:34:28.579Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/4d/a3c5b874a556d5731e3e657aaf04311bb76f0a5c3ec220ed43051be6b64b/ruff-0.15.14-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d4ed42e6696c8dfa5f06728e6441993901f548eb92d73bc472cb5a38d1395fbf", size = 11493299, upload-time = "2026-05-21T14:34:41.836Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/c0/56472c251d09858a53e51efbd485b09e1995d8731668b76d52e5dd6ee0f1/ruff-0.15.14-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:715c543cf450c4888251f91c52f1942a800541d9bddd7ac060aa4e6b77ae7cba", size = 11455931, upload-time = "2026-05-21T14:34:57.276Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/4a/e2e7b4d8dbf233d4eace59c75bc3435fa6d8bd3bae82d351d4e4300c0fd1/ruff-0.15.14-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:72ebab6013ec887d439d8b7593737a0a4ffb06d45d209d4e4bf2e92813082d3f", size = 11400794, upload-time = "2026-05-21T14:34:39.773Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c7/83c0539fe34c3e09136204d1e75d6052492364e0b3cb05e9465423f567d7/ruff-0.15.14-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:49072d36abdbe97a8dd7f480afe9c675699c0c495d4c84076e2c1203c4550581", size = 10804759, upload-time = "2026-05-21T14:34:31.045Z" },
+    { url = "https://files.pythonhosted.org/packages/86/a6/18f2bfc095a2ab4a78745644e428205532ce6653a5d0fa8501572891534d/ruff-0.15.14-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:958522aee105068640c2c2ceae08f413ae44d922f52a1374ac13d6a96032fc93", size = 10539517, upload-time = "2026-05-21T14:34:53.064Z" },
+    { url = "https://files.pythonhosted.org/packages/54/3a/5a8b3b69c654d4e4bf1d246ac5b49cbcdac6eaab6905925f8915f31e3b80/ruff-0.15.14-py3-none-musllinux_1_2_i686.whl", hash = "sha256:f3707da619a143a2e8830e2abab8224478d69ace2d28cb6c20543ae97c36bf61", size = 11065169, upload-time = "2026-05-21T14:34:24.484Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/c5/8864e4e7925b836ea354b31d57641ec03830564e281a8b6f061f8c3e0ec1/ruff-0.15.14-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:bb01d645694e3ec0102105d07ef2d53703970407d59c04e59d3ba0b7a1d53553", size = 11560214, upload-time = "2026-05-21T14:34:50.975Z" },
+    { url = "https://files.pythonhosted.org/packages/36/38/012bf76752e1f89ed50b77b99532d90f3a3e287bc7918e1fc0948ac866ac/ruff-0.15.14-py3-none-win32.whl", hash = "sha256:6d0c1ad2a0ab718d39b6d8fd2217981ce4d625cd96a720095f798fb47d8b13e6", size = 10805548, upload-time = "2026-05-21T14:34:33.453Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/b7/4ea2c170f10ad760fff2a5250beb18897719dc8b52b53a24cddbb9dd3f19/ruff-0.15.14-py3-none-win_amd64.whl", hash = "sha256:802342981e056db3851a7836e5b070f8f15f67d4a685ae2a6160939d364b2902", size = 11939523, upload-time = "2026-05-21T14:34:18.077Z" },
+    { url = "https://files.pythonhosted.org/packages/62/d5/bc97ff895ec35cf3925d4bd60f3b39d822f377a446906ec9bcc87405e59b/ruff-0.15.14-py3-none-win_arm64.whl", hash = "sha256:ff47b90a9ef6a40c9e2f3b479c1fb78531adf055b94c1eba0a7ba04b31951826", size = 11208607, upload-time = "2026-05-21T14:34:26.525Z" },
 ]
 
 [[package]]
@@ -710,7 +766,10 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "httpx" },
     { name = "pre-commit" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "ruff" },
     { name = "ty" },
 ]
@@ -732,8 +791,11 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "httpx", specifier = ">=0.27" },
     { name = "pre-commit", specifier = ">=3.5.0" },
-    { name = "ruff", specifier = "==0.15.13" },
+    { name = "pytest", specifier = ">=8.0" },
+    { name = "pytest-asyncio", specifier = ">=0.23" },
+    { name = "ruff", specifier = "==0.15.14" },
     { name = "ty", specifier = ">=0.0.31" },
 ]
 


### PR DESCRIPTION
### PR Summary

- Add chat history persistence with Markdown transcripts
- Saves chat sessions as Markdown files under history/chat-history/ so conversations survive page reloads. Sessions are resumable from both the history panel and the file preview, and the transcript files are first-class project files — visible in the file tree, notes preview, and knowledge graph.

What's included:
- Core persistence
  - _index.json provides O(1) session lookup by ID — no full directory scan on each request
  - _hidden.json tracks sessions removed from the panel (soft-delete), so the file is preserved

- History panel UX
  - Slide-in panel listing all sessions grouped by date (Today / Yesterday / This Week / Older), with live search
  - Rename (pencil) and remove (✕) buttons appear on hover, right-aligned and vertically level
  - Removing a session from the panel hides it (soft-delete); deleting the file from the file tree removes it for real
  - Resuming a session from file preview unhides it and makes it reappear in the panel
  - Clear button saves the current session before starting a new one (no more accidental overwrites)
  - Polling refreshes the list every 2.5 seconds

- Resume behavior
  - Restores full message history, model/provider, and agent
  - Injects a short system message with the last-active date so the model has temporal context
  
- Hidden file coverage
  - _index.json, _hidden.json, and rumdl.toml are filtered from the file tree, notes preview, recent files, and knowledge graph via a single _UI_HIDDEN_NAMES constant in project.py
  ---
###  Test Plan
<img width="1920" height="1050" alt="Screenshot 2026-05-28 at 10 17 02 AM" src="https://github.com/user-attachments/assets/093493c8-cef8-409e-af4a-7649af965307" />

  - [ ] New session — open a project, send a message; verify the transcript appears as a .md file under history/chat-history/ 
<img width="404" height="1041" alt="Screenshot 2026-05-28 at 10 17 50 AM" src="https://github.com/user-attachments/assets/8e0e7b1d-2734-4a56-9c97-099bf75bc5b0" />

  - [ ] Resume from panel — click a past session in the history panel; verify messages, model, agent, and title are restored
  - [ ] Resume from file preview — open a chat .md file in the file preview; click "Resume Chat"; verify session loads and the panel list refreshes
  - [ ] Resume unhides — remove a session from the panel (✕), then resume it via file preview; verify it reappears in the panel
  - [ ] Rename — click the pencil on a session title; change the name; verify the panel entry updates and the .md
  filename changes to match
  - [ ] Clear = New Chat — mid-session, press Clear; verify the old session file is saved intact and a new blank session starts 
  - [ ] Hide vs delete — Delete a chat file from history/chat-history in the file tree; verify the session disappears from the panel
  - [ ] Search — type in the panel search box; verify results filter by title in real time
  - [ ] Hidden files — confirm _index.json, _hidden.json, and rumdl.toml do not appear in the file tree, notes preview, recent files list, or knowledge graph