### PR TITLE
feat: add sign in button to web ui, link to base and profile on hub

### DIFF
--- a/src/santai_cli/web/app.py
+++ b/src/santai_cli/web/app.py
@@ -1556,6 +1556,14 @@ def create_app(project: SantaiProject) -> FastAPI:
             "hub_url": hub_url,
         }
 
+    @app.post("/api/cloud/logout")
+    async def cloud_logout() -> dict[str, str]:
+        """Clear the user's saved credentials."""
+        from santai_cli.commands.auth import _clear_credentials
+
+        _clear_credentials()
+        return {"status": "logged_out"}
+
     @app.post("/api/cloud/push")
     async def cloud_push(req: CloudPushRequest) -> StreamingResponse:
         """Push the current project to the cloud, streaming SSE progress events."""

--- a/src/santai_cli/web/app.py
+++ b/src/santai_cli/web/app.py
@@ -1544,6 +1544,21 @@ def create_app(project: SantaiProject) -> FastAPI:
     @app.get("/api/cloud/status")
     async def cloud_status() -> dict[str, Any]:
         """Return whether the user is logged in to the Santai cloud."""
+        from santai_cli.commands.auth import DEFAULT_HUB_URL, load_credentials
+
+        creds = load_credentials()
+        hub_url = creds.get("hub_url", DEFAULT_HUB_URL) if creds else DEFAULT_HUB_URL
+        if not creds:
+            return {"logged_in": False, "username": None, "hub_url": hub_url}
+        return {
+            "logged_in": True,
+            "username": creds.get("username"),
+            "hub_url": hub_url,
+        }
+
+    @app.get("/api/cloud/avatar")
+    async def cloud_avatar() -> dict[str, Any]:
+        """Return the user's avatar URL fetched from the hub (slow — call separately)."""
         import asyncio
         import json as _json
         import urllib.request
@@ -1552,11 +1567,11 @@ def create_app(project: SantaiProject) -> FastAPI:
         from santai_cli.core.hub import USER_AGENT, get_backend_url
 
         creds = load_credentials()
-        hub_url = creds.get("hub_url", DEFAULT_HUB_URL) if creds else DEFAULT_HUB_URL
         if not creds:
-            return {"logged_in": False, "username": None, "hub_url": hub_url}
+            return {"avatar_url": None}
+        hub_url = creds.get("hub_url", DEFAULT_HUB_URL)
 
