### PR TITLE
feat: add selection modal to "Pull from Cloud" 

### DIFF
--- a/src/santai_cli/commands/push.py
+++ b/src/santai_cli/commands/push.py
@@ -34,7 +34,7 @@ MAX_UPLOAD_BYTES = 50 * 1024 * 1024
 
 def _should_include(path: Path, ignored_files: set[str]) -> bool:
     return (
-        not any(part in IGNORED_DIRECTORIES for part in path.parts)
+        not any(part in IGNORED_DIRECTORIES or part == ".santai" for part in path.parts)
         and path.name not in ignored_files
     )
 

--- a/src/santai_cli/commands/push.py
+++ b/src/santai_cli/commands/push.py
@@ -122,7 +122,10 @@ def push(
                 rel_str = str(rel)
                 curr_paths.add(rel_str)
                 zf.write(file_path, rel)
-                if file_path.suffix.lower() not in IMAGE_EXTENSIONS:
+                if (
+                    file_path.suffix.lower() not in IMAGE_EXTENSIONS
+                    and file_path.stat().st_size <= 1_000_000
+                ):
                     try:
                         curr_text[rel_str] = file_path.read_text(errors="replace")
                     except Exception:

--- a/src/santai_cli/commands/push.py
+++ b/src/santai_cli/commands/push.py
@@ -16,10 +16,16 @@ from santai_cli.commands.auth import DEFAULT_HUB_URL, load_credentials
 from santai_cli.core.hub import (
     USER_AGENT,
     create_base,
+    fetch_prev_files,
     get_backend_url,
+    make_diff_title,
     resolve_base_id,
 )
-from santai_cli.core.project import IGNORED_DIRECTORIES, SENSITIVE_FILES
+from santai_cli.core.project import (
+    IGNORED_DIRECTORIES,
+    IMAGE_EXTENSIONS,
+    SENSITIVE_FILES,
+)
 
 console = Console()
 
@@ -92,12 +98,20 @@ def push(
             console.print(f"[red]Failed to create project '{project_name}'.[/red]")
             raise typer.Exit(1)
 
+    # Fetch previous save for diff title generation
+    prev_paths, prev_text = fetch_prev_files(
+        backend, creds["token"], base_id, IMAGE_EXTENSIONS
+    )
+
     console.print(f"Packaging [bold]{project_name}[/bold]...")
 
     with tempfile.NamedTemporaryFile(suffix=".zip", delete=False) as tmp:
         tmp_path = Path(tmp.name)
 
     try:
+        curr_paths: set[str] = set()
+        curr_text: dict[str, str] = {}
+
         with zipfile.ZipFile(tmp_path, "w", zipfile.ZIP_DEFLATED) as zf:
             for file_path in sorted(project_dir.rglob("*")):
                 if not file_path.is_file():
@@ -105,7 +119,14 @@ def push(
                 rel = file_path.relative_to(project_dir)
                 if not _should_include(rel, ignored_files):
                     continue
+                rel_str = str(rel)
+                curr_paths.add(rel_str)
                 zf.write(file_path, rel)
+                if file_path.suffix.lower() not in IMAGE_EXTENSIONS:
+                    try:
+                        curr_text[rel_str] = file_path.read_text(errors="replace")
+                    except Exception:
+                        curr_text[rel_str] = ""
 
         zip_size = tmp_path.stat().st_size
 
@@ -119,11 +140,25 @@ def push(
         console.print(f"  Archive size: {_format_size(zip_size)}")
         console.print("Uploading...")
 
+        diff = make_diff_title(prev_paths, curr_paths, prev_text, curr_text)
+        n = len(curr_paths)
+        _snap = f"Snapshot · {n} file{'s' if n != 1 else ''}"
+        push_title = diff if diff else ("Initial push" if not prev_paths else _snap)
+
         zip_bytes = tmp_path.read_bytes()
 
         boundary = "----SantaiUploadBoundary"
         body_parts: list[bytes] = []
 
+        def _field(field_name: str, value: str) -> list[bytes]:
+            return [
+                f"--{boundary}\r\n".encode(),
+                f'Content-Disposition: form-data; name="{field_name}"\r\n\r\n'.encode(),
+                value.encode(),
+                b"\r\n",
+            ]
+
+        body_parts.extend(_field("title", push_title))
         body_parts.append(f"--{boundary}\r\n".encode())
         filename = f"{quote(project_name)}.zip"
         body_parts.append(
@@ -133,7 +168,6 @@ def push(
         body_parts.append(b"Content-Type: application/zip\r\n\r\n")
         body_parts.append(zip_bytes)
         body_parts.append(b"\r\n")
-
         body_parts.append(f"--{boundary}--\r\n".encode())
 
         body = b"".join(body_parts)

--- a/src/santai_cli/core/hub.py
+++ b/src/santai_cli/core/hub.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 
@@ -74,6 +75,7 @@ def fetch_prev_files(
         if not latest_key:
             return set(), {}
     except Exception:
+        logging.debug("fetch_prev_files: failed to fetch saves list", exc_info=True)
         return set(), {}
 
     # 2. Load file content for that save
@@ -97,6 +99,7 @@ def fetch_prev_files(
         }
         return all_paths, text_content
     except Exception:
+        logging.debug("fetch_prev_files: failed to load file content", exc_info=True)
         return set(), {}
 
 

--- a/src/santai_cli/core/hub.py
+++ b/src/santai_cli/core/hub.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
 
 try:
     _CLI_VERSION = version("santai-cli")
@@ -42,6 +43,91 @@ def create_base(backend: str, token: str, name: str) -> str | None:
             return str(data["id"]) if "id" in data else None
     except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError):
         return None
+
+
+def fetch_prev_files(
+    backend: str, token: str, base_id: str, image_exts: set[str]
+) -> tuple[set[str], dict[str, str]]:
+    """Return (all_paths, text_content) from the latest cloud save for diffing.
+
+    Falls back to empty sets/dicts on any error so callers can treat it as
+    'no previous save' without crashing.
+    """
+    import urllib.error
+    import urllib.request
+
+    auth = {"Authorization": f"Bearer {token}", "User-Agent": USER_AGENT}
+
+    # 1. Get the latest save key from the cloud-saves list
+    try:
+        saves_req = urllib.request.Request(
+            f"{backend}/ai/edit/cloud-saves/{base_id}", headers=auth
+        )
+        with urllib.request.urlopen(saves_req, timeout=15) as resp:
+            data = json.loads(resp.read())
+        saves = (
+            data if isinstance(data, list) else data.get("saves", data.get("data", []))
+        )
+        if not saves:
+            return set(), {}
+        latest_key = saves[0].get("key")
+        if not latest_key:
+            return set(), {}
+    except Exception:
+        return set(), {}
+
+    # 2. Load file content for that save
+    try:
+        load_req = urllib.request.Request(
+            f"{backend}/ai/edit/load-from-cloud",
+            data=json.dumps({"manifestKey": latest_key}).encode(),
+            method="POST",
+            headers={**auth, "Content-Type": "application/json"},
+        )
+        with urllib.request.urlopen(load_req, timeout=60) as resp:
+            result = json.loads(resp.read())
+        if not result.get("success"):
+            return set(), {}
+        files: list = result.get("files", [])
+        all_paths = {f["path"] for f in files if f.get("path")}
+        text_content = {
+            f["path"]: f.get("content", "")
+            for f in files
+            if f.get("path") and Path(f["path"]).suffix.lower() not in image_exts
+        }
+        return all_paths, text_content
+    except Exception:
+        return set(), {}
+
+
+def make_diff_title(
+    prev_paths: set[str],
+    curr_paths: set[str],
+    prev_text: dict[str, str],
+    curr_text: dict[str, str],
+) -> str:
+    """Generate a human-readable summary of what changed between two file snapshots."""
+    added = sorted(curr_paths - prev_paths)
+    deleted = sorted(prev_paths - curr_paths)
+    modified = sorted(
+        p
+        for p in curr_paths & prev_paths
+        if p in prev_text and p in curr_text and curr_text[p] != prev_text[p]
+    )
+
+    def _fmt(verb: str, names: list) -> str:
+        if not names:
+            return ""
+        label = Path(names[0]).name
+        rest = len(names) - 1
+        return f"{verb} {label}" if not rest else f"{verb} {label} and {rest} more"
+
+    parts = [
+        s
+        for s in [_fmt("Add", added), _fmt("Update", modified), _fmt("Delete", deleted)]
+        if s
+    ]
+    return ", ".join(parts)
 
 
 def resolve_base_id(backend: str, token: str, name: str, username: str) -> str | None:

--- a/src/santai_cli/core/hub.py
+++ b/src/santai_cli/core/hub.py
@@ -115,19 +115,18 @@ def make_diff_title(
         if p in prev_text and p in curr_text and curr_text[p] != prev_text[p]
     )
 
-    def _fmt(verb: str, names: list) -> str:
-        if not names:
-            return ""
-        label = Path(names[0]).name
-        rest = len(names) - 1
-        return f"{verb} {label}" if not rest else f"{verb} {label} and {rest} more"
-
-    parts = [
-        s
-        for s in [_fmt("Add", added), _fmt("Update", modified), _fmt("Delete", deleted)]
-        if s
-    ]
-    return ", ".join(parts)
+    # Flatten all changes; headline is the first, the rest become "and N more".
+    all_changes = (
+        [("Add", p) for p in added]
+        + [("Update", p) for p in modified]
+        + [("Delete", p) for p in deleted]
+    )
+    if not all_changes:
+        return ""
+    verb, first = all_changes[0]
+    label = Path(first).name
+    rest = len(all_changes) - 1
+    return f"{verb} {label}" if not rest else f"{verb} {label} and {rest} more"
 
 
 def resolve_base_id(backend: str, token: str, name: str, username: str) -> str | None:

--- a/src/santai_cli/core/hub.py
+++ b/src/santai_cli/core/hub.py
@@ -14,6 +14,46 @@ except PackageNotFoundError:
 
 USER_AGENT = f"santai-cli/{_CLI_VERSION}"
 
+# Directories that hold user-created content — prefer these as the headline file.
+_CONTENT_DIRS: frozenset[str] = frozenset({"media", "notes"})
+
+# Boilerplate filenames that should never be the headline even when added.
+_SCAFFOLD_NAMES: frozenset[str] = frozenset(
+    {
+        ".env.example",
+        ".gitignore",
+        ".eslintrc",
+        ".prettierrc",
+        ".editorconfig",
+        "requirements.txt",
+        "requirements-dev.txt",
+        "package.json",
+        "package-lock.json",
+        "yarn.lock",
+        "makefile",
+        "dockerfile",
+        "docker-compose.yml",
+        "docker-compose.yaml",
+        "setup.py",
+        "pyproject.toml",
+        "setup.cfg",
+        "tsconfig.json",
+        "vite.config.js",
+        "vite.config.ts",
+        "claude.md",
+    }
+)
+
+
+def _headline_sort_key(path_str: str) -> tuple[int, int, str]:
+    """Sort key that surfaces user content files before scaffolding/dotfiles."""
+    p = Path(path_str)
+    name_lower = p.name.lower()
+    in_content_dir = bool(p.parts) and p.parts[0] in _CONTENT_DIRS
+    is_low_priority = name_lower.startswith(".") or name_lower in _SCAFFOLD_NAMES
+    tier = 0 if in_content_dir else (2 if is_low_priority else 1)
+    return (tier, len(p.parts), name_lower)
+
 
 def get_backend_url(hub_url: str) -> str:
     if ":3000" in hub_url:
@@ -110,12 +150,15 @@ def make_diff_title(
     curr_text: dict[str, str],
 ) -> str:
     """Generate a human-readable summary of what changed between two file snapshots."""
-    added = sorted(curr_paths - prev_paths)
-    deleted = sorted(prev_paths - curr_paths)
+    added = sorted(curr_paths - prev_paths, key=_headline_sort_key)
+    deleted = sorted(prev_paths - curr_paths, key=_headline_sort_key)
     modified = sorted(
-        p
-        for p in curr_paths & prev_paths
-        if p in prev_text and p in curr_text and curr_text[p] != prev_text[p]
+        (
+            p
+            for p in curr_paths & prev_paths
+            if p in prev_text and p in curr_text and curr_text[p] != prev_text[p]
+        ),
+        key=_headline_sort_key,
     )
 
     # Flatten all changes; headline is the first, the rest become "and N more".

--- a/src/santai_cli/core/project.py
+++ b/src/santai_cli/core/project.py
@@ -43,6 +43,16 @@ SENSITIVE_FILES: set[str] = {
     "credentials.json",
 }
 
+IMAGE_EXTENSIONS: set[str] = {
+    ".png",
+    ".jpg",
+    ".jpeg",
+    ".gif",
+    ".webp",
+    ".bmp",
+    ".ico",
+}
+
 
 def validate_santai_structure(path: Path) -> list[str]:
     """Return a list of missing SANTAI_DIRS in the given path.

--- a/src/santai_cli/web/app.py
+++ b/src/santai_cli/web/app.py
@@ -139,7 +139,7 @@ def _save_push_title(root: Path, version: object, title: str) -> None:
     import json as _json
 
     path = root / ".santai" / "push-titles.json"
-    path.parent.mkdir(exist_ok=True)
+    path.parent.mkdir(parents=True, exist_ok=True)
     try:
         existing: dict = _json.loads(path.read_text()) if path.exists() else {}
         existing[str(version)] = title
@@ -2097,15 +2097,18 @@ def create_app(project: SantaiProject) -> FastAPI:
                                 plan.append((member, target))
                             preserved = _clear_and_preserve()
                             count = 0
-                            for member, target in plan:
-                                target.parent.mkdir(parents=True, exist_ok=True)
-                                raw = zf.read(member)
-                                if target.suffix.lower() in _CLOUD_IMAGE_EXTS:
-                                    raw = _decode_data_url(raw)
-                                target.write_bytes(raw)
-                                count += 1
-                            for p, data in preserved.items():
-                                p.write_bytes(data)
+                            try:
+                                for member, target in plan:
+                                    target.parent.mkdir(parents=True, exist_ok=True)
+                                    raw = zf.read(member)
+                                    if target.suffix.lower() in _CLOUD_IMAGE_EXTS:
+                                        raw = _decode_data_url(raw)
+                                    target.write_bytes(raw)
+                                    count += 1
+                                for p, data in preserved.items():
+                                    p.write_bytes(data)
+                            except OSError as exc:
+                                return f"Failed to write files: {exc}", count
                         return None, count
                     except zipfile.BadZipFile:
                         return "Downloaded file is not a valid zip.", 0
@@ -2168,32 +2171,35 @@ def create_app(project: SantaiProject) -> FastAPI:
 
                         def apply_files(files: list) -> "str | None":
                             preserved = _clear_and_preserve()
-                            for file_obj in files:
-                                path_str = file_obj.get("path", "")
-                                if not path_str:
-                                    continue
-                                target = (dest_path / path_str).resolve()
-                                try:
-                                    target.relative_to(dest_path)
-                                except ValueError:
-                                    return f"Unsafe path '{path_str}'."
-                                target.parent.mkdir(parents=True, exist_ok=True)
-                                content = file_obj.get("content", "")
-                                if target.suffix.lower() in _CLOUD_IMAGE_EXTS:
-                                    raw = _decode_data_url(
-                                        content.encode()
-                                        if isinstance(content, str)
-                                        else content
-                                    )
-                                else:
-                                    raw = (
-                                        content.encode()
-                                        if isinstance(content, str)
-                                        else content
-                                    )
-                                target.write_bytes(raw)
-                            for p, data in preserved.items():
-                                p.write_bytes(data)
+                            try:
+                                for file_obj in files:
+                                    path_str = file_obj.get("path", "")
+                                    if not path_str:
+                                        continue
+                                    target = (dest_path / path_str).resolve()
+                                    try:
+                                        target.relative_to(dest_path)
+                                    except ValueError:
+                                        return f"Unsafe path '{path_str}'."
+                                    target.parent.mkdir(parents=True, exist_ok=True)
+                                    content = file_obj.get("content", "")
+                                    if target.suffix.lower() in _CLOUD_IMAGE_EXTS:
+                                        raw = _decode_data_url(
+                                            content.encode()
+                                            if isinstance(content, str)
+                                            else content
+                                        )
+                                    else:
+                                        raw = (
+                                            content.encode()
+                                            if isinstance(content, str)
+                                            else content
+                                        )
+                                    target.write_bytes(raw)
+                                for p, data in preserved.items():
+                                    p.write_bytes(data)
+                            except OSError as exc:
+                                return f"Failed to write files: {exc}"
                             return None
 
                         apply_err = await asyncio.to_thread(apply_files, files_data)

--- a/src/santai_cli/web/app.py
+++ b/src/santai_cli/web/app.py
@@ -1770,12 +1770,13 @@ def create_app(project: SantaiProject) -> FastAPI:
 
                 yield _sse({"type": "status", "message": "Packaging..."})
 
-                def build_zip() -> bytes | str:
+                def build_zip() -> "tuple[bytes, int] | str":
                     import tempfile as _tmp
 
                     with _tmp.NamedTemporaryFile(suffix=".zip", delete=False) as tmp:
                         tmp_path = Path(tmp.name)
                     try:
+                        file_count = 0
                         with zipfile.ZipFile(tmp_path, "w", zipfile.ZIP_DEFLATED) as zf:
                             for fp in sorted(project.root.rglob("*")):
                                 if not fp.is_file():
@@ -1791,13 +1792,14 @@ def create_app(project: SantaiProject) -> FastAPI:
                                     zf.writestr(str(rel), _encode_data_url(fp))
                                 else:
                                     zf.write(fp, rel)
+                                file_count += 1
                         size = tmp_path.stat().st_size
                         if size > _CLOUD_MAX_BYTES:
                             return (
                                 f"Archive is {format_size(size)}, "
                                 "exceeds the 50 MB limit."
                             )
-                        return tmp_path.read_bytes()
+                        return tmp_path.read_bytes(), file_count
                     finally:
                         tmp_path.unlink(missing_ok=True)
 
@@ -1806,7 +1808,8 @@ def create_app(project: SantaiProject) -> FastAPI:
                     yield _sse({"type": "error", "message": result})
                     return
 
-                zip_bytes: bytes = result
+                zip_bytes, _file_count = result
+                _push_title = f"Web snapshot · {_file_count} file{'s' if _file_count != 1 else ''}"
                 yield _sse(
                     {
                         "type": "status",
@@ -1814,14 +1817,23 @@ def create_app(project: SantaiProject) -> FastAPI:
                     }
                 )
 
-                def upload(data: bytes) -> dict | str:
+                def upload(data: bytes, title: str) -> dict | str:
                     boundary = "----SantaiWebUpload"
+
+                    def _field(name: str, value: str) -> bytes:
+                        return (
+                            f"--{boundary}\r\n"
+                            f'Content-Disposition: form-data; name="{name}"\r\n\r\n'
+                            f"{value}\r\n"
+                        ).encode()
+
                     disposition = (
                         f'Content-Disposition: form-data; name="file"; '
                         f'filename="{quote(project_name)}.zip"\r\n'
                     )
                     body = b"".join(
                         [
+                            _field("title", title),
                             f"--{boundary}\r\n".encode(),
                             disposition.encode(),
                             b"Content-Type: application/zip\r\n\r\n",
@@ -1858,7 +1870,7 @@ def create_app(project: SantaiProject) -> FastAPI:
                     except (urllib.error.URLError, TimeoutError):
                         return "Could not reach the hub. Check your connection."
 
-                upload_result = await asyncio.to_thread(upload, zip_bytes)
+                upload_result = await asyncio.to_thread(upload, zip_bytes, _push_title)
                 if isinstance(upload_result, str):
                     err_event: dict = {"type": "error", "message": upload_result}
                     if "login" in upload_result.lower():

--- a/src/santai_cli/web/app.py
+++ b/src/santai_cli/web/app.py
@@ -1906,7 +1906,11 @@ def create_app(project: SantaiProject) -> FastAPI:
                     return
 
                 yield _sse(
-                    {"type": "done", "version": upload_result.get("version", "?")}
+                    {
+                        "type": "done",
+                        "version": upload_result.get("version", "?"),
+                        "title": _push_title,
+                    }
                 )
             finally:
                 _cloud_push_lock.release()

--- a/src/santai_cli/web/app.py
+++ b/src/santai_cli/web/app.py
@@ -78,7 +78,7 @@ class CloudPushRequest(BaseModel):
 
 
 class CloudPullRequest(BaseModel):
-    pass
+    manifest_key: str | None = None
 
 
 class SmartPlaceRequest(BaseModel):
@@ -1521,6 +1521,74 @@ def create_app(project: SantaiProject) -> FastAPI:
 
     # === Cloud Push / Pull Endpoints ===
 
+    @app.get("/api/cloud/list-saves")
+    async def cloud_list_saves() -> dict[str, Any]:
+        """List available cloud save versions for the current project."""
+        import json as _json
+        import urllib.error
+        import urllib.request
+
+        from santai_cli.commands.auth import DEFAULT_HUB_URL, load_credentials
+        from santai_cli.core.hub import USER_AGENT, get_backend_url, resolve_base_id
+
+        creds = load_credentials()
+        if not creds:
+            return {"error": "Not logged in.", "saves": []}
+
+        hub_url = creds.get("hub_url", DEFAULT_HUB_URL)
+        backend = get_backend_url(hub_url)
+        project_name = project.root.name
+
+        base_id = await asyncio.to_thread(
+            resolve_base_id,
+            backend,
+            creds["token"],
+            project_name,
+            creds.get("username", ""),
+        )
+        if not base_id:
+            return {
+                "error": f"Project '{project_name}' not found in the cloud.",
+                "saves": [],
+            }
+
+        def fetch_versions() -> dict:
+            req = urllib.request.Request(
+                f"{backend}/ai/edit/cloud-saves/{base_id}",
+                headers={
+                    "Authorization": f"Bearer {creds['token']}",
+                    "User-Agent": USER_AGENT,
+                },
+            )
+            try:
+                with urllib.request.urlopen(req, timeout=15) as resp:
+                    data = _json.loads(resp.read())
+                saves: list = (
+                    data
+                    if isinstance(data, list)
+                    else data.get("saves", data.get("data", []))
+                )
+                return {"saves": saves, "base_id": base_id}
+            except urllib.error.HTTPError as e:
+                try:
+                    raw = e.read().decode(errors="replace")
+                except Exception:
+                    raw = ""
+                return {
+                    "error": (
+                        f"Could not fetch saves (HTTP {e.code}): "
+                        f"{raw.strip()[:200] or 'no details'}"
+                    ),
+                    "saves": [],
+                }
+            except (urllib.error.URLError, TimeoutError):
+                return {
+                    "error": "Could not reach the hub. Check your connection.",
+                    "saves": [],
+                }
+
+        return await asyncio.to_thread(fetch_versions)
+
     _CLOUD_IGNORED_DIRS = {
         ".git",
         ".ruff_cache",
@@ -1577,14 +1645,23 @@ def create_app(project: SantaiProject) -> FastAPI:
             if e.code == 403:
                 return "Access denied. Check your account permissions."
             try:
-                body = _json.loads(e.read().decode(errors="replace"))
+                raw = e.read().decode(errors="replace")
+            except Exception:
+                return f"Server error {e.code}."
+            try:
+                body = _json.loads(raw)
+                detail = body.get("detail")
+                if isinstance(detail, list) and detail:
+                    detail = detail[0].get("msg") or str(detail[0])
                 return (
                     body.get("error")
                     or body.get("message")
+                    or (str(detail) if detail else None)
+                    or raw.strip()[:300]
                     or f"Server error {e.code}."
                 )
             except Exception:
-                return f"Server error {e.code}."
+                return raw.strip()[:300] or f"Server error {e.code}."
 
         def _resolve_or_create(
             backend: str, token: str, name: str, hub_url: str, username: str
@@ -1627,12 +1704,19 @@ def create_app(project: SantaiProject) -> FastAPI:
                         return str(data["id"]), None, None
                     return None, f"Unexpected response creating '{name}'.", None
             except urllib.error.HTTPError as e:
-                login_url = hub_url if e.code in (401, 403) else None
-                return (
-                    None,
-                    f"Could not create '{name}': {_http_error_msg(e)}",
-                    login_url,
+                msg = _http_error_msg(e)
+                _auth_codes = (401, 403)
+                _auth_phrases = ("sign", "not logged in", "unauthorized")
+                is_auth_err = e.code in _auth_codes or any(
+                    p in msg.lower() for p in _auth_phrases
                 )
+                if is_auth_err:
+                    return (
+                        None,
+                        "Session expired. Run 'santai login' to re-authenticate.",
+                        hub_url,
+                    )
+                return (None, f"Could not create '{name}': {msg}", None)
             except (urllib.error.URLError, TimeoutError):
                 return None, "Could not reach the hub. Check your connection.", None
 
@@ -1860,139 +1944,224 @@ def create_app(project: SantaiProject) -> FastAPI:
                     )
                     return
 
-                def get_download_info() -> "dict | str":
-                    info_req = urllib.request.Request(
-                        f"{backend}/bases/{base_id}/download",
-                        headers={
-                            "Authorization": f"Bearer {creds['token']}",
-                            "User-Agent": USER_AGENT,
-                        },
-                    )
-                    try:
-                        with urllib.request.urlopen(info_req, timeout=15) as resp:
-                            return _json.loads(resp.read())
-                    except urllib.error.HTTPError as e:
-                        if e.code == 401:
-                            return (
-                                "Session expired. Run 'santai login' "
-                                "to re-authenticate."
-                            )
-                        if e.code == 404:
-                            return f"Project '{project_name}' not found."
-                        return f"Pull failed (HTTP {e.code})."
-                    except (urllib.error.URLError, TimeoutError):
-                        return "Could not reach the hub. Check your connection."
+                def _clear_and_preserve() -> "dict[Path, bytes]":
+                    """Clear user files, return preserved sensitive file bytes."""
+                    preserved: dict[Path, bytes] = {}
+                    for fname in _CLOUD_SENSITIVE:
+                        p = dest_path / fname
+                        if p.is_file():
+                            preserved[p] = p.read_bytes()
+                    for item in dest_path.iterdir():
+                        if (
+                            item.name.startswith(".")
+                            or item.name in _CLOUD_IGNORED_DIRS
+                        ):
+                            continue
+                        if item.is_dir():
+                            shutil.rmtree(item)
+                        else:
+                            item.unlink()
+                    return preserved
 
-                info = await asyncio.to_thread(get_download_info)
-                if isinstance(info, str):
-                    pull_err: dict = {"type": "error", "message": info}
-                    if "login" in info.lower():
-                        pull_err["login_url"] = hub_url
-                    yield _sse(pull_err)
-                    return
+                if req.manifest_key:
+                    # Versioned pull: fetch file contents from hub
+                    def load_from_cloud() -> "dict | str":
+                        load_req = urllib.request.Request(
+                            f"{backend}/ai/edit/load-from-cloud",
+                            data=_json.dumps(
+                                {"manifestKey": req.manifest_key}
+                            ).encode(),
+                            method="POST",
+                            headers={
+                                "Authorization": f"Bearer {creds['token']}",
+                                "Content-Type": "application/json",
+                                "User-Agent": USER_AGENT,
+                            },
+                        )
+                        try:
+                            with urllib.request.urlopen(load_req, timeout=60) as resp:
+                                return _json.loads(resp.read())
+                        except urllib.error.HTTPError as e:
+                            if e.code == 401:
+                                return (
+                                    "Session expired. Run 'santai login' "
+                                    "to re-authenticate."
+                                )
+                            return f"Load failed (HTTP {e.code})."
+                        except (urllib.error.URLError, TimeoutError):
+                            return "Could not reach the hub. Check your connection."
 
-                download_url = info.get("downloadUrl")
-                if not download_url:
-                    yield _sse(
-                        {"type": "error", "message": "No download URL received."}
-                    )
-                    return
-                if not download_url.startswith(("https://", "http://")):
+                    yield _sse({"type": "status", "message": "Loading save..."})
+                    load_result = await asyncio.to_thread(load_from_cloud)
+                    if isinstance(load_result, str):
+                        load_err: dict = {"type": "error", "message": load_result}
+                        if "login" in load_result.lower():
+                            load_err["login_url"] = hub_url
+                        yield _sse(load_err)
+                        return
+                    if not load_result.get("success"):
+                        yield _sse({"type": "error", "message": "Failed to load save."})
+                        return
+
+                    files_data: list = load_result.get("files", [])
                     yield _sse(
                         {
-                            "type": "error",
-                            "message": "Download URL has unexpected scheme.",
+                            "type": "status",
+                            "message": f"Applying {len(files_data)} files...",
                         }
                     )
-                    return
 
-                size = info.get("size", 0)
-                yield _sse(
-                    {
-                        "type": "status",
-                        "message": f"Downloading ({format_size(size)})...",
-                    }
-                )
-
-                def download_and_extract() -> "str | None":
-                    import tempfile as _tmp
-
-                    with _tmp.NamedTemporaryFile(suffix=".zip", delete=False) as tmp:
-                        tmp_path = Path(tmp.name)
-                    try:
-                        dl_req = urllib.request.Request(download_url)
-                        with (
-                            urllib.request.urlopen(dl_req, timeout=120) as resp,
-                            open(tmp_path, "wb") as f,
-                        ):
-                            shutil.copyfileobj(resp, f)
-
-                        with zipfile.ZipFile(tmp_path, "r") as zf:
-                            # Build extraction plan: strip cloud wrapper
-                            # (manifest.json + files/ prefix)
-                            plan: list[tuple[zipfile.ZipInfo, Path]] = []
-                            for member in zf.infolist():
-                                name = member.filename
-                                if name == "manifest.json":
-                                    continue
-                                if name.startswith("files/"):
-                                    name = name[len("files/") :]
-                                # Skip directory entries and empty names
-                                if not name or name.endswith("/"):
-                                    continue
-                                target = (dest_path / name).resolve()
-                                try:
-                                    target.relative_to(dest_path)
-                                except ValueError:
-                                    return (
-                                        f"Zip contains unsafe path '{member.filename}'."
-                                    )
-                                if member.external_attr >> 28 == 0xA:
-                                    return f"Zip contains symlink '{member.filename}'."
-                                plan.append((member, target))
-                            # Preserve sensitive local files that are never pushed
-                            preserved: dict[Path, bytes] = {}
-                            for fname in _CLOUD_SENSITIVE:
-                                p = dest_path / fname
-                                if p.is_file():
-                                    preserved[p] = p.read_bytes()
-                            # Clear project files absent from the cloud archive.
-                            # Skip directories/files that are never pushed so
-                            # their local state is not destroyed (e.g. .git,
-                            # .venv, node_modules).
-                            for item in dest_path.iterdir():
-                                if (
-                                    item.name.startswith(".")
-                                    or item.name in _CLOUD_IGNORED_DIRS
-                                ):
-                                    continue
-                                if item.is_dir():
-                                    shutil.rmtree(item)
-                                else:
-                                    item.unlink()
-                            # Extract with cloud wrapper stripped
-                            for member, target in plan:
-                                target.parent.mkdir(parents=True, exist_ok=True)
-                                raw = zf.read(member)
-                                if target.suffix.lower() in _CLOUD_IMAGE_EXTS:
-                                    raw = _decode_data_url(raw)
-                                target.write_bytes(raw)
-                            # Restore preserved files
-                            for p, data in preserved.items():
-                                p.write_bytes(data)
+                    def apply_files(files: list) -> "str | None":
+                        preserved = _clear_and_preserve()
+                        for file_obj in files:
+                            path_str = file_obj.get("path", "")
+                            if not path_str:
+                                continue
+                            target = (dest_path / path_str).resolve()
+                            try:
+                                target.relative_to(dest_path)
+                            except ValueError:
+                                return f"Unsafe path '{path_str}'."
+                            target.parent.mkdir(parents=True, exist_ok=True)
+                            content = file_obj.get("content", "")
+                            if target.suffix.lower() in _CLOUD_IMAGE_EXTS:
+                                raw = _decode_data_url(
+                                    content.encode()
+                                    if isinstance(content, str)
+                                    else content
+                                )
+                            else:
+                                raw = (
+                                    content.encode()
+                                    if isinstance(content, str)
+                                    else content
+                                )
+                            target.write_bytes(raw)
+                        for p, data in preserved.items():
+                            p.write_bytes(data)
                         return None
-                    except zipfile.BadZipFile:
-                        return "Downloaded file is not a valid zip."
-                    except (urllib.error.URLError, TimeoutError):
-                        return "Download failed. The URL may have expired — try again."
-                    finally:
-                        tmp_path.unlink(missing_ok=True)
 
-                yield _sse({"type": "status", "message": "Extracting..."})
-                err = await asyncio.to_thread(download_and_extract)
-                if err:
-                    yield _sse({"type": "error", "message": err})
-                    return
+                    err = await asyncio.to_thread(apply_files, files_data)
+                    if err:
+                        yield _sse({"type": "error", "message": err})
+                        return
+
+                else:
+                    # Latest pull: download zip from hub
+                    def get_download_info() -> "dict | str":
+                        info_req = urllib.request.Request(
+                            f"{backend}/bases/{base_id}/download",
+                            headers={
+                                "Authorization": f"Bearer {creds['token']}",
+                                "User-Agent": USER_AGENT,
+                            },
+                        )
+                        try:
+                            with urllib.request.urlopen(info_req, timeout=15) as resp:
+                                return _json.loads(resp.read())
+                        except urllib.error.HTTPError as e:
+                            if e.code == 401:
+                                return (
+                                    "Session expired. Run 'santai login' "
+                                    "to re-authenticate."
+                                )
+                            if e.code == 404:
+                                return f"Project '{project_name}' not found."
+                            return f"Pull failed (HTTP {e.code})."
+                        except (urllib.error.URLError, TimeoutError):
+                            return "Could not reach the hub. Check your connection."
+
+                    info = await asyncio.to_thread(get_download_info)
+                    if isinstance(info, str):
+                        pull_err: dict = {"type": "error", "message": info}
+                        if "login" in info.lower():
+                            pull_err["login_url"] = hub_url
+                        yield _sse(pull_err)
+                        return
+
+                    download_url = info.get("downloadUrl")
+                    if not download_url:
+                        yield _sse(
+                            {"type": "error", "message": "No download URL received."}
+                        )
+                        return
+                    if not download_url.startswith(("https://", "http://")):
+                        yield _sse(
+                            {
+                                "type": "error",
+                                "message": "Download URL has unexpected scheme.",
+                            }
+                        )
+                        return
+
+                    size = info.get("size", 0)
+                    yield _sse(
+                        {
+                            "type": "status",
+                            "message": f"Downloading ({format_size(size)})...",
+                        }
+                    )
+
+                    def download_and_extract() -> "str | None":
+                        import tempfile as _tmp
+
+                        with _tmp.NamedTemporaryFile(
+                            suffix=".zip", delete=False
+                        ) as tmp:
+                            tmp_path = Path(tmp.name)
+                        try:
+                            dl_req = urllib.request.Request(download_url)
+                            with (
+                                urllib.request.urlopen(dl_req, timeout=120) as resp,
+                                open(tmp_path, "wb") as f,
+                            ):
+                                shutil.copyfileobj(resp, f)
+
+                            with zipfile.ZipFile(tmp_path, "r") as zf:
+                                plan: list[tuple[zipfile.ZipInfo, Path]] = []
+                                for member in zf.infolist():
+                                    name = member.filename
+                                    if name == "manifest.json":
+                                        continue
+                                    if name.startswith("files/"):
+                                        name = name[len("files/") :]
+                                    if not name or name.endswith("/"):
+                                        continue
+                                    target = (dest_path / name).resolve()
+                                    try:
+                                        target.relative_to(dest_path)
+                                    except ValueError:
+                                        return (
+                                            f"Zip contains unsafe path"
+                                            f" '{member.filename}'."
+                                        )
+                                    if member.external_attr >> 28 == 0xA:
+                                        return (
+                                            f"Zip contains symlink '{member.filename}'."
+                                        )
+                                    plan.append((member, target))
+                                preserved = _clear_and_preserve()
+                                for member, target in plan:
+                                    target.parent.mkdir(parents=True, exist_ok=True)
+                                    raw = zf.read(member)
+                                    if target.suffix.lower() in _CLOUD_IMAGE_EXTS:
+                                        raw = _decode_data_url(raw)
+                                    target.write_bytes(raw)
+                                for p, data in preserved.items():
+                                    p.write_bytes(data)
+                            return None
+                        except zipfile.BadZipFile:
+                            return "Downloaded file is not a valid zip."
+                        except (urllib.error.URLError, TimeoutError):
+                            return "Download failed. URL may have expired — try again."
+                        finally:
+                            tmp_path.unlink(missing_ok=True)
+
+                    yield _sse({"type": "status", "message": "Extracting..."})
+                    err = await asyncio.to_thread(download_and_extract)
+                    if err:
+                        yield _sse({"type": "error", "message": err})
+                        return
 
                 yield _sse({"type": "done", "pulled": True})
             finally:

--- a/src/santai_cli/web/app.py
+++ b/src/santai_cli/web/app.py
@@ -21,6 +21,7 @@ from santai_cli.core.project import (
     IMAGE_EXTENSIONS,
     MARKDOWN_LINK_PATTERN,
     SANTAI_FOLDER_DESCRIPTIONS,
+    SENSITIVE_FILES,
     WIKILINK_PATTERN,
     SantaiProject,
     get_directory_stats,
@@ -1622,7 +1623,7 @@ def create_app(project: SantaiProject) -> FastAPI:
         ".venv",
         "node_modules",
     }
-    _CLOUD_SENSITIVE = {".env", "credentials.json"}
+    _CLOUD_SENSITIVE = SENSITIVE_FILES
     _CLOUD_MAX_BYTES = 50 * 1024 * 1024
     _CLOUD_IMAGE_EXTS = IMAGE_EXTENSIONS
 

--- a/src/santai_cli/web/app.py
+++ b/src/santai_cli/web/app.py
@@ -1811,6 +1811,7 @@ def create_app(project: SantaiProject) -> FastAPI:
                     finally:
                         tmp_path.unlink(missing_ok=True)
 
+                assert base_id is not None
                 _prev_task = asyncio.to_thread(
                     fetch_prev_files,
                     backend,

--- a/src/santai_cli/web/app.py
+++ b/src/santai_cli/web/app.py
@@ -134,6 +134,20 @@ def format_size(size_bytes: int | float) -> str:
     return f"{size_bytes:.1f} TB"
 
 
+def _save_push_title(root: Path, version: object, title: str) -> None:
+    """Persist a computed push title to .santai/push-titles.json."""
+    import json as _json
+
+    path = root / ".santai" / "push-titles.json"
+    path.parent.mkdir(exist_ok=True)
+    try:
+        existing: dict = _json.loads(path.read_text()) if path.exists() else {}
+        existing[str(version)] = title
+        path.write_text(_json.dumps(existing, indent=2))
+    except Exception:
+        pass
+
+
 def format_time_ago(dt: datetime) -> str:
     """Format datetime as relative time (e.g., '2 hours ago')."""
     now = datetime.now()
@@ -1569,6 +1583,16 @@ def create_app(project: SantaiProject) -> FastAPI:
                     if isinstance(data, list)
                     else data.get("saves", data.get("data", []))
                 )
+                _titles_path = project.root / ".santai" / "push-titles.json"
+                if _titles_path.exists():
+                    try:
+                        _local = _json.loads(_titles_path.read_text())
+                        for _s in saves:
+                            _v = str(_s.get("version", ""))
+                            if _v in _local:
+                                _s["localTitle"] = _local[_v]
+                    except Exception:
+                        pass
                 return {"saves": saves, "base_id": base_id}
             except urllib.error.HTTPError as e:
                 try:
@@ -1783,7 +1807,8 @@ def create_app(project: SantaiProject) -> FastAPI:
                                     continue
                                 rel = fp.relative_to(project.root)
                                 if any(
-                                    part in _CLOUD_IGNORED_DIRS for part in rel.parts
+                                    part in _CLOUD_IGNORED_DIRS or part == ".santai"
+                                    for part in rel.parts
                                 ):
                                     continue
                                 if rel.name in ignored_files:
@@ -1906,10 +1931,12 @@ def create_app(project: SantaiProject) -> FastAPI:
                     yield _sse(err_event)
                     return
 
+                _pushed_version = upload_result.get("version", "?")
+                _save_push_title(project.root, _pushed_version, _push_title)
                 yield _sse(
                     {
                         "type": "done",
-                        "version": upload_result.get("version", "?"),
+                        "version": _pushed_version,
                         "title": _push_title,
                     }
                 )
@@ -2007,10 +2034,96 @@ def create_app(project: SantaiProject) -> FastAPI:
                             item.unlink()
                     return preserved
 
+                def _get_download_info(url: str) -> "dict | str":
+                    dl_req = urllib.request.Request(
+                        url,
+                        headers={
+                            "Authorization": f"Bearer {creds['token']}",
+                            "User-Agent": USER_AGENT,
+                        },
+                    )
+                    try:
+                        with urllib.request.urlopen(dl_req, timeout=15) as resp:
+                            return _json.loads(resp.read())
+                    except urllib.error.HTTPError as e:
+                        if e.code == 401:
+                            return (
+                                "Session expired. Run 'santai login' "
+                                "to re-authenticate."
+                            )
+                        if e.code == 404:
+                            return f"Project '{project_name}' not found."
+                        return f"Pull failed (HTTP {e.code})."
+                    except (urllib.error.URLError, TimeoutError):
+                        return "Could not reach the hub. Check your connection."
+
+                def _do_zip_extract(url: str) -> "tuple[str | None, int]":
+                    import tempfile as _tmp
+
+                    with _tmp.NamedTemporaryFile(suffix=".zip", delete=False) as tmp:
+                        tmp_path = Path(tmp.name)
+                    try:
+                        zip_dl = urllib.request.Request(url)
+                        with (
+                            urllib.request.urlopen(zip_dl, timeout=120) as resp,
+                            open(tmp_path, "wb") as f,
+                        ):
+                            shutil.copyfileobj(resp, f)
+
+                        with zipfile.ZipFile(tmp_path, "r") as zf:
+                            plan: list[tuple[zipfile.ZipInfo, Path]] = []
+                            for member in zf.infolist():
+                                name = member.filename
+                                if name == "manifest.json":
+                                    continue
+                                if name.startswith("files/"):
+                                    name = name[len("files/") :]
+                                if not name or name.endswith("/"):
+                                    continue
+                                target = (dest_path / name).resolve()
+                                try:
+                                    target.relative_to(dest_path)
+                                except ValueError:
+                                    return (
+                                        f"Zip contains unsafe path"
+                                        f" '{member.filename}'.",
+                                        0,
+                                    )
+                                if member.external_attr >> 28 == 0xA:
+                                    return (
+                                        f"Zip contains symlink '{member.filename}'.",
+                                        0,
+                                    )
+                                plan.append((member, target))
+                            preserved = _clear_and_preserve()
+                            count = 0
+                            for member, target in plan:
+                                target.parent.mkdir(parents=True, exist_ok=True)
+                                raw = zf.read(member)
+                                if target.suffix.lower() in _CLOUD_IMAGE_EXTS:
+                                    raw = _decode_data_url(raw)
+                                target.write_bytes(raw)
+                                count += 1
+                            for p, data in preserved.items():
+                                p.write_bytes(data)
+                        return None, count
+                    except zipfile.BadZipFile:
+                        return "Downloaded file is not a valid zip.", 0
+                    except (urllib.error.URLError, TimeoutError):
+                        return (
+                            "Download failed. URL may have expired — try again.",
+                            0,
+                        )
+                    finally:
+                        tmp_path.unlink(missing_ok=True)
+
+                assert base_id is not None
+                files_restored = 0
+
                 if req.manifest_key:
-                    # Versioned pull: fetch file contents from hub
+                    # Versioned pull: try load-from-cloud first
                     def load_from_cloud() -> "dict | str":
-                        load_req = urllib.request.Request(
+                        lc_req = urllib.request.Request(
                             f"{backend}/ai/edit/load-from-cloud",
                             data=_json.dumps(
                                 {"manifestKey": req.manifest_key}
@@ -2023,7 +2136,7 @@ def create_app(project: SantaiProject) -> FastAPI:
                             },
                         )
                         try:
-                            with urllib.request.urlopen(load_req, timeout=60) as resp:
+                            with urllib.request.urlopen(lc_req, timeout=60) as resp:
                                 return _json.loads(resp.read())
                         except urllib.error.HTTPError as e:
                             if e.code == 401:
@@ -2037,99 +2150,143 @@ def create_app(project: SantaiProject) -> FastAPI:
 
                     yield _sse({"type": "status", "message": "Loading save..."})
                     load_result = await asyncio.to_thread(load_from_cloud)
-                    if isinstance(load_result, str):
-                        load_err: dict = {"type": "error", "message": load_result}
-                        if "login" in load_result.lower():
-                            load_err["login_url"] = hub_url
-                        yield _sse(load_err)
-                        return
-                    if not load_result.get("success"):
-                        yield _sse({"type": "error", "message": "Failed to load save."})
-                        return
-
-                    files_data: list = load_result.get("files", [])
-                    yield _sse(
-                        {
-                            "type": "status",
-                            "message": f"Applying {len(files_data)} files...",
-                        }
+                    _lc_ok = (
+                        not isinstance(load_result, str)
+                        and bool(load_result.get("success"))
+                        and bool(load_result.get("files"))
                     )
 
-                    def apply_files(files: list) -> "str | None":
-                        preserved = _clear_and_preserve()
-                        for file_obj in files:
-                            path_str = file_obj.get("path", "")
-                            if not path_str:
-                                continue
-                            target = (dest_path / path_str).resolve()
-                            try:
-                                target.relative_to(dest_path)
-                            except ValueError:
-                                return f"Unsafe path '{path_str}'."
-                            target.parent.mkdir(parents=True, exist_ok=True)
-                            content = file_obj.get("content", "")
-                            if target.suffix.lower() in _CLOUD_IMAGE_EXTS:
-                                raw = _decode_data_url(
-                                    content.encode()
-                                    if isinstance(content, str)
-                                    else content
-                                )
-                            else:
-                                raw = (
-                                    content.encode()
-                                    if isinstance(content, str)
-                                    else content
-                                )
-                            target.write_bytes(raw)
-                        for p, data in preserved.items():
-                            p.write_bytes(data)
-                        return None
+                    if _lc_ok:
+                        assert not isinstance(load_result, str)
+                        files_data: list = load_result.get("files", [])
+                        yield _sse(
+                            {
+                                "type": "status",
+                                "message": f"Applying {len(files_data)} files...",
+                            }
+                        )
 
-                    err = await asyncio.to_thread(apply_files, files_data)
-                    if err:
-                        yield _sse({"type": "error", "message": err})
-                        return
+                        def apply_files(files: list) -> "str | None":
+                            preserved = _clear_and_preserve()
+                            for file_obj in files:
+                                path_str = file_obj.get("path", "")
+                                if not path_str:
+                                    continue
+                                target = (dest_path / path_str).resolve()
+                                try:
+                                    target.relative_to(dest_path)
+                                except ValueError:
+                                    return f"Unsafe path '{path_str}'."
+                                target.parent.mkdir(parents=True, exist_ok=True)
+                                content = file_obj.get("content", "")
+                                if target.suffix.lower() in _CLOUD_IMAGE_EXTS:
+                                    raw = _decode_data_url(
+                                        content.encode()
+                                        if isinstance(content, str)
+                                        else content
+                                    )
+                                else:
+                                    raw = (
+                                        content.encode()
+                                        if isinstance(content, str)
+                                        else content
+                                    )
+                                target.write_bytes(raw)
+                            for p, data in preserved.items():
+                                p.write_bytes(data)
+                            return None
+
+                        apply_err = await asyncio.to_thread(apply_files, files_data)
+                        if apply_err:
+                            yield _sse({"type": "error", "message": apply_err})
+                            return
+                        files_restored = len(files_data)
+                    else:
+                        # Fallback: try versioned zip download
+                        import re as _re
+
+                        _vm = _re.search(r"/v(\d+)\.zip$", req.manifest_key or "")
+                        _ver = _vm.group(1) if _vm else None
+                        _dl_url: str | None = None
+                        _dl_size = 0
+                        _fell_to_latest = False
+
+                        for _cand in filter(
+                            None,
+                            [
+                                (f"{backend}/bases/{base_id}/download?version={_ver}")
+                                if _ver
+                                else None,
+                                f"{backend}/bases/{base_id}/download",
+                            ],
+                        ):
+                            _di = await asyncio.to_thread(_get_download_info, _cand)
+                            if not isinstance(_di, str) and _di.get("downloadUrl"):
+                                _dl_url = _di["downloadUrl"]
+                                _dl_size = _di.get("size", 0)
+                                _fell_to_latest = (
+                                    "?version=" not in _cand and _ver is not None
+                                )
+                                break
+
+                        if not _dl_url:
+                            _orig = (
+                                load_result
+                                if isinstance(load_result, str)
+                                else "Failed to load save."
+                            )
+                            _fb_err: dict = {"type": "error", "message": _orig}
+                            if "login" in _orig.lower():
+                                _fb_err["login_url"] = hub_url
+                            yield _sse(_fb_err)
+                            return
+
+                        assert isinstance(_dl_url, str)
+                        if not _dl_url.startswith(("https://", "http://")):
+                            yield _sse(
+                                {
+                                    "type": "error",
+                                    "message": "Download URL has unexpected scheme.",
+                                }
+                            )
+                            return
+
+                        _sz_msg = format_size(_dl_size)
+                        _status = (
+                            f"Could not load that version — restoring latest"
+                            f" ({_sz_msg})..."
+                            if _fell_to_latest
+                            else f"Downloading ({_sz_msg})..."
+                        )
+                        yield _sse({"type": "status", "message": _status})
+                        yield _sse({"type": "status", "message": "Extracting..."})
+                        _zex_err, files_restored = await asyncio.to_thread(
+                            _do_zip_extract, _dl_url
+                        )
+                        if _zex_err:
+                            yield _sse({"type": "error", "message": _zex_err})
+                            return
 
                 else:
                     # Latest pull: download zip from hub
-                    def get_download_info() -> "dict | str":
-                        info_req = urllib.request.Request(
-                            f"{backend}/bases/{base_id}/download",
-                            headers={
-                                "Authorization": f"Bearer {creds['token']}",
-                                "User-Agent": USER_AGENT,
-                            },
-                        )
-                        try:
-                            with urllib.request.urlopen(info_req, timeout=15) as resp:
-                                return _json.loads(resp.read())
-                        except urllib.error.HTTPError as e:
-                            if e.code == 401:
-                                return (
-                                    "Session expired. Run 'santai login' "
-                                    "to re-authenticate."
-                                )
-                            if e.code == 404:
-                                return f"Project '{project_name}' not found."
-                            return f"Pull failed (HTTP {e.code})."
-                        except (urllib.error.URLError, TimeoutError):
-                            return "Could not reach the hub. Check your connection."
-
-                    info = await asyncio.to_thread(get_download_info)
-                    if isinstance(info, str):
-                        pull_err: dict = {"type": "error", "message": info}
-                        if "login" in info.lower():
-                            pull_err["login_url"] = hub_url
-                        yield _sse(pull_err)
+                    _info_l = await asyncio.to_thread(
+                        _get_download_info,
+                        f"{backend}/bases/{base_id}/download",
+                    )
+                    if isinstance(_info_l, str):
+                        _pull_err: dict = {"type": "error", "message": _info_l}
+                        if "login" in _info_l.lower():
+                            _pull_err["login_url"] = hub_url
+                        yield _sse(_pull_err)
                         return
 
-                    download_url = info.get("downloadUrl")
-                    if not download_url:
+                    _dl_url_l = _info_l.get("downloadUrl")
+                    if not _dl_url_l:
                         yield _sse(
                             {"type": "error", "message": "No download URL received."}
                         )
                         return
-                    if not download_url.startswith(("https://", "http://")):
+                    if not _dl_url_l.startswith(("https://", "http://")):
                         yield _sse(
                             {
                                 "type": "error",
@@ -2138,76 +2295,24 @@ def create_app(project: SantaiProject) -> FastAPI:
                         )
                         return
 
-                    size = info.get("size", 0)
+                    _sz_l = format_size(_info_l.get("size", 0))
                     yield _sse(
                         {
                             "type": "status",
-                            "message": f"Downloading ({format_size(size)})...",
+                            "message": f"Downloading ({_sz_l})...",
                         }
                     )
-
-                    def download_and_extract() -> "str | None":
-                        import tempfile as _tmp
-
-                        with _tmp.NamedTemporaryFile(
-                            suffix=".zip", delete=False
-                        ) as tmp:
-                            tmp_path = Path(tmp.name)
-                        try:
-                            dl_req = urllib.request.Request(download_url)
-                            with (
-                                urllib.request.urlopen(dl_req, timeout=120) as resp,
-                                open(tmp_path, "wb") as f,
-                            ):
-                                shutil.copyfileobj(resp, f)
-
-                            with zipfile.ZipFile(tmp_path, "r") as zf:
-                                plan: list[tuple[zipfile.ZipInfo, Path]] = []
-                                for member in zf.infolist():
-                                    name = member.filename
-                                    if name == "manifest.json":
-                                        continue
-                                    if name.startswith("files/"):
-                                        name = name[len("files/") :]
-                                    if not name or name.endswith("/"):
-                                        continue
-                                    target = (dest_path / name).resolve()
-                                    try:
-                                        target.relative_to(dest_path)
-                                    except ValueError:
-                                        return (
-                                            f"Zip contains unsafe path"
-                                            f" '{member.filename}'."
-                                        )
-                                    if member.external_attr >> 28 == 0xA:
-                                        return (
-                                            f"Zip contains symlink '{member.filename}'."
-                                        )
-                                    plan.append((member, target))
-                                preserved = _clear_and_preserve()
-                                for member, target in plan:
-                                    target.parent.mkdir(parents=True, exist_ok=True)
-                                    raw = zf.read(member)
-                                    if target.suffix.lower() in _CLOUD_IMAGE_EXTS:
-                                        raw = _decode_data_url(raw)
-                                    target.write_bytes(raw)
-                                for p, data in preserved.items():
-                                    p.write_bytes(data)
-                            return None
-                        except zipfile.BadZipFile:
-                            return "Downloaded file is not a valid zip."
-                        except (urllib.error.URLError, TimeoutError):
-                            return "Download failed. URL may have expired — try again."
-                        finally:
-                            tmp_path.unlink(missing_ok=True)
-
                     yield _sse({"type": "status", "message": "Extracting..."})
-                    err = await asyncio.to_thread(download_and_extract)
-                    if err:
-                        yield _sse({"type": "error", "message": err})
+                    _zex_err_l, files_restored = await asyncio.to_thread(
+                        _do_zip_extract, _dl_url_l
+                    )
+                    if _zex_err_l:
+                        yield _sse({"type": "error", "message": _zex_err_l})
                         return
 
-                yield _sse({"type": "done", "pulled": True})
+                yield _sse(
+                    {"type": "done", "pulled": True, "filesRestored": files_restored}
+                )
             finally:
                 _cloud_pull_lock.release()
 

--- a/src/santai_cli/web/app.py
+++ b/src/santai_cli/web/app.py
@@ -18,6 +18,7 @@ from fastapi.templating import Jinja2Templates
 from pydantic import BaseModel
 
 from santai_cli.core.project import (
+    IMAGE_EXTENSIONS,
     MARKDOWN_LINK_PATTERN,
     SANTAI_FOLDER_DESCRIPTIONS,
     WIKILINK_PATTERN,
@@ -1599,15 +1600,7 @@ def create_app(project: SantaiProject) -> FastAPI:
     }
     _CLOUD_SENSITIVE = {".env", "credentials.json"}
     _CLOUD_MAX_BYTES = 50 * 1024 * 1024
-    _CLOUD_IMAGE_EXTS = {
-        ".png",
-        ".jpg",
-        ".jpeg",
-        ".gif",
-        ".webp",
-        ".bmp",
-        ".ico",
-    }
+    _CLOUD_IMAGE_EXTS = IMAGE_EXTENSIONS
 
     @app.get("/api/cloud/status")
     async def cloud_status() -> dict[str, Any]:
@@ -1634,7 +1627,12 @@ def create_app(project: SantaiProject) -> FastAPI:
         from urllib.parse import quote
 
         from santai_cli.commands.auth import DEFAULT_HUB_URL, load_credentials
-        from santai_cli.core.hub import USER_AGENT, get_backend_url
+        from santai_cli.core.hub import (
+            USER_AGENT,
+            fetch_prev_files,
+            get_backend_url,
+            make_diff_title,
+        )
 
         def _sse(data: dict) -> str:
             return f"data: {_json.dumps(data)}\n\n"
@@ -1770,13 +1768,15 @@ def create_app(project: SantaiProject) -> FastAPI:
 
                 yield _sse({"type": "status", "message": "Packaging..."})
 
-                def build_zip() -> "tuple[bytes, int] | str":
+                def build_zip() -> "tuple[bytes, int, set[str], dict[str, str]] | str":
                     import tempfile as _tmp
 
                     with _tmp.NamedTemporaryFile(suffix=".zip", delete=False) as tmp:
                         tmp_path = Path(tmp.name)
                     try:
                         file_count = 0
+                        curr_paths: set[str] = set()
+                        curr_text: dict[str, str] = {}
                         with zipfile.ZipFile(tmp_path, "w", zipfile.ZIP_DEFLATED) as zf:
                             for fp in sorted(project.root.rglob("*")):
                                 if not fp.is_file():
@@ -1788,10 +1788,18 @@ def create_app(project: SantaiProject) -> FastAPI:
                                     continue
                                 if rel.name in ignored_files:
                                     continue
+                                rel_str = str(rel)
+                                curr_paths.add(rel_str)
                                 if fp.suffix.lower() in _CLOUD_IMAGE_EXTS:
-                                    zf.writestr(str(rel), _encode_data_url(fp))
+                                    zf.writestr(rel_str, _encode_data_url(fp))
                                 else:
                                     zf.write(fp, rel)
+                                    try:
+                                        curr_text[rel_str] = fp.read_text(
+                                            errors="replace"
+                                        )
+                                    except Exception:
+                                        curr_text[rel_str] = ""
                                 file_count += 1
                         size = tmp_path.stat().st_size
                         if size > _CLOUD_MAX_BYTES:
@@ -1799,17 +1807,36 @@ def create_app(project: SantaiProject) -> FastAPI:
                                 f"Archive is {format_size(size)}, "
                                 "exceeds the 50 MB limit."
                             )
-                        return tmp_path.read_bytes(), file_count
+                        return tmp_path.read_bytes(), file_count, curr_paths, curr_text
                     finally:
                         tmp_path.unlink(missing_ok=True)
 
-                result = await asyncio.to_thread(build_zip)
+                _prev_task = asyncio.to_thread(
+                    fetch_prev_files,
+                    backend,
+                    creds["token"],
+                    base_id,
+                    _CLOUD_IMAGE_EXTS,
+                )
+                (prev_paths, prev_text), result = await asyncio.gather(
+                    _prev_task, asyncio.to_thread(build_zip)
+                )
                 if isinstance(result, str):
                     yield _sse({"type": "error", "message": result})
                     return
 
-                zip_bytes, _file_count = result
-                _push_title = f"Web snapshot · {_file_count} file{'s' if _file_count != 1 else ''}"
+                zip_bytes, _file_count, curr_paths, curr_text = result
+                _diff = make_diff_title(prev_paths, curr_paths, prev_text, curr_text)
+                _n = _file_count
+                _push_title = (
+                    _diff
+                    if _diff
+                    else (
+                        "Initial push"
+                        if not prev_paths
+                        else f"Snapshot · {_n} file{'s' if _n != 1 else ''}"
+                    )
+                )
                 yield _sse(
                     {
                         "type": "status",

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -703,55 +703,6 @@
         .cloud-status.error { color: #ef4444; }
         .cloud-status.success { color: var(--accent); }
 
-        .cloud-inline-form {
-            display: none;
-            flex-direction: column;
-            gap: 6px;
-        }
-
-        .cloud-inline-form.visible { display: flex; }
-
-        .cloud-confirm-msg {
-            font-size: 12px;
-            color: var(--text-secondary, var(--text-muted));
-            line-height: 1.4;
-        }
-
-        .cloud-inline-form input[type="text"] {
-            background: rgba(255,255,255,0.6);
-            border: 1px solid rgba(0,0,0,0.12);
-            border-radius: 8px;
-            padding: 7px 10px;
-            font-size: 12px;
-            color: var(--text-primary);
-            width: 100%;
-            box-sizing: border-box;
-        }
-
-        .cloud-inline-form input[type="text"]:focus {
-            outline: none;
-            border-color: var(--accent);
-        }
-
-        .cloud-form-row {
-            display: flex;
-            gap: 6px;
-        }
-
-        .cloud-form-row .btn {
-            flex: 1;
-            justify-content: center;
-            font-size: 13px;
-            padding: 7px 6px;
-        }
-
-        #cloud-pull-cancel-btn {
-            background: rgba(0, 0, 0, 0.06);
-        }
-
-        #cloud-pull-cancel-btn:hover {
-            background: rgba(0, 0, 0, 0.1);
-        }
 
         .btn {
             background: rgba(255, 255, 255, 0.7);
@@ -3938,13 +3889,7 @@
                             Pull from Cloud
                         </button>
                     </div>
-                    <div class="cloud-inline-form" id="cloud-pull-confirm">
-                        <span class="cloud-confirm-msg" id="cloud-confirm-msg">Replace local files with the latest cloud version?</span>
-                        <div class="cloud-form-row">
-                            <button class="btn btn-primary" onclick="cloudPullConfirmStored()">Replace</button>
-                            <button class="btn" id="cloud-pull-cancel-btn" onclick="cloudPullCancel()">Cancel</button>
-                        </div>
-                    </div>
+
                     <span class="cloud-status" id="cloud-status"></span>
                 </div>
                 <ul class="tree-view" id="tree-view"></ul>
@@ -9357,11 +9302,6 @@
             cloudPullConfirm(key);
         }
 
-        function cloudPullCancel() {
-            _pendingManifestKey = null;
-            document.getElementById('cloud-pull-confirm').classList.remove('visible');
-            setCloudStatus('');
-        }
 
         async function cloudPullConfirm(manifestKey) {
             if (_cloudStreaming) return;

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -4390,7 +4390,7 @@
                     </svg>
                 </button>
             </div>
-            <p style="font-size: 13px; color: var(--text-primary); opacity: 0.65; margin: 0 0 12px;">
+            <p id="cloud-saves-subtitle" style="font-size: 13px; color: var(--text-primary); opacity: 0.65; margin: 0 0 12px;">
                 Select a save to load. This will overwrite your current local files.
             </p>
             <div class="cloud-saves-list" id="cloud-saves-list">
@@ -4401,8 +4401,8 @@
                     This will overwrite your current local files.
                 </p>
                 <div style="display: flex; gap: 8px; justify-content: center;">
-                    <button class="btn" onclick="cloudSaveConfirmCancel()">Cancel</button>
                     <button class="btn btn-primary" onclick="cloudSaveConfirmLoad()">Load</button>
+                    <button class="btn" onclick="cloudSaveConfirmCancel()">Cancel</button>
                 </div>
             </div>
         </div>
@@ -9337,6 +9337,7 @@
         function cloudPullPrepare(manifestKey) {
             _pendingManifestKey = manifestKey;
             document.getElementById('cloud-saves-list').style.display = 'none';
+            document.getElementById('cloud-saves-subtitle').style.display = 'none';
             document.getElementById('cloud-save-confirm-pane').style.display = '';
         }
 
@@ -9344,6 +9345,7 @@
             _pendingManifestKey = null;
             document.getElementById('cloud-save-confirm-pane').style.display = 'none';
             document.getElementById('cloud-saves-list').style.display = '';
+            document.getElementById('cloud-saves-subtitle').style.display = '';
         }
 
         function cloudSaveConfirmLoad() {
@@ -9514,6 +9516,7 @@
             document.getElementById('cloud-saves-modal').classList.remove('show');
             document.getElementById('cloud-save-confirm-pane').style.display = 'none';
             document.getElementById('cloud-saves-list').style.display = '';
+            document.getElementById('cloud-saves-subtitle').style.display = '';
             _pendingManifestKey = null;
         }
 

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -4398,7 +4398,7 @@
             </div>
             <div id="cloud-save-confirm-pane" style="display:none; padding: 16px 0 4px; text-align: center;">
                 <p style="margin: 0 0 16px; font-size: 14px; color: var(--text-primary); opacity: 0.8;">
-                    This will overwrite your current local files.
+                    This will overwrite your current local files. Load anyway?
                 </p>
                 <div style="display: flex; gap: 8px; justify-content: center;">
                     <button class="btn btn-primary" onclick="cloudSaveConfirmLoad()">Load</button>

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -1222,6 +1222,87 @@
             justify-content: flex-end;
         }
 
+        /* Cloud saves picker modal */
+        .cloud-saves-list {
+            display: flex;
+            flex-direction: column;
+            gap: 6px;
+            max-height: 320px;
+            overflow-y: auto;
+            margin-bottom: 4px;
+            padding-right: 4px;
+            scrollbar-width: thin;
+            scrollbar-color: transparent transparent;
+            transition: scrollbar-color 0.25s ease;
+        }
+
+        .cloud-saves-list:hover {
+            scrollbar-color: rgba(0, 0, 0, 0.12) transparent;
+        }
+
+        .cloud-saves-list::-webkit-scrollbar {
+            width: 3px;
+        }
+
+        .cloud-saves-list::-webkit-scrollbar-track {
+            background: transparent;
+        }
+
+        .cloud-saves-list::-webkit-scrollbar-thumb {
+            background: transparent;
+            border-radius: 999px;
+        }
+
+        .cloud-saves-list:hover::-webkit-scrollbar-thumb {
+            background: rgba(0, 0, 0, 0.12);
+        }
+
+        .cloud-save-item {
+            display: flex;
+            align-items: center;
+            gap: 12px;
+            padding: 10px 12px;
+            border: 1px solid var(--glass-border);
+            border-radius: 10px;
+            transition: var(--transition-quick);
+            background: var(--fill-white);
+            user-select: none;
+        }
+
+        .cloud-save-item:hover {
+            background: var(--fill-active);
+        }
+
+        .cloud-save-meta {
+            flex: 1;
+            min-width: 0;
+        }
+
+        .cloud-save-title {
+            font-size: 14px;
+            font-weight: 500;
+            color: var(--text-primary);
+            margin-bottom: 2px;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+        }
+
+        .cloud-save-info {
+            font-size: 12px;
+            color: var(--text-primary);
+            opacity: 0.5;
+        }
+
+        .cloud-saves-empty,
+        .cloud-saves-loading {
+            text-align: center;
+            color: var(--text-primary);
+            font-size: 14px;
+            padding: 24px 0;
+            opacity: 0.45;
+        }
+
         .right-rail {
             width: 380px;
             min-width: 320px;
@@ -4269,6 +4350,31 @@
             <div class="modal-actions" style="margin-top: 20px; justify-content: flex-start;">
                 <button class="btn btn-primary" id="settings-save-btn" onclick="saveSettings()">Save</button>
                 <button class="btn" onclick="closeModals()">Cancel</button>
+            </div>
+        </div>
+    </div>
+
+    <!-- Cloud Saves Modal -->
+    <div class="modal-overlay" id="cloud-saves-modal">
+        <div class="modal" style="min-width: 440px; max-width: 560px;">
+            <div class="edit-modal-header" style="margin-bottom: 6px;">
+                <h2 style="margin: 0; font-size: 17px; display: flex; align-items: center; gap: 8px;">
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" style="width:20px;height:20px;flex-shrink:0;">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M12 9V15.75m0 0l-3-3m3 3l3-3M6.75 19.5a4.5 4.5 0 01-1.41-8.775 5.25 5.25 0 0110.233-2.33 3 3 0 013.758 3.848A3.752 3.752 0 0118 19.5H6.75z" />
+                    </svg>
+                    Pull from Cloud
+                </h2>
+                <button class="preview-close" onclick="closeCloudSavesModal()">
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+                    </svg>
+                </button>
+            </div>
+            <p style="font-size: 13px; color: var(--text-primary); opacity: 0.5; margin: 0 0 12px;">
+                Select a save to load. This will overwrite your current local files.
+            </p>
+            <div class="cloud-saves-list" id="cloud-saves-list">
+                <div class="cloud-saves-loading">Loading saves...</div>
             </div>
         </div>
     </div>
@@ -9194,7 +9300,7 @@
                 return;
             }
             setCloudStatus('');
-            document.getElementById('cloud-pull-confirm').classList.add('visible');
+            showCloudSavesModal();
         }
 
         function cloudPullCancel() {
@@ -9202,16 +9308,16 @@
             setCloudStatus('');
         }
 
-        async function cloudPullConfirm() {
+        async function cloudPullConfirm(manifestKey) {
             if (_cloudStreaming) return;
-            document.getElementById('cloud-pull-confirm').classList.remove('visible');
             _cloudStreaming = true;
             setCloudStatus('Looking up project...');
             try {
+                const body = manifestKey ? {manifest_key: manifestKey} : {};
                 const response = await fetch('/api/cloud/pull', {
                     method: 'POST',
                     headers: {'Content-Type': 'application/json'},
-                    body: JSON.stringify({}),
+                    body: JSON.stringify(body),
                 });
                 if (!response.ok) {
                     const err = await response.json().catch(() => ({}));
@@ -9256,6 +9362,68 @@
                     } catch { /* ignore malformed SSE lines */ }
                 }
             }
+        }
+
+        // --- Cloud saves modal ---
+
+        function _fmtBytes(bytes) {
+            if (bytes < 1024) return bytes + ' B';
+            if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + ' KB';
+            return (bytes / (1024 * 1024)).toFixed(1) + ' MB';
+        }
+
+        function _escHtml(str) {
+            return String(str)
+                .replace(/&/g, '&amp;').replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+        }
+
+        async function showCloudSavesModal() {
+            const listEl = document.getElementById('cloud-saves-list');
+            if (listEl) listEl.innerHTML = '<div class="cloud-saves-loading">Loading saves…</div>';
+            document.getElementById('cloud-saves-modal').classList.add('show');
+            try {
+                const res = await fetch('/api/cloud/list-saves');
+                if (!res.ok) throw new Error('HTTP ' + res.status);
+                const data = await res.json();
+                if (data.error) {
+                    listEl.innerHTML = `<div class="cloud-saves-empty">${_escHtml(data.error)}</div>`;
+                    return;
+                }
+                const saves = data.saves || [];
+                if (!saves.length) {
+                    listEl.innerHTML = '<div class="cloud-saves-empty">No cloud saves found for this project.</div>';
+                    return;
+                }
+                listEl.innerHTML = '';
+                saves.forEach((save, idx) => {
+                    const item = document.createElement('div');
+                    item.className = 'cloud-save-item';
+                    const title = save.title || save.name || ('Save ' + (save.version ?? idx + 1));
+                    const parts = [];
+                    if (save.createdAt) parts.push(new Date(save.createdAt).toLocaleString());
+                    if (save.size) parts.push(_fmtBytes(save.size));
+                    if (save.filesCount) parts.push(save.filesCount + ' files');
+                    const manifestKey = save.manifestKey ?? save.manifest_key ?? null;
+                    item.innerHTML =
+                        '<div class="cloud-save-meta">' +
+                        '<div class="cloud-save-title">' + _escHtml(title) + '</div>' +
+                        (parts.length ? '<div class="cloud-save-info">' + _escHtml(parts.join(' · ')) + '</div>' : '') +
+                        '</div>' +
+                        '<button class="btn btn-primary" style="flex-shrink:0;font-size:13px;padding:6px 14px;">Load</button>';
+                    item.querySelector('button').addEventListener('click', () => {
+                        closeCloudSavesModal();
+                        cloudPullConfirm(manifestKey);
+                    });
+                    listEl.appendChild(item);
+                });
+            } catch {
+                listEl.innerHTML = '<div class="cloud-saves-empty">Failed to load saves. Check your connection.</div>';
+            }
+        }
+
+        function closeCloudSavesModal() {
+            document.getElementById('cloud-saves-modal').classList.remove('show');
         }
 
         // --- Chat-triggered cloud operations ---

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -1227,7 +1227,7 @@
             display: flex;
             flex-direction: column;
             gap: 6px;
-            max-height: 320px;
+            max-height: 420px;
             overflow-y: auto;
             margin-bottom: 4px;
             padding-right: 4px;
@@ -1291,7 +1291,27 @@
         .cloud-save-info {
             font-size: 12px;
             color: var(--text-primary);
-            opacity: 0.5;
+            opacity: 0.65;
+            display: flex;
+            align-items: center;
+            gap: 6px;
+            flex-wrap: wrap;
+        }
+
+        .cloud-save-tag {
+            display: inline-flex;
+            align-items: center;
+            font-size: 10px;
+            font-weight: 600;
+            letter-spacing: 0.04em;
+            text-transform: uppercase;
+            padding: 1px 6px;
+            border-radius: 4px;
+            background: var(--fill-active);
+            border: 1px solid var(--glass-border);
+            color: var(--text-primary);
+            opacity: 1;
+            flex-shrink: 0;
         }
 
         .cloud-saves-empty,
@@ -1300,7 +1320,7 @@
             color: var(--text-primary);
             font-size: 14px;
             padding: 24px 0;
-            opacity: 0.45;
+            opacity: 0.6;
         }
 
         .right-rail {
@@ -4356,7 +4376,7 @@
 
     <!-- Cloud Saves Modal -->
     <div class="modal-overlay" id="cloud-saves-modal">
-        <div class="modal" style="min-width: 440px; max-width: 560px;">
+        <div class="modal" style="min-width: 520px; max-width: 680px;">
             <div class="edit-modal-header" style="margin-bottom: 6px;">
                 <h2 style="margin: 0; font-size: 17px; display: flex; align-items: center; gap: 8px;">
                     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" style="width:20px;height:20px;flex-shrink:0;">
@@ -4370,7 +4390,7 @@
                     </svg>
                 </button>
             </div>
-            <p style="font-size: 13px; color: var(--text-primary); opacity: 0.5; margin: 0 0 12px;">
+            <p style="font-size: 13px; color: var(--text-primary); opacity: 0.65; margin: 0 0 12px;">
                 Select a save to load. This will overwrite your current local files.
             </p>
             <div class="cloud-saves-list" id="cloud-saves-list">
@@ -9399,16 +9419,43 @@
                 saves.forEach((save, idx) => {
                     const item = document.createElement('div');
                     item.className = 'cloud-save-item';
-                    const title = save.title || save.name || ('Save ' + (save.version ?? idx + 1));
+
+                    // Detect origin and derive a meaningful display title
+                    const rawTitle = save.title || save.name || '';
+                    const rawOrigin = save.origin || save.source || '';
+                    let originTag = null;
+                    let displayTitle = rawTitle;
+
+                    const _isCli = rawOrigin === 'cli' || /\bfrom\s+cli\b/i.test(rawTitle);
+                    if (_isCli) {
+                        originTag = 'CLI';
+                        displayTitle = rawTitle.replace(/\bpush\s+from\s+cli\b[\s·\-]*/i, '').trim();
+                    } else {
+                        originTag = 'Hub';
+                        displayTitle = rawTitle.replace(/\b(push\s+)?from\s+(the\s+)?hub\b[\s·\-]*/i, '').replace(/\bsantai\s+hub\b[\s·\-]*/i, '').trim();
+                    }
+                    if (!displayTitle) {
+                        displayTitle = save.version ? 'Version ' + save.version : ('Save ' + (idx + 1));
+                    }
+
                     const parts = [];
                     if (save.createdAt) parts.push(new Date(save.createdAt).toLocaleString());
                     if (save.size) parts.push(_fmtBytes(save.size));
                     if (save.filesCount) parts.push(save.filesCount + ' files');
                     const manifestKey = save.manifestKey ?? save.manifest_key ?? null;
+
+                    const tagHtml = originTag
+                        ? '<span class="cloud-save-tag">' + _escHtml(originTag) + '</span>'
+                        : '';
+                    const infoText = parts.length ? _escHtml(parts.join(' · ')) : '';
+                    const infoHtml = (infoText || tagHtml)
+                        ? '<div class="cloud-save-info">' + infoText + tagHtml + '</div>'
+                        : '';
+
                     item.innerHTML =
                         '<div class="cloud-save-meta">' +
-                        '<div class="cloud-save-title">' + _escHtml(title) + '</div>' +
-                        (parts.length ? '<div class="cloud-save-info">' + _escHtml(parts.join(' · ')) + '</div>' : '') +
+                        '<div class="cloud-save-title">' + _escHtml(displayTitle) + '</div>' +
+                        infoHtml +
                         '</div>' +
                         '<button class="btn btn-primary" style="flex-shrink:0;font-size:13px;padding:6px 14px;">Load</button>';
                     item.querySelector('button').addEventListener('click', () => {

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -9377,6 +9377,13 @@
                                 await Promise.all([refreshTree(), refreshFiles()]);
                                 setCloudStatus('Successfully pulled from cloud.', 'success');
                             } else {
+                                if (data.title && data.version != null) {
+                                    try {
+                                        const stored = JSON.parse(localStorage.getItem('santai-push-titles') || '{}');
+                                        stored[String(data.version)] = data.title;
+                                        localStorage.setItem('santai-push-titles', JSON.stringify(stored));
+                                    } catch {}
+                                }
                                 setCloudStatus('Successfully saved to the cloud.', 'success');
                             }
                             setTimeout(() => setCloudStatus(''), 4000);
@@ -9419,6 +9426,8 @@
                     listEl.innerHTML = '<div class="cloud-saves-empty">No cloud saves found for this project.</div>';
                     return;
                 }
+                let _storedTitles = {};
+                try { _storedTitles = JSON.parse(localStorage.getItem('santai-push-titles') || '{}'); } catch {}
                 listEl.innerHTML = '';
                 saves.forEach((save, idx) => {
                     const item = document.createElement('div');
@@ -9433,7 +9442,9 @@
                     const _isCli = rawOrigin === 'cli' || /\bfrom\s+cli\b/i.test(rawTitle);
                     if (_isCli) {
                         originTag = 'CLI';
-                        displayTitle = rawTitle.replace(/\bpush\s+from\s+cli\b[\s·\-]*/i, '').trim();
+                        // Use locally-stored diff title if available, else strip generic prefix
+                        const _stored = save.version != null ? _storedTitles[String(save.version)] : null;
+                        displayTitle = _stored || rawTitle.replace(/\bpush\s+from\s+cli\b[\s·\-]*/i, '').trim();
                     } else {
                         originTag = 'Hub';
                         displayTitle = rawTitle.replace(/\b(push\s+)?from\s+(the\s+)?hub\b[\s·\-]*/i, '').replace(/\bsantai\s+hub\b[\s·\-]*/i, '').trim();

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -9439,15 +9439,14 @@
                         displayTitle = rawTitle.replace(/\b(push\s+)?from\s+(the\s+)?hub\b[\s·\-]*/i, '').replace(/\bsantai\s+hub\b[\s·\-]*/i, '').trim();
                     }
                     if (!displayTitle) {
-                        displayTitle = save.version ? 'Version ' + save.version : ('Save ' + (idx + 1));
+                        displayTitle = save.version ? 'v' + save.version : ('Save ' + (idx + 1));
                     }
 
                     const parts = [];
                     if (save.createdAt) parts.push(new Date(save.createdAt).toLocaleString());
                     if (save.size) parts.push(_fmtBytes(save.size));
                     if (save.filesCount) parts.push(save.filesCount + ' files');
-                    const manifestKey = save.manifestKey ?? save.manifest_key ?? save.key ?? save.id ?? null;
-                    console.log('[cloud-saves] save object:', save, '→ manifestKey:', manifestKey);
+                    const manifestKey = save.key ?? save.manifestKey ?? save.manifest_key ?? null;
 
                     const tagHtml = originTag
                         ? '<span class="cloud-save-tag">' + _escHtml(originTag) + '</span>'

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -4396,6 +4396,15 @@
             <div class="cloud-saves-list" id="cloud-saves-list">
                 <div class="cloud-saves-loading">Loading saves...</div>
             </div>
+            <div id="cloud-save-confirm-pane" style="display:none; padding: 16px 0 4px; text-align: center;">
+                <p style="margin: 0 0 16px; font-size: 14px; color: var(--text-primary); opacity: 0.8;">
+                    This will overwrite your current local files.
+                </p>
+                <div style="display: flex; gap: 8px; justify-content: center;">
+                    <button class="btn" onclick="cloudSaveConfirmCancel()">Cancel</button>
+                    <button class="btn btn-primary" onclick="cloudSaveConfirmLoad()">Load</button>
+                </div>
+            </div>
         </div>
     </div>
 
@@ -9325,23 +9334,25 @@
 
         let _pendingManifestKey = null;
 
-        function cloudPullPrepare(title, version, filesCount, createdAt, manifestKey) {
+        function cloudPullPrepare(manifestKey) {
             _pendingManifestKey = manifestKey;
-            const vStr = version != null ? `v${version}` : '';
-            const fStr = filesCount != null ? `${filesCount} file${filesCount !== 1 ? 's' : ''}` : '';
-            const dStr = createdAt
-                ? new Date(createdAt).toLocaleString(undefined, {month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit'})
-                : '';
-            const meta = [vStr, fStr, dStr].filter(Boolean).join(' · ');
-            const msg = meta
-                ? `Restore "${title}" (${meta})? This will replace your local files.`
-                : `Restore "${title}"? This will replace your local files.`;
-            document.getElementById('cloud-confirm-msg').textContent = msg;
-            document.getElementById('cloud-pull-confirm').classList.add('visible');
+            document.getElementById('cloud-saves-list').style.display = 'none';
+            document.getElementById('cloud-save-confirm-pane').style.display = '';
         }
 
-        function cloudPullConfirmStored() {
-            cloudPullConfirm(_pendingManifestKey);
+        function cloudSaveConfirmCancel() {
+            _pendingManifestKey = null;
+            document.getElementById('cloud-save-confirm-pane').style.display = 'none';
+            document.getElementById('cloud-saves-list').style.display = '';
+        }
+
+        function cloudSaveConfirmLoad() {
+            const key = _pendingManifestKey;
+            _pendingManifestKey = null;
+            closeCloudSavesModal();
+            document.getElementById('cloud-save-confirm-pane').style.display = 'none';
+            document.getElementById('cloud-saves-list').style.display = '';
+            cloudPullConfirm(key);
         }
 
         function cloudPullCancel() {
@@ -9490,8 +9501,7 @@
                         '</div>' +
                         '<button class="btn btn-primary" style="flex-shrink:0;font-size:13px;padding:6px 14px;">Load</button>';
                     item.querySelector('button').addEventListener('click', () => {
-                        closeCloudSavesModal();
-                        cloudPullPrepare(displayTitle, save.version, save.filesCount, save.createdAt, manifestKey);
+                        cloudPullPrepare(manifestKey);
                     });
                     listEl.appendChild(item);
                 });
@@ -9502,6 +9512,9 @@
 
         function closeCloudSavesModal() {
             document.getElementById('cloud-saves-modal').classList.remove('show');
+            document.getElementById('cloud-save-confirm-pane').style.display = 'none';
+            document.getElementById('cloud-saves-list').style.display = '';
+            _pendingManifestKey = null;
         }
 
         // --- Chat-triggered cloud operations ---

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -4401,8 +4401,8 @@
                     This will overwrite your current local files. Load anyway?
                 </p>
                 <div style="display: flex; gap: 8px; justify-content: center;">
-                    <button class="btn btn-primary" style="width: 100px;" onclick="cloudSaveConfirmLoad()">Load</button>
-                    <button class="btn" style="width: 100px;" onclick="cloudSaveConfirmCancel()">Cancel</button>
+                    <button class="btn btn-primary" style="width: 120px; justify-content: center;" onclick="cloudSaveConfirmLoad()">Load</button>
+                    <button class="btn" style="width: 120px; justify-content: center;" onclick="cloudSaveConfirmCancel()">Cancel</button>
                 </div>
             </div>
         </div>

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -4401,8 +4401,8 @@
                     This will overwrite your current local files. Load anyway?
                 </p>
                 <div style="display: flex; gap: 8px; justify-content: center;">
-                    <button class="btn btn-primary" onclick="cloudSaveConfirmLoad()">Load</button>
-                    <button class="btn" onclick="cloudSaveConfirmCancel()">Cancel</button>
+                    <button class="btn btn-primary" style="width: 100px;" onclick="cloudSaveConfirmLoad()">Load</button>
+                    <button class="btn" style="width: 100px;" onclick="cloudSaveConfirmCancel()">Cancel</button>
                 </div>
             </div>
         </div>

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -3939,9 +3939,9 @@
                         </button>
                     </div>
                     <div class="cloud-inline-form" id="cloud-pull-confirm">
-                        <span class="cloud-confirm-msg">Replace local files with the latest cloud version?</span>
+                        <span class="cloud-confirm-msg" id="cloud-confirm-msg">Replace local files with the latest cloud version?</span>
                         <div class="cloud-form-row">
-                            <button class="btn btn-primary" onclick="cloudPullConfirm()">Replace</button>
+                            <button class="btn btn-primary" onclick="cloudPullConfirmStored()">Replace</button>
                             <button class="btn" id="cloud-pull-cancel-btn" onclick="cloudPullCancel()">Cancel</button>
                         </div>
                     </div>
@@ -9323,7 +9323,29 @@
             showCloudSavesModal();
         }
 
+        let _pendingManifestKey = null;
+
+        function cloudPullPrepare(title, version, filesCount, createdAt, manifestKey) {
+            _pendingManifestKey = manifestKey;
+            const vStr = version != null ? `v${version}` : '';
+            const fStr = filesCount != null ? `${filesCount} file${filesCount !== 1 ? 's' : ''}` : '';
+            const dStr = createdAt
+                ? new Date(createdAt).toLocaleString(undefined, {month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit'})
+                : '';
+            const meta = [vStr, fStr, dStr].filter(Boolean).join(' · ');
+            const msg = meta
+                ? `Restore "${title}" (${meta})? This will replace your local files.`
+                : `Restore "${title}"? This will replace your local files.`;
+            document.getElementById('cloud-confirm-msg').textContent = msg;
+            document.getElementById('cloud-pull-confirm').classList.add('visible');
+        }
+
+        function cloudPullConfirmStored() {
+            cloudPullConfirm(_pendingManifestKey);
+        }
+
         function cloudPullCancel() {
+            _pendingManifestKey = null;
             document.getElementById('cloud-pull-confirm').classList.remove('visible');
             setCloudStatus('');
         }
@@ -9375,15 +9397,12 @@
                         } else if (data.type === 'done') {
                             if (data.pulled) {
                                 await Promise.all([refreshTree(), refreshFiles()]);
-                                setCloudStatus('Successfully pulled from cloud.', 'success');
+                                const _n = data.filesRestored;
+                                const _detail = _n != null
+                                    ? ` ${_n} file${_n !== 1 ? 's' : ''} restored.`
+                                    : '';
+                                setCloudStatus('Successfully pulled from cloud.' + _detail, 'success');
                             } else {
-                                if (data.title && data.version != null) {
-                                    try {
-                                        const stored = JSON.parse(localStorage.getItem('santai-push-titles') || '{}');
-                                        stored[String(data.version)] = data.title;
-                                        localStorage.setItem('santai-push-titles', JSON.stringify(stored));
-                                    } catch {}
-                                }
                                 setCloudStatus('Successfully saved to the cloud.', 'success');
                             }
                             setTimeout(() => setCloudStatus(''), 4000);
@@ -9426,8 +9445,6 @@
                     listEl.innerHTML = '<div class="cloud-saves-empty">No cloud saves found for this project.</div>';
                     return;
                 }
-                let _storedTitles = {};
-                try { _storedTitles = JSON.parse(localStorage.getItem('santai-push-titles') || '{}'); } catch {}
                 listEl.innerHTML = '';
                 saves.forEach((save, idx) => {
                     const item = document.createElement('div');
@@ -9442,9 +9459,8 @@
                     const _isCli = rawOrigin === 'cli' || /\bfrom\s+cli\b/i.test(rawTitle);
                     if (_isCli) {
                         originTag = 'CLI';
-                        // Use locally-stored diff title if available, else strip generic prefix
-                        const _stored = save.version != null ? _storedTitles[String(save.version)] : null;
-                        displayTitle = _stored || rawTitle.replace(/\bpush\s+from\s+cli\b[\s·\-]*/i, '').trim();
+                        // Prefer server-enriched localTitle (from .santai/push-titles.json)
+                        displayTitle = save.localTitle || rawTitle.replace(/\bpush\s+from\s+cli\b[\s·\-]*/i, '').trim();
                     } else {
                         originTag = 'Hub';
                         displayTitle = rawTitle.replace(/\b(push\s+)?from\s+(the\s+)?hub\b[\s·\-]*/i, '').replace(/\bsantai\s+hub\b[\s·\-]*/i, '').trim();
@@ -9475,7 +9491,7 @@
                         '<button class="btn btn-primary" style="flex-shrink:0;font-size:13px;padding:6px 14px;">Load</button>';
                     item.querySelector('button').addEventListener('click', () => {
                         closeCloudSavesModal();
-                        cloudPullConfirm(manifestKey);
+                        cloudPullPrepare(displayTitle, save.version, save.filesCount, save.createdAt, manifestKey);
                     });
                     listEl.appendChild(item);
                 });

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -9412,7 +9412,7 @@
                                 await Promise.all([refreshTree(), refreshFiles()]);
                                 const _n = data.filesRestored;
                                 const _detail = _n != null
-                                    ? ` ${_n} file${_n !== 1 ? 's' : ''} restored.`
+                                    ? ` ${_n} file${_n !== 1 ? 's' : ''} loaded.`
                                     : '';
                                 setCloudStatus('Successfully pulled from cloud.' + _detail, 'success');
                             } else {

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -9330,10 +9330,14 @@
 
         async function cloudPullConfirm(manifestKey) {
             if (_cloudStreaming) return;
+            if (!manifestKey) {
+                setCloudStatus('Could not identify save version — check browser console for save object fields.', 'error');
+                return;
+            }
             _cloudStreaming = true;
             setCloudStatus('Looking up project...');
             try {
-                const body = manifestKey ? {manifest_key: manifestKey} : {};
+                const body = {manifest_key: manifestKey};
                 const response = await fetch('/api/cloud/pull', {
                     method: 'POST',
                     headers: {'Content-Type': 'application/json'},
@@ -9442,7 +9446,8 @@
                     if (save.createdAt) parts.push(new Date(save.createdAt).toLocaleString());
                     if (save.size) parts.push(_fmtBytes(save.size));
                     if (save.filesCount) parts.push(save.filesCount + ' files');
-                    const manifestKey = save.manifestKey ?? save.manifest_key ?? null;
+                    const manifestKey = save.manifestKey ?? save.manifest_key ?? save.key ?? save.id ?? null;
+                    console.log('[cloud-saves] save object:', save, '→ manifestKey:', manifestKey);
 
                     const tagHtml = originTag
                         ? '<span class="cloud-save-tag">' + _escHtml(originTag) + '</span>'


### PR DESCRIPTION
### Summary
This branch delivers the selection modal tied to "Pull from Cloud" and a significant overhaul of the cloud push/pull experience end-to-end.

New cloud saves selection modal
  - "Pull from Cloud" now opens a scrollable modal listing all cloud saves instead of immediately pulling the latest
  - Each save shows a descriptive title, date, file count, and a CLI or Hub origin tag

Descriptive push titles
  - Before each push (CLI and web), the previous cloud save is fetched and diffed against the current files
  - Titles like "Add sky.md", "Update notes.md and 3 more", "Delete old.md" are generated automatically
  - Falls back to "Initial push" on first push or "Snapshot · N files" when nothing changed
  -  Titles are stored in .santai/push-titles.json on the local machine and merged into the saves list by the local web process at display time. They persist across browser sessions, but are machine-local — no browser cache dependency
---
### Test plan
<img width="1523" height="1047" alt="Screenshot 2026-05-28 at 3 15 05 PM" src="https://github.com/user-attachments/assets/c2916df1-e6ad-4056-a6fd-7a18962490f6" />

  - [ ] Saves selection modal opens correctly — click "Pull from Cloud"; modal appears with the full list of saves, each showing title, date, file count, and CLI/Hub tag
  - [ ] CLI saves show descriptive titles — "Push to Cloud" after changing/creating a file; reopen the modal and confirm the new save shows "Update notes.md" (or similar) instead of "Push from CLI" or "v12"
  - [ ] Pull correct version — open the modal, select an old save (e.g. v1 with 3 files), click Load, confirm "Load", verify the project directory now contains exactly those 3 files (not the latest 12)
<img width="273" height="235" alt="Screenshot 2026-05-28 at 3 15 48 PM" src="https://github.com/user-attachments/assets/2cada0f4-39c8-4f1e-94e8-d7781e721aeb" />
 
  - [ ] Post-pull feedback — after a pull, status bar shows "Successfully pulled from cloud. N files loaded." with the correct count
<img width="561" height="214" alt="Screenshot 2026-05-28 at 3 15 42 PM" src="https://github.com/user-attachments/assets/aba057f7-a886-4226-9448-10221773f8c3" />

  - [ ] Specific confirmation text — clicking "Load" asks the user to confirm they want to overwrite their local files; clicking "Cancel" clears it without pulling
  - [ ] Chat functionality — asking the AI chatbot to pull from the cloud loads the latest save 