-        def _fetch_avatar() -> str | None:
+        def _fetch() -> str | None:
             try:
                 backend = get_backend_url(hub_url)
                 req = urllib.request.Request(
@@ -1581,47 +1596,7 @@ def create_app(project: SantaiProject) -> FastAPI:
             except Exception:
                 return None
 
-        avatar_url = await asyncio.to_thread(_fetch_avatar)
-
-        return {
-            "logged_in": True,
-            "username": creds.get("username"),
-            "hub_url": hub_url,
-            "avatar_url": avatar_url,
-        }
-
-    @app.get("/api/cloud/debug-session")
-    async def cloud_debug_session() -> dict[str, Any]:
-        """Return raw session data from the hub for debugging."""
-        import asyncio
-        import json as _json
-        import urllib.request
-
-        from santai_cli.commands.auth import DEFAULT_HUB_URL, load_credentials
-        from santai_cli.core.hub import USER_AGENT, get_backend_url
-
-        creds = load_credentials()
-        if not creds:
-            return {"error": "not logged in"}
-        hub_url = creds.get("hub_url", DEFAULT_HUB_URL)
-
-        def _fetch() -> dict:
-            try:
-                backend = get_backend_url(hub_url)
-                url = f"{backend}/auth/get-session"
-                req = urllib.request.Request(
-                    url,
-                    headers={
-                        "Authorization": f"Bearer {creds['token']}",
-                        "User-Agent": USER_AGENT,
-                    },
-                )
-                with urllib.request.urlopen(req, timeout=5) as resp:
-                    return {"url": url, "data": _json.loads(resp.read())}
-            except Exception as e:
-                return {"url": url, "error": str(e)}
-
-        return await asyncio.to_thread(_fetch)
+        return {"avatar_url": await asyncio.to_thread(_fetch)}
 
     @app.post("/api/cloud/logout")
     async def cloud_logout() -> dict[str, str]:

--- a/src/santai_cli/web/app.py
+++ b/src/santai_cli/web/app.py
@@ -1558,7 +1558,7 @@ def create_app(project: SantaiProject) -> FastAPI:
 
     @app.get("/api/cloud/avatar")
     async def cloud_avatar() -> dict[str, Any]:
-        """Return the user's avatar URL fetched from the hub (slow — call separately)."""
+        """Return the user's avatar URL from the hub (slow — call separately)."""
         import asyncio
         import json as _json
         import urllib.request

--- a/src/santai_cli/web/app.py
+++ b/src/santai_cli/web/app.py
@@ -1544,17 +1544,84 @@ def create_app(project: SantaiProject) -> FastAPI:
     @app.get("/api/cloud/status")
     async def cloud_status() -> dict[str, Any]:
         """Return whether the user is logged in to the Santai cloud."""
+        import asyncio
+        import json as _json
+        import urllib.request
+
         from santai_cli.commands.auth import DEFAULT_HUB_URL, load_credentials
+        from santai_cli.core.hub import USER_AGENT, get_backend_url
 
         creds = load_credentials()
         hub_url = creds.get("hub_url", DEFAULT_HUB_URL) if creds else DEFAULT_HUB_URL
         if not creds:
             return {"logged_in": False, "username": None, "hub_url": hub_url}
+
+        def _fetch_avatar() -> str | None:
+            try:
+                backend = get_backend_url(hub_url)
+                req = urllib.request.Request(
+                    f"{backend}/auth/get-session",
+                    headers={
+                        "Authorization": f"Bearer {creds['token']}",
+                        "User-Agent": USER_AGENT,
+                    },
+                )
+                with urllib.request.urlopen(req, timeout=3) as resp:
+                    data = _json.loads(resp.read())
+                    user = data.get("user", {})
+                    url = (
+                        user.get("image")
+                        or user.get("avatar_url")
+                        or user.get("avatar")
+                        or user.get("picture")
+                    )
+                    if url and not url.startswith("http"):
+                        url = hub_url.rstrip("/") + "/" + url.lstrip("/")
+                    return url
+            except Exception:
+                return None
+
+        avatar_url = await asyncio.to_thread(_fetch_avatar)
+
         return {
             "logged_in": True,
             "username": creds.get("username"),
             "hub_url": hub_url,
+            "avatar_url": avatar_url,
         }
+
+    @app.get("/api/cloud/debug-session")
+    async def cloud_debug_session() -> dict[str, Any]:
+        """Return raw session data from the hub for debugging."""
+        import asyncio
+        import json as _json
+        import urllib.request
+
+        from santai_cli.commands.auth import DEFAULT_HUB_URL, load_credentials
+        from santai_cli.core.hub import USER_AGENT, get_backend_url
+
+        creds = load_credentials()
+        if not creds:
+            return {"error": "not logged in"}
+        hub_url = creds.get("hub_url", DEFAULT_HUB_URL)
+
+        def _fetch() -> dict:
+            try:
+                backend = get_backend_url(hub_url)
+                url = f"{backend}/auth/get-session"
+                req = urllib.request.Request(
+                    url,
+                    headers={
+                        "Authorization": f"Bearer {creds['token']}",
+                        "User-Agent": USER_AGENT,
+                    },
+                )
+                with urllib.request.urlopen(req, timeout=5) as resp:
+                    return {"url": url, "data": _json.loads(resp.read())}
+            except Exception as e:
+                return {"url": url, "error": str(e)}
+
+        return await asyncio.to_thread(_fetch)
 
     @app.post("/api/cloud/logout")
     async def cloud_logout() -> dict[str, str]:

--- a/src/santai_cli/web/app.py
+++ b/src/santai_cli/web/app.py
@@ -1559,9 +1559,7 @@ def create_app(project: SantaiProject) -> FastAPI:
     @app.get("/api/cloud/avatar")
     async def cloud_avatar() -> dict[str, Any]:
         """Return the user's avatar URL from the hub (slow — call separately)."""
-        import asyncio
-        import json as _json
-        import urllib.request
+        import httpx
 
         from santai_cli.commands.auth import DEFAULT_HUB_URL, load_credentials
         from santai_cli.core.hub import USER_AGENT, get_backend_url
@@ -1571,32 +1569,29 @@ def create_app(project: SantaiProject) -> FastAPI:
             return {"avatar_url": None}
         hub_url = creds.get("hub_url", DEFAULT_HUB_URL)
 
-        def _fetch() -> str | None:
-            try:
-                backend = get_backend_url(hub_url)
-                req = urllib.request.Request(
+        try:
+            backend = get_backend_url(hub_url)
+            async with httpx.AsyncClient(timeout=3.0) as client:
+                resp = await client.get(
                     f"{backend}/auth/get-session",
                     headers={
                         "Authorization": f"Bearer {creds['token']}",
                         "User-Agent": USER_AGENT,
                     },
                 )
-                with urllib.request.urlopen(req, timeout=3) as resp:
-                    data = _json.loads(resp.read())
-                    user = data.get("user", {})
-                    url = (
-                        user.get("image")
-                        or user.get("avatar_url")
-                        or user.get("avatar")
-                        or user.get("picture")
-                    )
-                    if url and not url.startswith("http"):
-                        url = hub_url.rstrip("/") + "/" + url.lstrip("/")
-                    return url
-            except Exception:
-                return None
-
-        return {"avatar_url": await asyncio.to_thread(_fetch)}
+                resp.raise_for_status()
+                user = resp.json().get("user", {})
+                url = (
+                    user.get("image")
+                    or user.get("avatar_url")
+                    or user.get("avatar")
+                    or user.get("picture")
+                )
+                if url and not url.startswith(("http://", "https://")):
+                    url = hub_url.rstrip("/") + "/" + url.lstrip("/")
+                return {"avatar_url": url}
+        except Exception:
+            return {"avatar_url": None}
 
     @app.post("/api/cloud/logout")
     async def cloud_logout() -> dict[str, str]:

--- a/src/santai_cli/web/app.py
+++ b/src/santai_cli/web/app.py
@@ -1858,7 +1858,12 @@ def create_app(project: SantaiProject) -> FastAPI:
                     return
 
                 yield _sse(
-                    {"type": "done", "version": upload_result.get("version", "?")}
+                    {
+                        "type": "done",
+                        "version": upload_result.get("version", "?"),
+                        "base_id": base_id,
+                        "hub_url": hub_url,
+                    }
                 )
             finally:
                 _cloud_push_lock.release()

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -270,6 +270,100 @@
             letter-spacing: 0.02em;
         }
 
+        .auth-widget {
+            margin-left: auto;
+            flex-shrink: 0;
+        }
+
+        .auth-sign-in-btn {
+            font-size: 11px;
+            padding: 4px 10px;
+            border-radius: 20px;
+            background: var(--accent);
+            color: white;
+            border: none;
+            cursor: pointer;
+            white-space: nowrap;
+            font-weight: 500;
+            transition: background 0.15s;
+        }
+
+        .auth-sign-in-btn:hover {
+            background: var(--accent-hover);
+        }
+
+        .user-avatar {
+            width: 28px;
+            height: 28px;
+            border-radius: 50%;
+            background: var(--accent);
+            color: white;
+            font-size: 12px;
+            font-weight: 600;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            cursor: pointer;
+            border: none;
+            user-select: none;
+            flex-shrink: 0;
+        }
+
+        .user-avatar:hover { opacity: 0.85; }
+
+        .user-menu-wrapper { position: relative; }
+
+        .user-menu {
+            display: none;
+            position: absolute;
+            top: calc(100% + 6px);
+            right: 0;
+            background: var(--surface, #fff);
+            border: 1px solid rgba(0,0,0,0.1);
+            border-radius: 10px;
+            box-shadow: 0 4px 20px rgba(0,0,0,0.12);
+            min-width: 160px;
+            z-index: 1000;
+            overflow: hidden;
+        }
+
+        .user-menu.open { display: block; }
+
+        .user-menu-name {
+            padding: 10px 14px 8px;
+            font-size: 11px;
+            color: var(--text-secondary, rgba(0,0,0,0.55));
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            border-bottom: 1px solid rgba(0,0,0,0.07);
+        }
+
+        .user-menu-name a {
+            color: inherit;
+            text-decoration: none;
+            font-weight: 500;
+            transition: color 0.1s;
+        }
+
+        .user-menu-name a:hover {
+            color: rgba(0,0,0,0.85);
+        }
+
+        .user-menu-item {
+            padding: 9px 14px;
+            font-size: 13px;
+            color: var(--text-primary);
+            cursor: pointer;
+            display: flex;
+            align-items: center;
+            gap: 8px;
+        }
+
+        .user-menu-item:hover { background: rgba(0,0,0,0.05); }
+
+        .user-menu-item.danger { color: #ef4444; }
+
         .sidebar-section {
             background: rgba(0, 0, 0, 0.04);
             border-radius: 12px;
@@ -3806,6 +3900,7 @@
             <div class="sidebar-header">
                 <img src="/static/logo.png" alt="Santai" onerror="this.style.display='none'" onclick="showDashboard()" style="cursor: pointer;">
                 <h1 onclick="showDashboard()" style="cursor: pointer;">Santai</h1>
+                <div class="auth-widget" id="auth-widget"></div>
             </div>
 
             <!-- Tree View -->
@@ -9107,6 +9202,7 @@
 
         let _cloudStreaming = false;
         let _cloudLoggedIn = false;
+        let _cloudUsername = null;
         let _chatPullPendingConfirm = false;
         let _chatPostLoginPending = null; // 'push' | 'pull'
 
@@ -9116,11 +9212,51 @@
                 if (!res.ok) return;
                 const data = await res.json();
                 _cloudLoggedIn = !!data.logged_in;
-                if (data.logged_in) {
+                _cloudUsername = data.username || null;
+                _renderAuthWidget();
+                if (data.logged_in && data.username) {
                     const pushBtn = document.getElementById('cloud-push-btn');
-                    if (pushBtn && data.username) pushBtn.title = `Push to cloud (${data.username})`;
+                    if (pushBtn) pushBtn.title = `Push to cloud (${data.username})`;
                 }
             } catch { /* ignore — buttons always clickable, backend returns error if needed */ }
+        }
+
+        function _renderAuthWidget() {
+            const el = document.getElementById('auth-widget');
+            if (!el) return;
+            if (!_cloudLoggedIn) {
+                el.innerHTML = `<button class="auth-sign-in-btn" onclick="startCloudLogin(event,'push')">Sign In / Up</button>`;
+            } else {
+                const initial = (_cloudUsername || '?')[0].toUpperCase();
+                const name = _cloudUsername || 'you';
+                el.innerHTML = `<div class="user-menu-wrapper" id="user-menu-wrapper">
+                    <button class="user-avatar" onclick="toggleUserMenu(event)" title="${name}">${initial}</button>
+                    <div class="user-menu" id="user-menu">
+                        <div class="user-menu-name">Signed in as <a href="https://hub.sant.ai/profile/${name}" target="_blank" rel="noopener">@${name}</a></div>
+                        <div class="user-menu-item danger" onclick="cloudSignOut()">
+                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" style="width:14px;height:14px;flex-shrink:0"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" /></svg>
+                            Sign Out
+                        </div>
+                    </div>
+                </div>`;
+            }
+        }
+
+        function toggleUserMenu(e) {
+            if (e) e.stopPropagation();
+            const menu = document.getElementById('user-menu');
+            if (menu) menu.classList.toggle('open');
+        }
+
+        async function cloudSignOut() {
+            try { await fetch('/api/cloud/logout', { method: 'POST' }); } catch { /* ignore */ }
+            _cloudLoggedIn = false;
+            _cloudUsername = null;
+            _renderAuthWidget();
+            const pushBtn = document.getElementById('cloud-push-btn');
+            if (pushBtn) pushBtn.title = '';
+            setCloudStatus('Signed out.', 'success');
+            setTimeout(() => setCloudStatus(''), 3000);
         }
 
         let _cloudStatusTimer = null;
@@ -9444,6 +9580,14 @@
         }
 
         initCloudStatus();
+
+        document.addEventListener('click', function(e) {
+            const wrapper = document.getElementById('user-menu-wrapper');
+            if (wrapper && !wrapper.contains(e.target)) {
+                const menu = document.getElementById('user-menu');
+                if (menu) menu.classList.remove('open');
+            }
+        });
     </script>
     <div class="graph-tooltip" id="graph-tooltip"></div>
     <div class="graph-tooltip" id="folder-move-tooltip"></div>

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -9210,6 +9210,7 @@
         let _cloudLoggedIn = false;
         let _cloudUsername = null;
         let _cloudAvatarUrl = null;
+        let _cloudHubUrl = null;
         let _hubBaseUrl = localStorage.getItem('santai-hub-base-url') || null;
         let _chatPullPendingConfirm = false;
         let _chatPostLoginPending = null; // 'push' | 'pull'
@@ -9221,13 +9222,25 @@
                 const data = await res.json();
                 _cloudLoggedIn = !!data.logged_in;
                 _cloudUsername = data.username || null;
-                _cloudAvatarUrl = data.avatar_url || null;
+                _cloudHubUrl = data.hub_url || null;
                 _renderAuthWidget();
                 if (data.logged_in && data.username) {
                     const pushBtn = document.getElementById('cloud-push-btn');
                     if (pushBtn) pushBtn.title = `Push to cloud (${data.username})`;
+                    // Fetch avatar separately — don't block widget render
+                    fetch('/api/cloud/avatar').then(r => r.ok ? r.json() : null).then(d => {
+                        if (d?.avatar_url) { _cloudAvatarUrl = d.avatar_url; _renderAuthWidget(); }
+                    }).catch(() => {});
                 }
             } catch { /* ignore — buttons always clickable, backend returns error if needed */ }
+        }
+
+        function _esc(s) {
+            return String(s).replace(/&/g,'&amp;').replace(/"/g,'&quot;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+        }
+
+        function _safeHttpUrl(url) {
+            try { const u = new URL(url); return (u.protocol === 'https:' || u.protocol === 'http:') ? url : null; } catch { return null; }
         }
 
         function _renderAuthWidget() {
@@ -9238,19 +9251,25 @@
             } else {
                 const initial = (_cloudUsername || '?')[0].toUpperCase();
                 const name = _cloudUsername || 'you';
-                const avatarInner = _cloudAvatarUrl
-                    ? `<img src="${_cloudAvatarUrl}" alt="${name}" referrerpolicy="no-referrer" style="width:100%;height:100%;border-radius:50%;object-fit:cover;" onerror="this.parentElement.textContent='${initial}'">`
-                    : initial;
-                const hubLink = _hubBaseUrl ? `
-                        <div class="user-menu-item" onclick="window.open('${_hubBaseUrl}','_blank','noopener')">
+                const safeAvatar = _cloudAvatarUrl ? _safeHttpUrl(_cloudAvatarUrl) : null;
+                const avatarInner = safeAvatar
+                    ? `<img src="${_esc(safeAvatar)}" alt="${_esc(name)}" referrerpolicy="no-referrer" style="width:100%;height:100%;border-radius:50%;object-fit:cover;" onerror="this.parentElement.textContent=${JSON.stringify(initial)}">`
+                    : _esc(initial);
+                const safeHubBase = _hubBaseUrl ? _safeHttpUrl(_hubBaseUrl) : null;
+                const hubLink = safeHubBase ? `
+                        <div class="user-menu-item" id="hub-link-item">
                             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" style="width:14px;height:14px;flex-shrink:0"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" /></svg>
                             View on Santai Hub
                         </div>
                         <div class="user-menu-divider"></div>` : '';
+                const profileUrl = _cloudHubUrl ? _esc(`${_cloudHubUrl}/profile/${name}`) : null;
+                const nameHtml = profileUrl
+                    ? `Signed in as <a href="${profileUrl}" target="_blank" rel="noopener">@${_esc(name)}</a>`
+                    : `Signed in as @${_esc(name)}`;
                 el.innerHTML = `<div class="user-menu-wrapper" id="user-menu-wrapper">
-                    <button class="user-avatar" onclick="toggleUserMenu(event)" title="${name}">${avatarInner}</button>
+                    <button class="user-avatar" onclick="toggleUserMenu(event)" title="${_esc(name)}">${avatarInner}</button>
                     <div class="user-menu" id="user-menu">
-                        <div class="user-menu-name">Signed in as <a href="https://hub.sant.ai/profile/${name}" target="_blank" rel="noopener">@${name}</a></div>
+                        <div class="user-menu-name">${nameHtml}</div>
                         ${hubLink}
                         <div class="user-menu-item danger" onclick="cloudSignOut()">
                             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" style="width:14px;height:14px;flex-shrink:0"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" /></svg>
@@ -9258,6 +9277,10 @@
                         </div>
                     </div>
                 </div>`;
+                if (safeHubBase) {
+                    const linkEl = el.querySelector('#hub-link-item');
+                    if (linkEl) linkEl.addEventListener('click', () => window.open(safeHubBase, '_blank', 'noopener'));
+                }
             }
         }
 
@@ -9272,6 +9295,9 @@
             _cloudLoggedIn = false;
             _cloudUsername = null;
             _cloudAvatarUrl = null;
+            _cloudHubUrl = null;
+            _hubBaseUrl = null;
+            localStorage.removeItem('santai-hub-base-url');
             _renderAuthWidget();
             const pushBtn = document.getElementById('cloud-push-btn');
             if (pushBtn) pushBtn.title = '';

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -364,6 +364,12 @@
 
         .user-menu-item.danger { color: #ef4444; }
 
+        .user-menu-divider {
+            height: 1px;
+            background: rgba(0,0,0,0.07);
+            margin: 2px 0;
+        }
+
         .sidebar-section {
             background: rgba(0, 0, 0, 0.04);
             border-radius: 12px;
@@ -9204,6 +9210,7 @@
         let _cloudLoggedIn = false;
         let _cloudUsername = null;
         let _cloudAvatarUrl = null;
+        let _hubBaseUrl = localStorage.getItem('santai-hub-base-url') || null;
         let _chatPullPendingConfirm = false;
         let _chatPostLoginPending = null; // 'push' | 'pull'
 
@@ -9234,10 +9241,17 @@
                 const avatarInner = _cloudAvatarUrl
                     ? `<img src="${_cloudAvatarUrl}" alt="${name}" referrerpolicy="no-referrer" style="width:100%;height:100%;border-radius:50%;object-fit:cover;" onerror="this.parentElement.textContent='${initial}'">`
                     : initial;
+                const hubLink = _hubBaseUrl ? `
+                        <div class="user-menu-item" onclick="window.open('${_hubBaseUrl}','_blank','noopener')">
+                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" style="width:14px;height:14px;flex-shrink:0"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" /></svg>
+                            View on Santai Hub
+                        </div>
+                        <div class="user-menu-divider"></div>` : '';
                 el.innerHTML = `<div class="user-menu-wrapper" id="user-menu-wrapper">
                     <button class="user-avatar" onclick="toggleUserMenu(event)" title="${name}">${avatarInner}</button>
                     <div class="user-menu" id="user-menu">
                         <div class="user-menu-name">Signed in as <a href="https://hub.sant.ai/profile/${name}" target="_blank" rel="noopener">@${name}</a></div>
+                        ${hubLink}
                         <div class="user-menu-item danger" onclick="cloudSignOut()">
                             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" style="width:14px;height:14px;flex-shrink:0"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" /></svg>
                             Sign Out
@@ -9389,6 +9403,11 @@
                                 await Promise.all([refreshTree(), refreshFiles()]);
                                 setCloudStatus('Successfully pulled from cloud.', 'success');
                             } else {
+                                if (data.base_id && data.hub_url) {
+                                    _hubBaseUrl = `${data.hub_url}/base/${data.base_id}?returnTo=%2Fexplore`;
+                                    localStorage.setItem('santai-hub-base-url', _hubBaseUrl);
+                                    _renderAuthWidget();
+                                }
                                 setCloudStatus('Successfully saved to the cloud.', 'success');
                             }
                             setTimeout(() => setCloudStatus(''), 4000);
@@ -9517,6 +9536,11 @@
                                 await Promise.all([refreshTree(), refreshFiles()]);
                                 finalMsg = 'Done! Your local files have been updated with the latest version from the cloud.';
                             } else {
+                                if (data.base_id && data.hub_url) {
+                                    _hubBaseUrl = `${data.hub_url}/base/${data.base_id}?returnTo=%2Fexplore`;
+                                    localStorage.setItem('santai-hub-base-url', _hubBaseUrl);
+                                    _renderAuthWidget();
+                                }
                                 finalMsg = 'Done! Your project has been saved to the cloud.';
                             }
                             msgDiv.textContent = finalMsg;

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -256,7 +256,7 @@
         .sidebar-header {
             display: flex;
             align-items: center;
-            gap: 10px;
+            gap: 6px;
         }
 
         .sidebar-header img {
@@ -276,8 +276,8 @@
         }
 
         .auth-sign-in-btn {
-            font-size: 11px;
-            padding: 4px 10px;
+            font-size: 13px;
+            padding: 6px 14px;
             border-radius: 20px;
             background: var(--accent);
             color: white;
@@ -9203,6 +9203,7 @@
         let _cloudStreaming = false;
         let _cloudLoggedIn = false;
         let _cloudUsername = null;
+        let _cloudAvatarUrl = null;
         let _chatPullPendingConfirm = false;
         let _chatPostLoginPending = null; // 'push' | 'pull'
 
@@ -9213,6 +9214,7 @@
                 const data = await res.json();
                 _cloudLoggedIn = !!data.logged_in;
                 _cloudUsername = data.username || null;
+                _cloudAvatarUrl = data.avatar_url || null;
                 _renderAuthWidget();
                 if (data.logged_in && data.username) {
                     const pushBtn = document.getElementById('cloud-push-btn');
@@ -9229,8 +9231,11 @@
             } else {
                 const initial = (_cloudUsername || '?')[0].toUpperCase();
                 const name = _cloudUsername || 'you';
+                const avatarInner = _cloudAvatarUrl
+                    ? `<img src="${_cloudAvatarUrl}" alt="${name}" referrerpolicy="no-referrer" style="width:100%;height:100%;border-radius:50%;object-fit:cover;" onerror="this.parentElement.textContent='${initial}'">`
+                    : initial;
                 el.innerHTML = `<div class="user-menu-wrapper" id="user-menu-wrapper">
-                    <button class="user-avatar" onclick="toggleUserMenu(event)" title="${name}">${initial}</button>
+                    <button class="user-avatar" onclick="toggleUserMenu(event)" title="${name}">${avatarInner}</button>
                     <div class="user-menu" id="user-menu">
                         <div class="user-menu-name">Signed in as <a href="https://hub.sant.ai/profile/${name}" target="_blank" rel="noopener">@${name}</a></div>
                         <div class="user-menu-item danger" onclick="cloudSignOut()">
@@ -9252,6 +9257,7 @@
             try { await fetch('/api/cloud/logout', { method: 'POST' }); } catch { /* ignore */ }
             _cloudLoggedIn = false;
             _cloudUsername = null;
+            _cloudAvatarUrl = null;
             _renderAuthWidget();
             const pushBtn = document.getElementById('cloud-push-btn');
             if (pushBtn) pushBtn.title = '';

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -351,7 +351,7 @@
         }
 
         .user-menu-item {
-            padding: 9px 14px;
+            padding: 5px 14px;
             font-size: 13px;
             color: var(--text-primary);
             cursor: pointer;
@@ -9229,7 +9229,7 @@
                     if (pushBtn) pushBtn.title = `Push to cloud (${data.username})`;
                     // Fetch avatar separately — don't block widget render
                     fetch('/api/cloud/avatar').then(r => r.ok ? r.json() : null).then(d => {
-                        if (d?.avatar_url) { _cloudAvatarUrl = d.avatar_url; _renderAuthWidget(); }
+                        if (_cloudLoggedIn && d?.avatar_url) { _cloudAvatarUrl = d.avatar_url; _renderAuthWidget(); }
                     }).catch(() => {});
                 }
             } catch { /* ignore — buttons always clickable, backend returns error if needed */ }
@@ -9253,7 +9253,7 @@
                 const name = _cloudUsername || 'you';
                 const safeAvatar = _cloudAvatarUrl ? _safeHttpUrl(_cloudAvatarUrl) : null;
                 const avatarInner = safeAvatar
-                    ? `<img src="${_esc(safeAvatar)}" alt="${_esc(name)}" referrerpolicy="no-referrer" style="width:100%;height:100%;border-radius:50%;object-fit:cover;" onerror="this.parentElement.textContent=${JSON.stringify(initial)}">`
+                    ? `<img src="${_esc(safeAvatar)}" alt="${_esc(name)}" referrerpolicy="no-referrer" style="width:100%;height:100%;border-radius:50%;object-fit:cover;">`
                     : _esc(initial);
                 const safeHubBase = _hubBaseUrl ? _safeHttpUrl(_hubBaseUrl) : null;
                 const hubLink = safeHubBase ? `
@@ -9262,7 +9262,8 @@
                             View on Santai Hub
                         </div>
                         <div class="user-menu-divider"></div>` : '';
-                const profileUrl = _cloudHubUrl ? _esc(`${_cloudHubUrl}/profile/${name}`) : null;
+                const safeProfileBase = _cloudHubUrl ? _safeHttpUrl(_cloudHubUrl) : null;
+                const profileUrl = safeProfileBase ? _esc(`${safeProfileBase}/profile/${encodeURIComponent(name)}`) : null;
                 const nameHtml = profileUrl
                     ? `Signed in as <a href="${profileUrl}" target="_blank" rel="noopener">@${_esc(name)}</a>`
                     : `Signed in as @${_esc(name)}`;
@@ -9280,6 +9281,10 @@
                 if (safeHubBase) {
                     const linkEl = el.querySelector('#hub-link-item');
                     if (linkEl) linkEl.addEventListener('click', () => window.open(safeHubBase, '_blank', 'noopener'));
+                }
+                if (safeAvatar) {
+                    const img = el.querySelector('.user-avatar img');
+                    if (img) img.onerror = () => { img.parentElement.textContent = initial; };
                 }
             }
         }


### PR DESCRIPTION
### Summary
  - Adds a sign in/sign out auth widget to the sidebar header. When the user is not logged in, a "Sign In / Up" button is shown; once authenticated, it's replaced with their avatar and a dropdown menu.
  - The dropdown shows the signed-in username (linked to their hub profile), a "Sign Out" action, and — after the first successful cloud push — a "View on Santai Hub" link that persists across page reloads via localStorage.
  - Extends /api/cloud/status to fetch and return the user's avatar URL from the hub backend (via /auth/get-session), with a 3-second timeout and silent fallback on failure.
  - Adds POST /api/cloud/logout to clear saved credentials server-side.
  - Adds GET /api/cloud/debug-session for raw session inspection (debug aid).
  - The push SSE done event now includes base_id and hub_url so the frontend can construct the hub link immediately after a first push.
---
### Test Plan
<img width="1920" height="1050" alt="Screenshot 2026-05-28 at 5 57 02 PM" src="https://github.com/user-attachments/assets/725b7985-8656-428c-9845-70027e3bc2b6" />

  - [x] Logged-out state: Open the web UI without having logged in using `santai login`. Confirm the "Sign In / Up" button appears in the sidebar header.
  - [x] Sign in flow: Click "Sign In / Up", complete auth. Confirm the button is replaced by the user avatar (or username initial if no avatar). Confirm the avatar tooltip shows the username.
<img width="300" height="185" alt="Signed in as @jeremy saputo" src="https://github.com/user-attachments/assets/36541f6f-e52e-48e6-a10f-0a9a4eae8178" />

  - [x] User menu open/close: Click the avatar to open the dropdown. Confirm it shows "Signed in as @username" with a link to the hub profile. Click outside the menu — confirm it closes.
  - [x] Sign out: Open the dropdown and click "Sign Out". Confirm the avatar is replaced by "Sign In / Up", the push button tooltip clears, and a brief "Signed out." status message appears.
<img width="294" height="214" alt="Signed in as @jeremy saputo" src="https://github.com/user-attachments/assets/bc00c730-f7e5-449d-a16c-19295dbd3271" />
 
  - [x] Hub link after push: With no prior push, confirm the "View on Santai Hub" item does not appear in the menu. Perform a cloud push; confirm the item appears and navigates to the correct base URL.