### PR TITLE
feat: add keyboard shortcut undo (Ctrl+Z / Cmd+Z), redo (Ctrl+Shift+Z / Cmd+Shift+Z) for file operations, file tree bulk deletion

### DIFF
--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -4251,7 +4251,6 @@
                         <!-- Breadcrumbs populated by JavaScript -->
                     </nav>
                 </div>
-                <div id="grid-selection-bar" style="display:none;padding:4px 12px;font-size:12px;color:var(--text-secondary);background:var(--bg-secondary);border-bottom:1px solid var(--border);user-select:none;"></div>
                 <div class="file-grid-container" id="file-grid-container" onclick="if(event.target===this||event.target.classList.contains('file-grid')){clearGridSelection();selectedItem=null;}">
                     <div class="loading">
                         <div class="spinner"></div>
@@ -4632,23 +4631,10 @@
         let lastClickedPath = null;    // anchor for shift-range selection
         let lastGridAnchorPath = null; // anchor for shift-range selection in file grid
 
-        function updateGridSelectionBar() {
-            const bar = document.getElementById('grid-selection-bar');
-            if (!bar) return;
-            const n = gridSelectedPaths.size;
-            if (n > 1) {
-                bar.textContent = `${n} items selected`;
-                bar.style.display = 'block';
-            } else {
-                bar.style.display = 'none';
-            }
-        }
-
         function clearGridSelection() {
             gridSelectedPaths.clear();
             lastGridAnchorPath = null;
             document.querySelectorAll('.file-item.selected').forEach(i => i.classList.remove('selected'));
-            updateGridSelectionBar();
         }
         let files = [];
         let previewPath = null;
@@ -5432,7 +5418,6 @@
                         gridSelectedPaths.add(allItems[i].dataset.path);
                     }
                     selectedItem = { path, isDir: el.dataset.isDir === 'true', name: el.dataset.name };
-                    updateGridSelectionBar();
                     return; // No auto-navigate in multi-select mode
                 }
             }
@@ -5450,7 +5435,6 @@
                     ? { path, isDir: el.dataset.isDir === 'true', name: el.dataset.name }
                     : null;
                 lastGridAnchorPath = path;
-                updateGridSelectionBar();
                 return; // No auto-navigate in multi-select mode
             }
 
@@ -5461,7 +5445,6 @@
             el.classList.add('selected');
             gridSelectedPaths.add(path);
             selectedItem = { path, isDir: el.dataset.isDir === 'true', name: el.dataset.name };
-            updateGridSelectionBar();
 
             // Auto-open: preview for files, navigate for folders
             if (selectedItem.isDir) {
@@ -6945,7 +6928,6 @@
                     allItems.forEach(i => { i.classList.add('selected'); gridSelectedPaths.add(i.dataset.path); });
                     lastGridAnchorPath = allItems[0].dataset.path;
                     selectedItem = { path: allItems[0].dataset.path, isDir: allItems[0].dataset.isDir === 'true', name: allItems[0].dataset.name };
-                    updateGridSelectionBar();
                 }
                 return;
             }

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -4659,6 +4659,11 @@
                 if (this._stack.length > this._maxHistory) this._stack.shift();
                 this._notify();
             }
+            restoreToUndo(op) {
+                this._stack.push(op);
+                if (this._stack.length > this._maxHistory) this._stack.shift();
+                this._notify();
+            }
             canUndo() { return this._stack.length > 0; }
             canRedo() { return this._redoStack.length > 0; }
             peek() { return this._stack[this._stack.length - 1] || null; }
@@ -4666,6 +4671,7 @@
             get size() { return this._stack.length; }
         }
         const undoManager = new UndoManager();
+        let _undoRedoBusy = false;
         function hasPreviewContent() {
             const header = document.getElementById('preview-file-header');
             return Boolean(header) && header.style.display !== 'none';
@@ -5040,6 +5046,7 @@
 
             try {
                 const snapshot = await _snapshotForDelete(previewPath, false);
+                if (!snapshot && !confirm(`"${filename}" is a binary or large file and cannot be undone — delete anyway?`)) return;
                 const res = await fetch(`/api/files?path=${encodeURIComponent(previewPath)}`, {
                     method: 'DELETE'
                 });
@@ -5568,6 +5575,7 @@
 
             const failed = [];
             const succeeded = [];
+            const noSnapshot = [];
             for (const item of items) {
                 try {
                     const snapshot = await _snapshotForDelete(item.path, item.isDir);
@@ -5576,7 +5584,11 @@
                         const err = await res.json();
                         throw new Error(err.detail || 'Failed to delete');
                     }
-                    if (snapshot) succeeded.push({ type: 'DELETE', path: item.path, isDir: item.isDir, snapshot, label: `Delete "${item.name}"` });
+                    if (snapshot) {
+                        succeeded.push({ type: 'DELETE', path: item.path, isDir: item.isDir, snapshot, label: `Delete "${item.name}"` });
+                    } else {
+                        noSnapshot.push(item.name);
+                    }
                     if (previewReferencesPath(item.path, item.isDir)) closePreview();
                 } catch (err) {
                     failed.push(item.name);
@@ -5596,6 +5608,9 @@
                 showToast(`Deleted ${items.length} items`, false, true);
             } else {
                 showToast(`Failed to delete: ${failed.join(', ')}`, true);
+            }
+            if (noSnapshot.length > 0) {
+                showToast(`${noSnapshot.length} item(s) deleted without undo (binary or large file): ${noSnapshot.join(', ')}`, true);
             }
             loadFiles(currentPath);
             loadTree();
@@ -5953,6 +5968,7 @@
 
             try {
                 const snapshot = await _snapshotForDelete(selectedItem.path, Boolean(selectedItem.is_dir));
+                if (!snapshot && !confirm(`"${selectedItem.name}" is a binary or large file and cannot be undone — delete anyway?`)) return;
                 const res = await fetch(`/api/files?path=${encodeURIComponent(selectedItem.path)}`, {
                     method: 'DELETE'
                 });
@@ -6673,54 +6689,95 @@
 
         async function _undoBulkMove(op) {
             const total = op.moves.length;
+            const remaining = [];
             for (let i = 0; i < total; i++) {
                 if (total > 1) showToast(`Undoing move ${i + 1}/${total}…`);
                 const m = op.moves[i];
-                const res = await fetch('/api/files/move', {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ source_path: m.newPath, target_folder: m.originalParent })
-                });
-                if (!res.ok) { const err = await res.json(); throw new Error(err.detail || 'Failed to undo move'); }
+                try {
+                    const res = await fetch('/api/files/move', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ source_path: m.newPath, target_folder: m.originalParent })
+                    });
+                    if (!res.ok) { const err = await res.json(); throw new Error(err.detail || 'Failed to undo move'); }
+                } catch (_) {
+                    remaining.push(m);
+                }
+            }
+            if (remaining.length > 0) {
+                const err = new Error(`Failed to undo ${remaining.length} move(s)`);
+                err.partialOp = { ...op, moves: remaining };
+                throw err;
             }
         }
 
         async function _redoBulkMove(op) {
             const total = op.moves.length;
+            const remaining = [];
             for (let i = 0; i < total; i++) {
                 if (total > 1) showToast(`Redoing move ${i + 1}/${total}…`);
                 const m = op.moves[i];
                 const targetFolder = m.newPath.includes('/') ? m.newPath.split('/').slice(0, -1).join('/') : '';
-                const res = await fetch('/api/files/move', {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ source_path: m.originalPath, target_folder: targetFolder })
-                });
-                if (!res.ok) { const err = await res.json(); throw new Error(err.detail || 'Failed to redo move'); }
+                try {
+                    const res = await fetch('/api/files/move', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ source_path: m.originalPath, target_folder: targetFolder })
+                    });
+                    if (!res.ok) { const err = await res.json(); throw new Error(err.detail || 'Failed to redo move'); }
+                } catch (_) {
+                    remaining.push(m);
+                }
+            }
+            if (remaining.length > 0) {
+                const err = new Error(`Failed to redo ${remaining.length} move(s)`);
+                err.partialOp = { ...op, moves: remaining };
+                throw err;
             }
         }
 
         async function _undoBulkDelete(op) {
             const total = op.ops.length;
+            const remaining = [];
             for (let i = 0; i < total; i++) {
                 showToast(`Restoring ${i + 1}/${total}…`);
-                await _undoDelete(op.ops[i]);
+                try {
+                    await _undoDelete(op.ops[i]);
+                } catch (_) {
+                    remaining.push(op.ops[i]);
+                }
+            }
+            if (remaining.length > 0) {
+                const err = new Error(`Failed to restore ${remaining.length} item(s)`);
+                err.partialOp = { ...op, ops: remaining };
+                throw err;
             }
         }
 
         async function _redoBulkDelete(op) {
             const total = op.ops.length;
+            const remaining = [];
             for (let i = 0; i < total; i++) {
                 showToast(`Deleting ${i + 1}/${total}…`);
-                await _redoDelete(op.ops[i]);
+                try {
+                    await _redoDelete(op.ops[i]);
+                } catch (_) {
+                    remaining.push(op.ops[i]);
+                }
+            }
+            if (remaining.length > 0) {
+                const err = new Error(`Failed to redo ${remaining.length} deletion(s)`);
+                err.partialOp = { ...op, ops: remaining };
+                throw err;
             }
         }
 
         async function performUndo() {
-            if (!undoManager.canUndo()) {
-                showToast('Nothing to undo');
+            if (_undoRedoBusy || !undoManager.canUndo()) {
+                if (!_undoRedoBusy) showToast('Nothing to undo');
                 return;
             }
+            _undoRedoBusy = true;
             const op = undoManager.pop();
             try {
                 switch (op.type) {
@@ -6738,8 +6795,10 @@
                 loadFiles(currentPath);
                 loadTree();
             } catch (err) {
-                undoManager.push(op); // restore on failure (push re-clears redo, but the op survives)
+                undoManager.restoreToUndo(err.partialOp || op);
                 showToast(`Undo failed: ${err.message}`, true);
+            } finally {
+                _undoRedoBusy = false;
             }
         }
 
@@ -6788,10 +6847,11 @@
         }
 
         async function performRedo() {
-            if (!undoManager.canRedo()) {
-                showToast('Nothing to redo');
+            if (_undoRedoBusy || !undoManager.canRedo()) {
+                if (!_undoRedoBusy) showToast('Nothing to redo');
                 return;
             }
+            _undoRedoBusy = true;
             const op = undoManager.popRedo();
             try {
                 switch (op.type) {
@@ -6809,8 +6869,10 @@
                 loadFiles(currentPath);
                 loadTree();
             } catch (err) {
-                undoManager.pushRedo(op); // restore on failure
+                undoManager.pushRedo(err.partialOp || op);
                 showToast(`Redo failed: ${err.message}`, true);
+            } finally {
+                _undoRedoBusy = false;
             }
         }
 
@@ -6903,15 +6965,13 @@
             // Cmd+A / Ctrl+A — select all items in the file grid and tree
             if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'a' && !inInput && currentView === 'browser') {
                 e.preventDefault();
-                // If a file is being previewed, scope selection to that file's parent folder
+                // Scope to previewed file's parent folder, or current browsed folder if no preview
                 const scopeFolder = previewPath
-                    ? previewPath.includes('/') ? previewPath.split('/').slice(0, -1).join('/') : ''
-                    : null;
-                const inScope = (itemPath) => scopeFolder === null
-                    ? true
-                    : scopeFolder === ''
-                        ? !itemPath.includes('/')
-                        : itemPath.startsWith(scopeFolder + '/') && !itemPath.slice(scopeFolder.length + 1).includes('/');
+                    ? (previewPath.includes('/') ? previewPath.split('/').slice(0, -1).join('/') : '')
+                    : currentPath;
+                const inScope = (itemPath) => scopeFolder === ''
+                    ? !itemPath.includes('/')
+                    : itemPath.startsWith(scopeFolder + '/') && !itemPath.slice(scopeFolder.length + 1).includes('/');
                 // Grid
                 const allGridItems = Array.from(document.querySelectorAll('#file-grid-container .file-item'));
                 const scopedGridItems = scopeFolder === null ? allGridItems : allGridItems.filter(i => inScope(i.dataset.path));

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -6900,16 +6900,21 @@
                 return;
             }
 
-            // Cmd+A / Ctrl+A — select all items in file grid
-            if ((e.ctrlKey || e.metaKey) && e.key === 'a' && !inInput && currentView === 'browser') {
+            // Cmd+A / Ctrl+A — select all items in the file grid and tree
+            if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'a' && !inInput && currentView === 'browser') {
                 e.preventDefault();
-                const allItems = Array.from(document.querySelectorAll('.file-item'));
-                if (allItems.length > 0) {
-                    gridSelectedPaths.clear();
-                    allItems.forEach(i => { i.classList.add('selected'); gridSelectedPaths.add(i.dataset.path); });
-                    lastGridAnchorPath = allItems[0].dataset.path;
-                    selectedItem = { path: allItems[0].dataset.path, isDir: allItems[0].dataset.isDir === 'true', name: allItems[0].dataset.name };
+                // Grid
+                const allGridItems = Array.from(document.querySelectorAll('#file-grid-container .file-item'));
+                gridSelectedPaths.clear();
+                allGridItems.forEach(i => { i.classList.add('selected'); gridSelectedPaths.add(i.dataset.path); });
+                if (allGridItems.length > 0) {
+                    lastGridAnchorPath = allGridItems[0].dataset.path;
+                    selectedItem = { path: allGridItems[0].dataset.path, isDir: allGridItems[0].dataset.isDir === 'true', name: allGridItems[0].dataset.name };
                 }
+                // Tree
+                const allTreeItems = getFlatVisibleTreeItems();
+                selectedItems = new Set(allTreeItems.map(el => el.dataset.path));
+                updateTreeSelection();
                 return;
             }
 

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -4235,18 +4235,6 @@
                             </svg>
                         </button>
                     </div>
-                    <div class="nav-arrows">
-                        <button class="nav-arrow" id="btn-undo" onclick="performUndo()" title="Undo (⌘Z)" disabled>
-                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 10h10a8 8 0 018 8v2M3 10l6 6m-6-6l6-6" />
-                            </svg>
-                        </button>
-                        <button class="nav-arrow" id="btn-redo" onclick="performRedo()" title="Redo (⌘⇧Z)" disabled>
-                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 10H11a8 8 0 00-8 8v2M21 10l-6 6m6-6l-6-6" />
-                            </svg>
-                        </button>
-                    </div>
                     <nav class="browser-breadcrumbs" id="browser-breadcrumbs">
                         <!-- Breadcrumbs populated by JavaScript -->
                     </nav>
@@ -4678,13 +4666,6 @@
             get size() { return this._stack.length; }
         }
         const undoManager = new UndoManager();
-        function updateUndoRedoButtons() {
-            const undoBtn = document.getElementById('btn-undo');
-            const redoBtn = document.getElementById('btn-redo');
-            if (undoBtn) undoBtn.disabled = !undoManager.canUndo();
-            if (redoBtn) redoBtn.disabled = !undoManager.canRedo();
-        }
-        undoManager._onChange = updateUndoRedoButtons;
         function hasPreviewContent() {
             const header = document.getElementById('preview-file-header');
             return Boolean(header) && header.style.display !== 'none';

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -4627,7 +4627,9 @@
         let currentPath = '';
         let selectedItem = null;
         let selectedItems = new Set(); // paths of multi-selected tree items
+        let gridSelectedPaths = new Set(); // paths of multi-selected file-grid items
         let lastClickedPath = null;    // anchor for shift-range selection
+        let lastGridAnchorPath = null; // anchor for shift-range selection in file grid
         let files = [];
         let previewPath = null;
         let previewHistory = []; // paths navigated via markdown links, for back-button
@@ -5219,6 +5221,8 @@
         async function loadFilesInternal(path = '') {
             currentPath = path;
             selectedItem = null;
+            gridSelectedPaths.clear();
+            lastGridAnchorPath = null;
             updateNavButtons();
 
             const container = document.getElementById('file-grid-container');
@@ -5256,6 +5260,8 @@
 
             currentPath = path;
             selectedItem = null;
+            gridSelectedPaths.clear();
+            lastGridAnchorPath = null;
             updateNavButtons();
 
             const container = document.getElementById('file-grid-container');
@@ -5368,12 +5374,12 @@
                         <div class="file-meta">${item.is_dir ? 'Folder' : item.size_formatted}</div>
                     </div>`;
                 html += `<div class="file-actions">
-                        <button class="file-action-btn edit-btn" onclick="event.stopPropagation(); editItem('${escAttr(item.path)}', '${escAttr(item.name)}')" title="Rename (⌘Z to undo)">
+                        <button class="file-action-btn edit-btn" onmousedown="event.stopPropagation()" onclick="event.stopPropagation(); editItem('${escAttr(item.path)}', '${escAttr(item.name)}')" title="Rename (⌘Z to undo)">
                             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                                 <path stroke-linecap="round" stroke-linejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931z" />
                             </svg>
                         </button>
-                        <button class="file-action-btn delete-btn" onclick="event.stopPropagation(); deleteItem('${escAttr(item.path)}', '${escAttr(item.name)}', ${item.is_dir})" title="Delete (⌘Z to undo)">
+                        <button class="file-action-btn delete-btn" onmousedown="event.stopPropagation()" onclick="event.stopPropagation(); deleteItem('${escAttr(item.path)}', '${escAttr(item.name)}', ${item.is_dir})" title="Delete (⌘Z to undo)">
                             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                                 <path stroke-linecap="round" stroke-linejoin="round" d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0" />
                             </svg>
@@ -5388,13 +5394,53 @@
         // Select item
         function selectItem(el, event) {
             event.stopPropagation();
-            document.querySelectorAll('.file-item').forEach(i => i.classList.remove('selected'));
+            // Guard: action buttons (edit/delete) handle their own clicks — don't clear selection
+            if (event.target && event.target.closest && event.target.closest('.file-action-btn')) return;
+
+            const path = el.dataset.path;
+            const allItems = Array.from(document.querySelectorAll('.file-item'));
+
+            if (event.shiftKey && lastGridAnchorPath) {
+                // Shift+click: select range from anchor to current item
+                const anchorIdx = allItems.findIndex(i => i.dataset.path === lastGridAnchorPath);
+                const currIdx = allItems.findIndex(i => i.dataset.path === path);
+                if (anchorIdx !== -1 && currIdx !== -1) {
+                    const lo = Math.min(anchorIdx, currIdx);
+                    const hi = Math.max(anchorIdx, currIdx);
+                    gridSelectedPaths.clear();
+                    allItems.forEach(i => i.classList.remove('selected'));
+                    for (let i = lo; i <= hi; i++) {
+                        allItems[i].classList.add('selected');
+                        gridSelectedPaths.add(allItems[i].dataset.path);
+                    }
+                    selectedItem = { path, isDir: el.dataset.isDir === 'true', name: el.dataset.name };
+                    return; // No auto-navigate in multi-select mode
+                }
+            }
+
+            if (event.metaKey || event.ctrlKey) {
+                // Cmd/Ctrl+click: toggle this item in the multi-selection
+                if (gridSelectedPaths.has(path)) {
+                    gridSelectedPaths.delete(path);
+                    el.classList.remove('selected');
+                } else {
+                    gridSelectedPaths.add(path);
+                    el.classList.add('selected');
+                }
+                selectedItem = gridSelectedPaths.size > 0
+                    ? { path, isDir: el.dataset.isDir === 'true', name: el.dataset.name }
+                    : null;
+                lastGridAnchorPath = path;
+                return; // No auto-navigate in multi-select mode
+            }
+
+            // Regular click: set anchor, clear multi-select, select only this item
+            lastGridAnchorPath = path;
+            gridSelectedPaths.clear();
+            allItems.forEach(i => i.classList.remove('selected'));
             el.classList.add('selected');
-            selectedItem = {
-                path: el.dataset.path,
-                isDir: el.dataset.isDir === 'true',
-                name: el.dataset.name
-            };
+            gridSelectedPaths.add(path);
+            selectedItem = { path, isDir: el.dataset.isDir === 'true', name: el.dataset.name };
 
             // Auto-open: preview for files, navigate for folders
             if (selectedItem.isDir) {
@@ -5474,8 +5520,33 @@
         // is allowed (the layout is recommended, not enforced) but worth a nudge.
         const SANTAI_DIRS = ['media', 'history', 'notes'];
 
+        // Gather items currently multi-selected across tree or grid (returns [] if < 2)
+        function _getMultiSelectedItems(clickedPath) {
+            // Tree multi-select takes priority when ≥2 tree items are selected
+            if (selectedItems.size > 1 && (clickedPath == null || selectedItems.has(clickedPath))) {
+                return Array.from(document.querySelectorAll('#tree-view .tree-item.tree-selected')).map(el => ({
+                    path: el.dataset.path,
+                    name: el.dataset.path.split('/').pop(),
+                    isDir: el.dataset.isDir === 'true'
+                }));
+            }
+            // Grid multi-select
+            const gridEls = Array.from(document.querySelectorAll('.file-item.selected'));
+            if (gridEls.length > 1) {
+                return gridEls.map(el => ({
+                    path: el.dataset.path,
+                    name: el.dataset.name,
+                    isDir: el.dataset.isDir === 'true'
+                }));
+            }
+            return [];
+        }
+
         // Delete item directly (from button)
         async function deleteItem(path, name, isDir) {
+            const multi = _getMultiSelectedItems(path);
+            if (multi.length > 0) return deleteSelectedItems(multi);
+
             const isSantaiDir = isDir && SANTAI_DIRS.includes(path);
             const msg = isSantaiDir
                 ? `Delete folder "${name}" and all its contents?\n\n"${name}" is one of the recommended santai folders — you can recreate it later if needed.`
@@ -5503,6 +5574,46 @@
             } catch (err) {
                 showToast(err.message, true);
             }
+        }
+
+        async function deleteSelectedItems(items) {
+            if (!items || items.length === 0) return;
+
+            if (!confirm(`Delete ${items.length} items?`)) return;
+
+            const failed = [];
+            const succeeded = [];
+            for (const item of items) {
+                try {
+                    const snapshot = await _snapshotForDelete(item.path, item.isDir);
+                    const res = await fetch(`/api/files?path=${encodeURIComponent(item.path)}`, { method: 'DELETE' });
+                    if (!res.ok) {
+                        const err = await res.json();
+                        throw new Error(err.detail || 'Failed to delete');
+                    }
+                    if (snapshot) succeeded.push({ type: 'DELETE', path: item.path, isDir: item.isDir, snapshot, label: `Delete "${item.name}"` });
+                    if (previewReferencesPath(item.path, item.isDir)) closePreview();
+                } catch (err) {
+                    failed.push(item.name);
+                }
+            }
+
+            if (succeeded.length === 1) {
+                undoManager.push(succeeded[0]);
+            } else if (succeeded.length > 1) {
+                undoManager.push({ type: 'BULK_DELETE', ops: succeeded, label: `Delete ${succeeded.length} items` });
+            }
+
+            gridSelectedPaths.clear();
+            selectedItems.clear();
+            updateTreeSelection();
+            if (failed.length === 0) {
+                showToast(`Deleted ${items.length} items`, false, true);
+            } else {
+                showToast(`Failed to delete: ${failed.join(', ')}`, true);
+            }
+            loadFiles(currentPath);
+            loadTree();
         }
 
         // Move item (drag and drop)
@@ -5843,6 +5954,9 @@
 
         // Delete
         async function deleteSelected() {
+            const multi = _getMultiSelectedItems(null);
+            if (multi.length > 0) return deleteSelectedItems(multi);
+
             if (!selectedItem) return;
             const isSantaiDir = selectedItem.is_dir && SANTAI_DIRS.includes(selectedItem.path);
             const deleteMsg = isSantaiDir
@@ -6572,6 +6686,14 @@
             if (previewPath && (previewPath === op.path || previewPath.startsWith(op.path + '/'))) closePreview();
         }
 
+        async function _undoBulkDelete(op) {
+            for (const subOp of op.ops) await _undoDelete(subOp);
+        }
+
+        async function _redoBulkDelete(op) {
+            for (const subOp of op.ops) await _redoDelete(subOp);
+        }
+
         async function performUndo() {
             if (!undoManager.canUndo()) {
                 showToast('Nothing to undo');
@@ -6586,6 +6708,7 @@
                     case 'CREATE_FILE':
                     case 'CREATE_FOLDER': await _undoCreate(op); break;
                     case 'DELETE':        await _undoDelete(op); break;
+                    case 'BULK_DELETE':   await _undoBulkDelete(op); break;
                 }
                 undoManager.pushRedo(op);
                 showToast(`Undid: ${op.label}`, false, false, true);
@@ -6655,6 +6778,7 @@
                     case 'CREATE_FILE':
                     case 'CREATE_FOLDER': await _redoCreate(op); break;
                     case 'DELETE':        await _redoDelete(op); break;
+                    case 'BULK_DELETE':   await _redoBulkDelete(op); break;
                 }
                 undoManager.pushFromRedo(op);
                 showToast(`Redid: ${op.label}`, false, true);

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -6903,17 +6903,28 @@
             // Cmd+A / Ctrl+A — select all items in the file grid and tree
             if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'a' && !inInput && currentView === 'browser') {
                 e.preventDefault();
+                // If a file is being previewed, scope selection to that file's parent folder
+                const scopeFolder = previewPath
+                    ? previewPath.includes('/') ? previewPath.split('/').slice(0, -1).join('/') : ''
+                    : null;
+                const inScope = (itemPath) => scopeFolder === null
+                    ? true
+                    : scopeFolder === ''
+                        ? !itemPath.includes('/')
+                        : itemPath.startsWith(scopeFolder + '/') && !itemPath.slice(scopeFolder.length + 1).includes('/');
                 // Grid
                 const allGridItems = Array.from(document.querySelectorAll('#file-grid-container .file-item'));
+                const scopedGridItems = scopeFolder === null ? allGridItems : allGridItems.filter(i => inScope(i.dataset.path));
                 gridSelectedPaths.clear();
-                allGridItems.forEach(i => { i.classList.add('selected'); gridSelectedPaths.add(i.dataset.path); });
-                if (allGridItems.length > 0) {
-                    lastGridAnchorPath = allGridItems[0].dataset.path;
-                    selectedItem = { path: allGridItems[0].dataset.path, isDir: allGridItems[0].dataset.isDir === 'true', name: allGridItems[0].dataset.name };
+                allGridItems.forEach(i => i.classList.remove('selected'));
+                scopedGridItems.forEach(i => { i.classList.add('selected'); gridSelectedPaths.add(i.dataset.path); });
+                if (scopedGridItems.length > 0) {
+                    lastGridAnchorPath = scopedGridItems[0].dataset.path;
+                    selectedItem = { path: scopedGridItems[0].dataset.path, isDir: scopedGridItems[0].dataset.isDir === 'true', name: scopedGridItems[0].dataset.name };
                 }
                 // Tree
                 const allTreeItems = getFlatVisibleTreeItems();
-                selectedItems = new Set(allTreeItems.map(el => el.dataset.path));
+                selectedItems = new Set(allTreeItems.filter(el => inScope(el.dataset.path)).map(el => el.dataset.path));
                 updateTreeSelection();
                 return;
             }
@@ -10222,6 +10233,16 @@
             if (previewPanel && previewPanel.classList.contains('fullscreen')) {
                 e.preventDefault();
                 togglePreviewFullscreen();
+                return;
+            }
+
+            // Deselect multi-selected files before closing anything
+            if (gridSelectedPaths.size > 1 || selectedItems.size > 1) {
+                e.preventDefault();
+                clearGridSelection();
+                selectedItem = null;
+                selectedItems.clear();
+                updateTreeSelection();
                 return;
             }
 

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -2157,18 +2157,28 @@
 
         .toast-undo-btn {
             background: none;
-            border: 1px solid currentColor;
+            border: 0px solid currentColor;
             border-radius: 6px;
             color: inherit;
             cursor: pointer;
             font-size: 12px;
             font-weight: 600;
             letter-spacing: 0.02em;
+            margin-left: 0;
+            max-width: 0;
+            opacity: 0;
+            overflow: hidden;
+            padding: 2px 0;
+            transition: opacity 0.2s, max-width 0.2s, margin-left 0.2s, padding 0.2s, border-width 0.2s;
+            vertical-align: middle;
+            white-space: nowrap;
+        }
+        .toast:hover .toast-undo-btn {
+            border-width: 1px;
             margin-left: 10px;
+            max-width: 80px;
             opacity: 0.8;
             padding: 2px 8px;
-            transition: opacity 0.15s, background 0.15s;
-            vertical-align: middle;
         }
         .toast-undo-btn:hover {
             background: rgba(0, 0, 0, 0.08);

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -1162,6 +1162,7 @@
             height: 80vh;
             display: flex;
             flex-direction: column;
+            padding-bottom: 16px;
         }
 
         .edit-modal-header {
@@ -4487,9 +4488,9 @@
                 </button>
             </div>
             <textarea class="edit-textarea" id="edit-textarea" placeholder="File content..."></textarea>
-            <div class="modal-actions">
-                <button class="btn" onclick="closeModals()">Cancel</button>
-                <button class="btn btn-primary" onclick="saveFileContent()">Save</button>
+            <div class="modal-actions" style="justify-content: flex-start;">
+                <button class="btn btn-primary" onclick="saveFileContent()" style="min-width: 72px; padding: 7px 16px; justify-content: center;">Save</button>
+                <button class="btn" onclick="closeModals()" style="min-width: 72px; padding: 7px 16px; justify-content: center;">Cancel</button>
             </div>
         </div>
     </div>

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -4624,20 +4624,33 @@
         let _previewLastContent = null;
         let _editOriginalContent = null; // content before editing, used for undo
 
-        // Undo manager — stack-based, stores up to 50 reversible operations
+        // Undo/redo manager — stack-based, stores up to 50 reversible operations
         class UndoManager {
             constructor(maxHistory = 50) {
                 this._stack = [];
+                this._redoStack = [];
                 this._maxHistory = maxHistory;
             }
             push(op) {
                 this._stack.push(op);
                 if (this._stack.length > this._maxHistory) this._stack.shift();
+                this._redoStack = []; // new user action clears redo history
             }
             pop() { return this._stack.pop() || null; }
+            pushRedo(op) {
+                this._redoStack.push(op);
+                if (this._redoStack.length > this._maxHistory) this._redoStack.shift();
+            }
+            popRedo() { return this._redoStack.pop() || null; }
+            pushFromRedo(op) {
+                // push back to undo after a redo without clearing the redo stack
+                this._stack.push(op);
+                if (this._stack.length > this._maxHistory) this._stack.shift();
+            }
             canUndo() { return this._stack.length > 0; }
+            canRedo() { return this._redoStack.length > 0; }
             peek() { return this._stack[this._stack.length - 1] || null; }
-            clear() { this._stack = []; }
+            clear() { this._stack = []; this._redoStack = []; }
             get size() { return this._stack.length; }
         }
         const undoManager = new UndoManager();
@@ -4995,7 +5008,7 @@
 
                 if (previousContent !== null && previousContent !== content) {
                     const fname = previewPath.split('/').pop();
-                    undoManager.push({ type: 'SAVE', path: previewPath, previousContent, label: `Edit "${fname}"` });
+                    undoManager.push({ type: 'SAVE', path: previewPath, previousContent, newContent: content, label: `Edit "${fname}"` });
                 }
 
                 closeModals();
@@ -5014,6 +5027,7 @@
             if (!confirm(`Delete "${filename}"?`)) return;
 
             try {
+                const snapshot = await _snapshotForDelete(previewPath, false);
                 const res = await fetch(`/api/files?path=${encodeURIComponent(previewPath)}`, {
                     method: 'DELETE'
                 });
@@ -5023,8 +5037,9 @@
                     throw new Error(err.detail || 'Failed to delete');
                 }
 
+                if (snapshot) undoManager.push({ type: 'DELETE', path: previewPath, isDir: false, snapshot, label: `Delete "${filename}"` });
                 closePreview();
-                showToast('File deleted');
+                showToast('File deleted', false, !!snapshot);
                 loadFiles(currentPath);
                 loadTree();
             } catch (err) {
@@ -5447,6 +5462,7 @@
             if (!confirm(msg)) return;
 
             try {
+                const snapshot = await _snapshotForDelete(path, isDir);
                 const res = await fetch(`/api/files?path=${encodeURIComponent(path)}`, {
                     method: 'DELETE'
                 });
@@ -5456,8 +5472,9 @@
                     throw new Error(err.detail || 'Failed to delete');
                 }
 
+                if (snapshot) undoManager.push({ type: 'DELETE', path, isDir: !!isDir, snapshot, label: `Delete "${name}"` });
                 if (previewReferencesPath(path, isDir)) closePreview();
-                showToast('Deleted successfully');
+                showToast('Deleted successfully', false, !!snapshot);
                 loadFiles(currentPath);
                 loadTree();
             } catch (err) {
@@ -5813,6 +5830,7 @@
             if (!confirm(deleteMsg)) return;
 
             try {
+                const snapshot = await _snapshotForDelete(selectedItem.path, Boolean(selectedItem.is_dir));
                 const res = await fetch(`/api/files?path=${encodeURIComponent(selectedItem.path)}`, {
                     method: 'DELETE'
                 });
@@ -5822,8 +5840,9 @@
                     throw new Error(err.detail || 'Failed to delete');
                 }
 
+                if (snapshot) undoManager.push({ type: 'DELETE', path: selectedItem.path, isDir: Boolean(selectedItem.is_dir), snapshot, label: `Delete "${selectedItem.name}"` });
                 if (previewReferencesPath(selectedItem.path, Boolean(selectedItem.is_dir))) closePreview();
-                showToast('Deleted successfully');
+                showToast('Deleted successfully', false, !!snapshot);
                 loadFiles(currentPath);
                 loadTree();
             } catch (err) {
@@ -6454,6 +6473,82 @@
             if (previewPath && (previewPath === op.path || previewPath.startsWith(op.path + '/'))) closePreview();
         }
 
+        async function _snapshotFolder(folderPath) {
+            const res = await fetch(`/api/files?path=${encodeURIComponent(folderPath)}`);
+            if (!res.ok) return [];
+            const data = await res.json();
+            const entries = [];
+            for (const item of data.items) {
+                if (item.is_dir) {
+                    entries.push(...await _snapshotFolder(item.path));
+                } else {
+                    const fres = await fetch(`/api/files/content?path=${encodeURIComponent(item.path)}`);
+                    if (fres.ok) {
+                        const fdata = await fres.json();
+                        if (fdata.content !== undefined) entries.push({ path: item.path, content: fdata.content });
+                    }
+                }
+            }
+            return entries;
+        }
+
+        async function _snapshotForDelete(path, isDir) {
+            if (!isDir) {
+                const res = await fetch(`/api/files/content?path=${encodeURIComponent(path)}`);
+                if (!res.ok) return null;
+                const data = await res.json();
+                return data.content !== undefined ? [{ path, content: data.content }] : null;
+            }
+            return await _snapshotFolder(path);
+        }
+
+        async function _undoDelete(op) {
+            if (op.isDir) {
+                // Recreate all intermediate folders then restore each file
+                const folders = new Set([op.path]);
+                for (const e of op.snapshot) {
+                    const parts = e.path.split('/');
+                    for (let i = 1; i < parts.length; i++) folders.add(parts.slice(0, i).join('/'));
+                }
+                for (const f of [...folders].sort((a, b) => a.split('/').length - b.split('/').length)) {
+                    await fetch(`/api/files/mkdirp?path=${encodeURIComponent(f)}`, { method: 'POST' });
+                }
+                for (const e of op.snapshot) {
+                    const parts = e.path.split('/');
+                    const name = parts.pop();
+                    await fetch('/api/files/touch', {
+                        method: 'POST', headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ path: parts.join('/'), name })
+                    });
+                    await fetch(`/api/files/save?path=${encodeURIComponent(e.path)}`, {
+                        method: 'POST', headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ content: e.content })
+                    });
+                }
+            } else {
+                if (!op.snapshot?.length) throw new Error('Cannot restore binary file');
+                const e = op.snapshot[0];
+                const parts = e.path.split('/');
+                const name = parts.pop();
+                const tr = await fetch('/api/files/touch', {
+                    method: 'POST', headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ path: parts.join('/'), name })
+                });
+                if (!tr.ok) { const err = await tr.json(); throw new Error(err.detail || 'Failed to restore file'); }
+                const sr = await fetch(`/api/files/save?path=${encodeURIComponent(e.path)}`, {
+                    method: 'POST', headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ content: e.content })
+                });
+                if (!sr.ok) { const err = await sr.json(); throw new Error(err.detail || 'Failed to restore file content'); }
+            }
+        }
+
+        async function _redoDelete(op) {
+            const res = await fetch(`/api/files?path=${encodeURIComponent(op.path)}`, { method: 'DELETE' });
+            if (!res.ok) { const err = await res.json(); throw new Error(err.detail || 'Failed to redo delete'); }
+            if (previewPath && (previewPath === op.path || previewPath.startsWith(op.path + '/'))) closePreview();
+        }
+
         async function performUndo() {
             if (!undoManager.canUndo()) {
                 showToast('Nothing to undo');
@@ -6467,12 +6562,84 @@
                     case 'RENAME':        await _undoRename(op); break;
                     case 'CREATE_FILE':
                     case 'CREATE_FOLDER': await _undoCreate(op); break;
+                    case 'DELETE':        await _undoDelete(op); break;
                 }
+                undoManager.pushRedo(op);
                 showToast(`Undid: ${op.label}`);
                 loadFiles(currentPath);
                 loadTree();
             } catch (err) {
+                undoManager.push(op); // restore on failure (push re-clears redo, but the op survives)
                 showToast(`Undo failed: ${err.message}`, true);
+            }
+        }
+
+        async function _redoSave(op) {
+            const res = await fetch(`/api/files/save?path=${encodeURIComponent(op.path)}`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ content: op.newContent })
+            });
+            if (!res.ok) { const err = await res.json(); throw new Error(err.detail || 'Failed to redo save'); }
+            if (previewPath === op.path) openFilePreview(op.path);
+        }
+
+        async function _redoMove(op) {
+            for (const m of op.moves) {
+                const targetFolder = m.newPath.includes('/') ? m.newPath.split('/').slice(0, -1).join('/') : '';
+                const res = await fetch('/api/files/move', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ source_path: m.originalPath, target_folder: targetFolder })
+                });
+                if (!res.ok) { const err = await res.json(); throw new Error(err.detail || 'Failed to redo move'); }
+            }
+        }
+
+        async function _redoRename(op) {
+            const res = await fetch('/api/files/rename', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ old_path: op.originalPath, new_name: op.newName })
+            });
+            if (!res.ok) { const err = await res.json(); throw new Error(err.detail || 'Failed to redo rename'); }
+        }
+
+        async function _redoCreate(op) {
+            const parts = op.path.split('/');
+            const name = parts.pop();
+            const path = parts.join('/');
+            const endpoint = op.type === 'CREATE_FILE' ? '/api/files/touch' : '/api/files/mkdir';
+            const res = await fetch(endpoint, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ path, name })
+            });
+            if (!res.ok) { const err = await res.json(); throw new Error(err.detail || 'Failed to redo create'); }
+        }
+
+        async function performRedo() {
+            if (!undoManager.canRedo()) {
+                showToast('Nothing to redo');
+                return;
+            }
+            const op = undoManager.popRedo();
+            try {
+                switch (op.type) {
+                    case 'SAVE':          await _redoSave(op);   break;
+                    case 'MOVE':          await _redoMove(op);   break;
+                    case 'RENAME':        await _redoRename(op); break;
+                    case 'CREATE_FILE':
+                    case 'CREATE_FOLDER': await _redoCreate(op); break;
+                    case 'DELETE':        await _redoDelete(op); break;
+                }
+                undoManager.pushFromRedo(op);
+                showToast(`Redid: ${op.label}`);
+                loadFiles(currentPath);
+                loadTree();
+            } catch (err) {
+                undoManager.pushRedo(op); // restore on failure
+                showToast(`Redo failed: ${err.message}`, true);
             }
         }
 
@@ -6550,6 +6717,13 @@
             if ((e.ctrlKey || e.metaKey) && e.key === 'z' && !e.shiftKey && !inInput) {
                 e.preventDefault();
                 performUndo();
+                return;
+            }
+
+            // Ctrl+Shift+Z / Cmd+Shift+Z — redo
+            if ((e.ctrlKey || e.metaKey) && e.key === 'z' && e.shiftKey && !inInput) {
+                e.preventDefault();
+                performRedo();
                 return;
             }
 

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -2155,6 +2155,26 @@
             background: rgba(254, 242, 242, 0.95);
         }
 
+        .toast-undo-btn {
+            background: none;
+            border: 1px solid currentColor;
+            border-radius: 6px;
+            color: inherit;
+            cursor: pointer;
+            font-size: 12px;
+            font-weight: 600;
+            letter-spacing: 0.02em;
+            margin-left: 10px;
+            opacity: 0.8;
+            padding: 2px 8px;
+            transition: opacity 0.15s, background 0.15s;
+            vertical-align: middle;
+        }
+        .toast-undo-btn:hover {
+            background: rgba(0, 0, 0, 0.08);
+            opacity: 1;
+        }
+
         /* Hidden file input */
         #file-input, #folder-upload-input {
             display: none;
@@ -4591,6 +4611,25 @@
         let previewReturnClusterId = null; // set when a file is opened from a cluster list
         let _previewPollTimer = null;
         let _previewLastContent = null;
+        let _editOriginalContent = null; // content before editing, used for undo
+
+        // Undo manager — stack-based, stores up to 50 reversible operations
+        class UndoManager {
+            constructor(maxHistory = 50) {
+                this._stack = [];
+                this._maxHistory = maxHistory;
+            }
+            push(op) {
+                this._stack.push(op);
+                if (this._stack.length > this._maxHistory) this._stack.shift();
+            }
+            pop() { return this._stack.pop() || null; }
+            canUndo() { return this._stack.length > 0; }
+            peek() { return this._stack[this._stack.length - 1] || null; }
+            clear() { this._stack = []; }
+            get size() { return this._stack.length; }
+        }
+        const undoManager = new UndoManager();
         function hasPreviewContent() {
             const header = document.getElementById('preview-file-header');
             return Boolean(header) && header.style.display !== 'none';
@@ -4915,6 +4954,7 @@
                     return;
                 }
 
+                _editOriginalContent = data.content; // capture for undo
                 document.getElementById('edit-modal-title').textContent = `Edit: ${data.name}`;
                 document.getElementById('edit-textarea').value = data.content;
                 document.getElementById('edit-modal').classList.add('show');
@@ -4928,6 +4968,7 @@
             if (!previewPath) return;
 
             const content = document.getElementById('edit-textarea').value;
+            const previousContent = _editOriginalContent;
 
             try {
                 const res = await fetch(`/api/files/save?path=${encodeURIComponent(previewPath)}`, {
@@ -4941,8 +4982,13 @@
                     throw new Error(err.detail || 'Failed to save file');
                 }
 
+                if (previousContent !== null && previousContent !== content) {
+                    const fname = previewPath.split('/').pop();
+                    undoManager.push({ type: 'SAVE', path: previewPath, previousContent, label: `Edit "${fname}"` });
+                }
+
                 closeModals();
-                showToast('File saved successfully');
+                showToast('File saved successfully', false, true);
                 openFilePreview(previewPath); // Refresh preview
             } catch (err) {
                 showToast(err.message, true);
@@ -5647,7 +5693,14 @@
                         const err = await res.json();
                         throw new Error(err.detail || 'Failed to move');
                     }
-                    showToast(`Moved "${item.name}" to ${dropFolder || 'root'}`);
+                    const originalParent = item.path.split('/').slice(0, -1).join('/');
+                    const newPath = dropFolder ? `${dropFolder}/${item.name}` : item.name;
+                    undoManager.push({
+                        type: 'MOVE',
+                        moves: [{ originalPath: item.path, originalParent, itemName: item.name, newPath }],
+                        label: `Move "${item.name}" to ${dropFolder || 'root'}`
+                    });
+                    showToast(`Moved "${item.name}" to ${dropFolder || 'root'}`, false, true);
                 } catch (err) {
                     showToast(err.message, true);
                     return;
@@ -5669,7 +5722,18 @@
                 const succeeded = results.filter(r => r.status === 'fulfilled').length;
                 const failed = results.filter(r => r.status === 'rejected');
                 if (succeeded > 0) {
-                    showToast(`Moved ${succeeded} item${succeeded !== 1 ? 's' : ''} to ${dropFolder || 'root'}`);
+                    const movedItems = moveable.filter((_, i) => results[i].status === 'fulfilled');
+                    const moves = movedItems.map(item => {
+                        const originalParent = item.path.split('/').slice(0, -1).join('/');
+                        const newPath = dropFolder ? `${dropFolder}/${item.name}` : item.name;
+                        return { originalPath: item.path, originalParent, itemName: item.name, newPath };
+                    });
+                    undoManager.push({
+                        type: 'MOVE',
+                        moves,
+                        label: `Move ${succeeded} item${succeeded !== 1 ? 's' : ''} to ${dropFolder || 'root'}`
+                    });
+                    showToast(`Moved ${succeeded} item${succeeded !== 1 ? 's' : ''} to ${dropFolder || 'root'}`, false, true);
                 }
                 if (failed.length > 0) {
                     showToast(failed[0].reason?.message || 'Some items failed to move', true);
@@ -5690,11 +5754,15 @@
                 if (!confirm(`"${selectedItem.name}" is one of the recommended santai folders — rename anyway?`)) return;
             }
 
+            const originalPath = selectedItem.path;
+            const originalName = selectedItem.name;
+            const parentFolder = originalPath.split('/').slice(0, -1).join('/');
+
             try {
                 const res = await fetch('/api/files/rename', {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ old_path: selectedItem.path, new_name: newName })
+                    body: JSON.stringify({ old_path: originalPath, new_name: newName })
                 });
 
                 if (!res.ok) {
@@ -5702,8 +5770,19 @@
                     throw new Error(err.detail || 'Failed to rename');
                 }
 
+                const newPath = parentFolder ? `${parentFolder}/${newName}` : newName;
+                undoManager.push({
+                    type: 'RENAME',
+                    originalPath,
+                    originalName,
+                    newName,
+                    newPath,
+                    parentFolder,
+                    label: `Rename "${originalName}" to "${newName}"`
+                });
+
                 closeModals();
-                showToast('Renamed successfully');
+                showToast('Renamed successfully', false, true);
                 loadFiles(currentPath);
                 loadTree();
             } catch (err) {
@@ -5764,8 +5843,11 @@
                     throw new Error(err.detail || 'Failed to create folder');
                 }
 
+                const createdPath = currentPath ? `${currentPath}/${name}` : name;
+                undoManager.push({ type: 'CREATE_FOLDER', path: createdPath, label: `New folder "${name}"` });
+
                 closeModals();
-                showToast('Folder created');
+                showToast('Folder created', false, true);
                 loadFiles(currentPath);
                 loadTree();
             } catch (err) {
@@ -5796,8 +5878,10 @@
                 }
 
                 const data = await res.json();
+                undoManager.push({ type: 'CREATE_FILE', path: data.path, label: `New file "${name}"` });
+
                 closeModals();
-                showToast('File created');
+                showToast('File created', false, true);
                 loadFiles(currentPath);
                 loadTree();
                 openFilePreview(data.path);
@@ -6321,6 +6405,66 @@
             }
         }
 
+        // Undo helpers
+
+        async function _undoSave(op) {
+            const res = await fetch(`/api/files/save?path=${encodeURIComponent(op.path)}`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ content: op.previousContent })
+            });
+            if (!res.ok) { const err = await res.json(); throw new Error(err.detail || 'Failed to restore file'); }
+            if (previewPath === op.path) openFilePreview(op.path);
+        }
+
+        async function _undoMove(op) {
+            for (const m of op.moves) {
+                const res = await fetch('/api/files/move', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ source_path: m.newPath, target_folder: m.originalParent })
+                });
+                if (!res.ok) { const err = await res.json(); throw new Error(err.detail || 'Failed to undo move'); }
+            }
+        }
+
+        async function _undoRename(op) {
+            const res = await fetch('/api/files/rename', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ old_path: op.newPath, new_name: op.originalName })
+            });
+            if (!res.ok) { const err = await res.json(); throw new Error(err.detail || 'Failed to undo rename'); }
+        }
+
+        async function _undoCreate(op) {
+            const res = await fetch(`/api/files?path=${encodeURIComponent(op.path)}`, { method: 'DELETE' });
+            if (!res.ok) { const err = await res.json(); throw new Error(err.detail || 'Failed to undo create'); }
+            if (previewPath && (previewPath === op.path || previewPath.startsWith(op.path + '/'))) closePreview();
+        }
+
+        async function performUndo() {
+            if (!undoManager.canUndo()) {
+                showToast('Nothing to undo');
+                return;
+            }
+            const op = undoManager.pop();
+            try {
+                switch (op.type) {
+                    case 'SAVE':          await _undoSave(op);   break;
+                    case 'MOVE':          await _undoMove(op);   break;
+                    case 'RENAME':        await _undoRename(op); break;
+                    case 'CREATE_FILE':
+                    case 'CREATE_FOLDER': await _undoCreate(op); break;
+                }
+                showToast(`Undid: ${op.label}`);
+                loadFiles(currentPath);
+                loadTree();
+            } catch (err) {
+                showToast(`Undo failed: ${err.message}`, true);
+            }
+        }
+
         document.querySelectorAll('.modal-overlay').forEach(m => {
             m.addEventListener('click', (e) => {
                 if (e.target === m) closeModals();
@@ -6373,15 +6517,31 @@
         }
 
         // Toast
-        function showToast(message, isError = false) {
+        function showToast(message, isError = false, undoable = false) {
             const toast = document.getElementById('toast');
-            toast.textContent = message;
+            clearTimeout(toast._hideTimer);
+            const safe = message.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+            if (undoable && undoManager.canUndo()) {
+                toast.innerHTML = `${safe} <button class="toast-undo-btn" onclick="performUndo()">Undo</button>`;
+            } else {
+                toast.textContent = message;
+            }
             toast.className = 'toast show' + (isError ? ' error' : '');
-            setTimeout(() => toast.classList.remove('show'), 3000);
+            toast._hideTimer = setTimeout(() => toast.classList.remove('show'), 4000);
         }
 
         // Keyboard shortcuts
         document.addEventListener('keydown', (e) => {
+            const active = document.activeElement;
+            const inInput = active && (active.tagName === 'INPUT' || active.tagName === 'TEXTAREA');
+
+            // Ctrl+Z / Cmd+Z — undo (skip when typing in an input or textarea)
+            if ((e.ctrlKey || e.metaKey) && e.key === 'z' && !e.shiftKey && !inInput) {
+                e.preventDefault();
+                performUndo();
+                return;
+            }
+
             if (e.key === 'Delete' && selectedItem) {
                 deleteSelected();
             }

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -4251,7 +4251,8 @@
                         <!-- Breadcrumbs populated by JavaScript -->
                     </nav>
                 </div>
-                <div class="file-grid-container" id="file-grid-container">
+                <div id="grid-selection-bar" style="display:none;padding:4px 12px;font-size:12px;color:var(--text-secondary);background:var(--bg-secondary);border-bottom:1px solid var(--border);user-select:none;"></div>
+                <div class="file-grid-container" id="file-grid-container" onclick="if(event.target===this||event.target.classList.contains('file-grid')){clearGridSelection();selectedItem=null;}">
                     <div class="loading">
                         <div class="spinner"></div>
                     </div>
@@ -4630,6 +4631,25 @@
         let gridSelectedPaths = new Set(); // paths of multi-selected file-grid items
         let lastClickedPath = null;    // anchor for shift-range selection
         let lastGridAnchorPath = null; // anchor for shift-range selection in file grid
+
+        function updateGridSelectionBar() {
+            const bar = document.getElementById('grid-selection-bar');
+            if (!bar) return;
+            const n = gridSelectedPaths.size;
+            if (n > 1) {
+                bar.textContent = `${n} items selected`;
+                bar.style.display = 'block';
+            } else {
+                bar.style.display = 'none';
+            }
+        }
+
+        function clearGridSelection() {
+            gridSelectedPaths.clear();
+            lastGridAnchorPath = null;
+            document.querySelectorAll('.file-item.selected').forEach(i => i.classList.remove('selected'));
+            updateGridSelectionBar();
+        }
         let files = [];
         let previewPath = null;
         let previewHistory = []; // paths navigated via markdown links, for back-button
@@ -5221,8 +5241,7 @@
         async function loadFilesInternal(path = '') {
             currentPath = path;
             selectedItem = null;
-            gridSelectedPaths.clear();
-            lastGridAnchorPath = null;
+            clearGridSelection();
             updateNavButtons();
 
             const container = document.getElementById('file-grid-container');
@@ -5260,8 +5279,7 @@
 
             currentPath = path;
             selectedItem = null;
-            gridSelectedPaths.clear();
-            lastGridAnchorPath = null;
+            clearGridSelection();
             updateNavButtons();
 
             const container = document.getElementById('file-grid-container');
@@ -5414,6 +5432,7 @@
                         gridSelectedPaths.add(allItems[i].dataset.path);
                     }
                     selectedItem = { path, isDir: el.dataset.isDir === 'true', name: el.dataset.name };
+                    updateGridSelectionBar();
                     return; // No auto-navigate in multi-select mode
                 }
             }
@@ -5431,6 +5450,7 @@
                     ? { path, isDir: el.dataset.isDir === 'true', name: el.dataset.name }
                     : null;
                 lastGridAnchorPath = path;
+                updateGridSelectionBar();
                 return; // No auto-navigate in multi-select mode
             }
 
@@ -5441,6 +5461,7 @@
             el.classList.add('selected');
             gridSelectedPaths.add(path);
             selectedItem = { path, isDir: el.dataset.isDir === 'true', name: el.dataset.name };
+            updateGridSelectionBar();
 
             // Auto-open: preview for files, navigate for folders
             if (selectedItem.isDir) {
@@ -5604,7 +5625,7 @@
                 undoManager.push({ type: 'BULK_DELETE', ops: succeeded, label: `Delete ${succeeded.length} items` });
             }
 
-            gridSelectedPaths.clear();
+            clearGridSelection();
             selectedItems.clear();
             updateTreeSelection();
             if (failed.length === 0) {
@@ -5891,7 +5912,7 @@
                         return { originalPath: item.path, originalParent, itemName: item.name, newPath };
                     });
                     undoManager.push({
-                        type: 'MOVE',
+                        type: 'BULK_MOVE',
                         moves,
                         label: `Move ${succeeded} item${succeeded !== 1 ? 's' : ''} to ${dropFolder || 'root'}`
                     });
@@ -6686,12 +6707,49 @@
             if (previewPath && (previewPath === op.path || previewPath.startsWith(op.path + '/'))) closePreview();
         }
 
+        async function _undoBulkMove(op) {
+            const total = op.moves.length;
+            for (let i = 0; i < total; i++) {
+                if (total > 1) showToast(`Undoing move ${i + 1}/${total}…`);
+                const m = op.moves[i];
+                const res = await fetch('/api/files/move', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ source_path: m.newPath, target_folder: m.originalParent })
+                });
+                if (!res.ok) { const err = await res.json(); throw new Error(err.detail || 'Failed to undo move'); }
+            }
+        }
+
+        async function _redoBulkMove(op) {
+            const total = op.moves.length;
+            for (let i = 0; i < total; i++) {
+                if (total > 1) showToast(`Redoing move ${i + 1}/${total}…`);
+                const m = op.moves[i];
+                const targetFolder = m.newPath.includes('/') ? m.newPath.split('/').slice(0, -1).join('/') : '';
+                const res = await fetch('/api/files/move', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ source_path: m.originalPath, target_folder: targetFolder })
+                });
+                if (!res.ok) { const err = await res.json(); throw new Error(err.detail || 'Failed to redo move'); }
+            }
+        }
+
         async function _undoBulkDelete(op) {
-            for (const subOp of op.ops) await _undoDelete(subOp);
+            const total = op.ops.length;
+            for (let i = 0; i < total; i++) {
+                showToast(`Restoring ${i + 1}/${total}…`);
+                await _undoDelete(op.ops[i]);
+            }
         }
 
         async function _redoBulkDelete(op) {
-            for (const subOp of op.ops) await _redoDelete(subOp);
+            const total = op.ops.length;
+            for (let i = 0; i < total; i++) {
+                showToast(`Deleting ${i + 1}/${total}…`);
+                await _redoDelete(op.ops[i]);
+            }
         }
 
         async function performUndo() {
@@ -6702,12 +6760,13 @@
             const op = undoManager.pop();
             try {
                 switch (op.type) {
-                    case 'SAVE':          await _undoSave(op);   break;
-                    case 'MOVE':          await _undoMove(op);   break;
-                    case 'RENAME':        await _undoRename(op); break;
+                    case 'SAVE':          await _undoSave(op);      break;
+                    case 'MOVE':          await _undoMove(op);      break;
+                    case 'BULK_MOVE':     await _undoBulkMove(op);  break;
+                    case 'RENAME':        await _undoRename(op);    break;
                     case 'CREATE_FILE':
-                    case 'CREATE_FOLDER': await _undoCreate(op); break;
-                    case 'DELETE':        await _undoDelete(op); break;
+                    case 'CREATE_FOLDER': await _undoCreate(op);    break;
+                    case 'DELETE':        await _undoDelete(op);    break;
                     case 'BULK_DELETE':   await _undoBulkDelete(op); break;
                 }
                 undoManager.pushRedo(op);
@@ -6772,12 +6831,13 @@
             const op = undoManager.popRedo();
             try {
                 switch (op.type) {
-                    case 'SAVE':          await _redoSave(op);   break;
-                    case 'MOVE':          await _redoMove(op);   break;
-                    case 'RENAME':        await _redoRename(op); break;
+                    case 'SAVE':          await _redoSave(op);      break;
+                    case 'MOVE':          await _redoMove(op);      break;
+                    case 'BULK_MOVE':     await _redoBulkMove(op);  break;
+                    case 'RENAME':        await _redoRename(op);    break;
                     case 'CREATE_FILE':
-                    case 'CREATE_FOLDER': await _redoCreate(op); break;
-                    case 'DELETE':        await _redoDelete(op); break;
+                    case 'CREATE_FOLDER': await _redoCreate(op);    break;
+                    case 'DELETE':        await _redoDelete(op);    break;
                     case 'BULK_DELETE':   await _redoBulkDelete(op); break;
                 }
                 undoManager.pushFromRedo(op);
@@ -6873,6 +6933,27 @@
             if ((e.ctrlKey || e.metaKey) && e.key === 'z' && e.shiftKey && !inInput) {
                 e.preventDefault();
                 performRedo();
+                return;
+            }
+
+            // Cmd+A / Ctrl+A — select all items in file grid
+            if ((e.ctrlKey || e.metaKey) && e.key === 'a' && !inInput && currentView === 'browser') {
+                e.preventDefault();
+                const allItems = Array.from(document.querySelectorAll('.file-item'));
+                if (allItems.length > 0) {
+                    gridSelectedPaths.clear();
+                    allItems.forEach(i => { i.classList.add('selected'); gridSelectedPaths.add(i.dataset.path); });
+                    lastGridAnchorPath = allItems[0].dataset.path;
+                    selectedItem = { path: allItems[0].dataset.path, isDir: allItems[0].dataset.isDir === 'true', name: allItems[0].dataset.name };
+                    updateGridSelectionBar();
+                }
+                return;
+            }
+
+            // Escape — clear grid selection (without navigating away)
+            if (e.key === 'Escape' && !document.querySelector('.modal-overlay.show') && gridSelectedPaths.size > 1) {
+                clearGridSelection();
+                selectedItem = null;
                 return;
             }
 

--- a/src/santai_cli/web/templates/index.html
+++ b/src/santai_cli/web/templates/index.html
@@ -4235,6 +4235,18 @@
                             </svg>
                         </button>
                     </div>
+                    <div class="nav-arrows">
+                        <button class="nav-arrow" id="btn-undo" onclick="performUndo()" title="Undo (⌘Z)" disabled>
+                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 10h10a8 8 0 018 8v2M3 10l6 6m-6-6l6-6" />
+                            </svg>
+                        </button>
+                        <button class="nav-arrow" id="btn-redo" onclick="performRedo()" title="Redo (⌘⇧Z)" disabled>
+                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 10H11a8 8 0 00-8 8v2M21 10l-6 6m6-6l-6-6" />
+                            </svg>
+                        </button>
+                    </div>
                     <nav class="browser-breadcrumbs" id="browser-breadcrumbs">
                         <!-- Breadcrumbs populated by JavaScript -->
                     </nav>
@@ -4315,7 +4327,7 @@
                         </svg>
                         Download
                     </button>
-                    <button class="btn btn-danger" id="preview-delete" onclick="deletePreviewFile()">
+                    <button class="btn btn-danger" id="preview-delete" onclick="deletePreviewFile()" title="Delete (⌘Z to undo)">
                         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                             <path stroke-linecap="round" stroke-linejoin="round" d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0" />
                         </svg>
@@ -4426,13 +4438,13 @@
             </svg>
             Download
         </button>
-        <button class="context-menu-item" onclick="showRenameModal()">
+        <button class="context-menu-item" onclick="showRenameModal()" title="Rename (⌘Z to undo)">
             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931z" />
             </svg>
             Rename
         </button>
-        <button class="context-menu-item danger" onclick="deleteSelected()">
+        <button class="context-menu-item danger" onclick="deleteSelected()" title="Delete (⌘Z to undo)">
             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0" />
             </svg>
@@ -4630,30 +4642,41 @@
                 this._stack = [];
                 this._redoStack = [];
                 this._maxHistory = maxHistory;
+                this._onChange = null;
             }
+            _notify() { if (this._onChange) this._onChange(); }
             push(op) {
                 this._stack.push(op);
                 if (this._stack.length > this._maxHistory) this._stack.shift();
                 this._redoStack = []; // new user action clears redo history
+                this._notify();
             }
-            pop() { return this._stack.pop() || null; }
+            pop() { const op = this._stack.pop() || null; this._notify(); return op; }
             pushRedo(op) {
                 this._redoStack.push(op);
                 if (this._redoStack.length > this._maxHistory) this._redoStack.shift();
+                this._notify();
             }
-            popRedo() { return this._redoStack.pop() || null; }
+            popRedo() { const op = this._redoStack.pop() || null; this._notify(); return op; }
             pushFromRedo(op) {
-                // push back to undo after a redo without clearing the redo stack
                 this._stack.push(op);
                 if (this._stack.length > this._maxHistory) this._stack.shift();
+                this._notify();
             }
             canUndo() { return this._stack.length > 0; }
             canRedo() { return this._redoStack.length > 0; }
             peek() { return this._stack[this._stack.length - 1] || null; }
-            clear() { this._stack = []; this._redoStack = []; }
+            clear() { this._stack = []; this._redoStack = []; this._notify(); }
             get size() { return this._stack.length; }
         }
         const undoManager = new UndoManager();
+        function updateUndoRedoButtons() {
+            const undoBtn = document.getElementById('btn-undo');
+            const redoBtn = document.getElementById('btn-redo');
+            if (undoBtn) undoBtn.disabled = !undoManager.canUndo();
+            if (redoBtn) redoBtn.disabled = !undoManager.canRedo();
+        }
+        undoManager._onChange = updateUndoRedoButtons;
         function hasPreviewContent() {
             const header = document.getElementById('preview-file-header');
             return Boolean(header) && header.style.display !== 'none';
@@ -5345,12 +5368,12 @@
                         <div class="file-meta">${item.is_dir ? 'Folder' : item.size_formatted}</div>
                     </div>`;
                 html += `<div class="file-actions">
-                        <button class="file-action-btn edit-btn" onclick="event.stopPropagation(); editItem('${escAttr(item.path)}', '${escAttr(item.name)}')" title="Rename">
+                        <button class="file-action-btn edit-btn" onclick="event.stopPropagation(); editItem('${escAttr(item.path)}', '${escAttr(item.name)}')" title="Rename (⌘Z to undo)">
                             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                                 <path stroke-linecap="round" stroke-linejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931z" />
                             </svg>
                         </button>
-                        <button class="file-action-btn delete-btn" onclick="event.stopPropagation(); deleteItem('${escAttr(item.path)}', '${escAttr(item.name)}', ${item.is_dir})" title="Delete">
+                        <button class="file-action-btn delete-btn" onclick="event.stopPropagation(); deleteItem('${escAttr(item.path)}', '${escAttr(item.name)}', ${item.is_dir})" title="Delete (⌘Z to undo)">
                             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                                 <path stroke-linecap="round" stroke-linejoin="round" d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0" />
                             </svg>
@@ -6565,7 +6588,7 @@
                     case 'DELETE':        await _undoDelete(op); break;
                 }
                 undoManager.pushRedo(op);
-                showToast(`Undid: ${op.label}`);
+                showToast(`Undid: ${op.label}`, false, false, true);
                 loadFiles(currentPath);
                 loadTree();
             } catch (err) {
@@ -6634,7 +6657,7 @@
                     case 'DELETE':        await _redoDelete(op); break;
                 }
                 undoManager.pushFromRedo(op);
-                showToast(`Redid: ${op.label}`);
+                showToast(`Redid: ${op.label}`, false, true);
                 loadFiles(currentPath);
                 loadTree();
             } catch (err) {
@@ -6695,12 +6718,14 @@
         }
 
         // Toast
-        function showToast(message, isError = false, undoable = false) {
+        function showToast(message, isError = false, undoable = false, redoable = false) {
             const toast = document.getElementById('toast');
             clearTimeout(toast._hideTimer);
             const safe = message.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
             if (undoable && undoManager.canUndo()) {
                 toast.innerHTML = `${safe} <button class="toast-undo-btn" onclick="performUndo()">Undo</button>`;
+            } else if (redoable && undoManager.canRedo()) {
+                toast.innerHTML = `${safe} <button class="toast-undo-btn" onclick="performRedo()">Redo</button>`;
             } else {
                 toast.textContent = message;
             }
@@ -6878,12 +6903,12 @@
             // before the toggle so the chevron stays anchored at the far right.
             if (node.path) {
                 html += `<span class="tree-actions">
-                    <button class="tree-action-btn edit-btn" onclick="event.stopPropagation(); editItem('${escAttr(node.path)}', '${escAttr(node.name)}')" title="Rename">
+                    <button class="tree-action-btn edit-btn" onclick="event.stopPropagation(); editItem('${escAttr(node.path)}', '${escAttr(node.name)}')" title="Rename (⌘Z to undo)">
                         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                             <path stroke-linecap="round" stroke-linejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931z" />
                         </svg>
                     </button>
-                    <button class="tree-action-btn delete-btn" onclick="event.stopPropagation(); deleteItem('${escAttr(node.path)}', '${escAttr(node.name)}', ${node.is_dir})" title="Delete">
+                    <button class="tree-action-btn delete-btn" onclick="event.stopPropagation(); deleteItem('${escAttr(node.path)}', '${escAttr(node.name)}', ${node.is_dir})" title="Delete (⌘Z to undo)">
                         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                             <path stroke-linecap="round" stroke-linejoin="round" d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0" />
                         </svg>
@@ -7079,6 +7104,7 @@
 
         function showDashboard() {
             currentView = 'dashboard';
+            undoManager.clear();
             resetPreviewState();
             hidePreviewPanel();
             document.getElementById('dashboard-view').style.display = 'flex';

--- a/tests/test_undo_manager.js
+++ b/tests/test_undo_manager.js
@@ -1,7 +1,7 @@
 /**
  * Unit tests for UndoManager — run with: node tests/test_undo_manager.js
  *
- * Tests the stack-based undo state management logic in isolation.
+ * Tests the stack-based undo/redo state management logic in isolation.
  * No DOM or fetch dependencies.
  */
 
@@ -12,16 +12,33 @@
 class UndoManager {
     constructor(maxHistory = 50) {
         this._stack = [];
+        this._redoStack = [];
         this._maxHistory = maxHistory;
+        this._onChange = null;
     }
+    _notify() { if (this._onChange) this._onChange(); }
     push(op) {
         this._stack.push(op);
         if (this._stack.length > this._maxHistory) this._stack.shift();
+        this._redoStack = [];
+        this._notify();
     }
-    pop() { return this._stack.pop() || null; }
+    pop() { const op = this._stack.pop() || null; this._notify(); return op; }
+    pushRedo(op) {
+        this._redoStack.push(op);
+        if (this._redoStack.length > this._maxHistory) this._redoStack.shift();
+        this._notify();
+    }
+    popRedo() { const op = this._redoStack.pop() || null; this._notify(); return op; }
+    pushFromRedo(op) {
+        this._stack.push(op);
+        if (this._stack.length > this._maxHistory) this._stack.shift();
+        this._notify();
+    }
     canUndo() { return this._stack.length > 0; }
+    canRedo() { return this._redoStack.length > 0; }
     peek() { return this._stack[this._stack.length - 1] || null; }
-    clear() { this._stack = []; }
+    clear() { this._stack = []; this._redoStack = []; this._notify(); }
     get size() { return this._stack.length; }
 }
 
@@ -65,6 +82,11 @@ test('canUndo() is false when empty', () => {
     assert(!um.canUndo(), 'should not be undoable when empty');
 });
 
+test('canRedo() is false when empty', () => {
+    const um = new UndoManager();
+    assert(!um.canRedo(), 'should not be redoable when empty');
+});
+
 test('size is 0 when empty', () => {
     const um = new UndoManager();
     assertEqual(um.size, 0);
@@ -73,6 +95,11 @@ test('size is 0 when empty', () => {
 test('pop() returns null when empty', () => {
     const um = new UndoManager();
     assertEqual(um.pop(), null);
+});
+
+test('popRedo() returns null when empty', () => {
+    const um = new UndoManager();
+    assertEqual(um.popRedo(), null);
 });
 
 test('peek() returns null when empty', () => {
@@ -132,7 +159,59 @@ test('peek returns last operation without removing it', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Tests: operation types
+// Tests: redo stack
+// ---------------------------------------------------------------------------
+
+console.log('\nUndoManager — redo stack');
+
+test('canRedo() is true after pushRedo', () => {
+    const um = new UndoManager();
+    um.pushRedo({ type: 'SAVE', label: 'Edit "foo.md"' });
+    assert(um.canRedo());
+});
+
+test('popRedo returns last pushed redo operation', () => {
+    const um = new UndoManager();
+    const op1 = { type: 'SAVE', label: 'first' };
+    const op2 = { type: 'RENAME', label: 'second' };
+    um.pushRedo(op1);
+    um.pushRedo(op2);
+    assertEqual(um.popRedo(), op2);
+});
+
+test('popRedo removes the redo operation', () => {
+    const um = new UndoManager();
+    um.pushRedo({ type: 'SAVE' });
+    um.popRedo();
+    assert(!um.canRedo());
+});
+
+test('push() clears the redo stack', () => {
+    const um = new UndoManager();
+    um.pushRedo({ type: 'SAVE', label: 'undone op' });
+    assert(um.canRedo(), 'redo should be available before push');
+    um.push({ type: 'DELETE', label: 'new action' });
+    assert(!um.canRedo(), 'new user action should clear redo history');
+});
+
+test('pushFromRedo() adds to undo stack without clearing redo stack', () => {
+    const um = new UndoManager();
+    um.pushRedo({ type: 'MOVE', label: 'next redo' });
+    um.pushFromRedo({ type: 'SAVE', label: 'restored op' });
+    assert(um.canUndo(), 'undo stack should have the restored op');
+    assert(um.canRedo(), 'redo stack should be preserved');
+});
+
+test('redo stack respects maxHistory cap', () => {
+    const um = new UndoManager(3);
+    for (let i = 0; i < 5; i++) um.pushRedo({ type: 'SAVE', label: `op-${i}` });
+    let count = 0;
+    while (um.canRedo()) { um.popRedo(); count++; }
+    assert(count <= 3, `redo stack had ${count} entries, expected <= 3`);
+});
+
+// ---------------------------------------------------------------------------
+// Tests: operation payloads
 // ---------------------------------------------------------------------------
 
 console.log('\nUndoManager — operation payloads');
@@ -206,7 +285,6 @@ test('enforces maxHistory limit by evicting the oldest entry', () => {
     um.push({ type: 'SAVE', label: 'third' });
     um.push({ type: 'SAVE', label: 'fourth' }); // evicts 'first'
     assertEqual(um.size, 3);
-    // Pop all three; 'first' should not be present
     const labels = [um.pop().label, um.pop().label, um.pop().label];
     assert(!labels.includes('first'), 'oldest entry should have been evicted');
     assert(labels.includes('second'));
@@ -226,13 +304,137 @@ test('size never exceeds maxHistory', () => {
 
 console.log('\nUndoManager — clear');
 
-test('clear() empties the stack', () => {
+test('clear() empties the undo stack', () => {
     const um = new UndoManager();
     um.push({ type: 'SAVE' });
     um.push({ type: 'MOVE' });
     um.clear();
     assertEqual(um.size, 0);
     assert(!um.canUndo());
+});
+
+test('clear() empties the redo stack', () => {
+    const um = new UndoManager();
+    um.pushRedo({ type: 'SAVE' });
+    um.clear();
+    assert(!um.canRedo(), 'clear should also wipe redo stack');
+});
+
+// ---------------------------------------------------------------------------
+// Tests: _onChange callback
+// ---------------------------------------------------------------------------
+
+console.log('\nUndoManager — _onChange callback');
+
+test('_onChange fires on push()', () => {
+    const um = new UndoManager();
+    let calls = 0;
+    um._onChange = () => calls++;
+    um.push({ type: 'SAVE' });
+    assertEqual(calls, 1);
+});
+
+test('_onChange fires on pop()', () => {
+    const um = new UndoManager();
+    um.push({ type: 'SAVE' });
+    let calls = 0;
+    um._onChange = () => calls++;
+    um.pop();
+    assertEqual(calls, 1);
+});
+
+test('_onChange fires on pushRedo()', () => {
+    const um = new UndoManager();
+    let calls = 0;
+    um._onChange = () => calls++;
+    um.pushRedo({ type: 'SAVE' });
+    assertEqual(calls, 1);
+});
+
+test('_onChange fires on popRedo()', () => {
+    const um = new UndoManager();
+    um.pushRedo({ type: 'SAVE' });
+    let calls = 0;
+    um._onChange = () => calls++;
+    um.popRedo();
+    assertEqual(calls, 1);
+});
+
+test('_onChange fires on pushFromRedo()', () => {
+    const um = new UndoManager();
+    let calls = 0;
+    um._onChange = () => calls++;
+    um.pushFromRedo({ type: 'SAVE' });
+    assertEqual(calls, 1);
+});
+
+test('_onChange fires on clear()', () => {
+    const um = new UndoManager();
+    um.push({ type: 'SAVE' });
+    let calls = 0;
+    um._onChange = () => calls++;
+    um.clear();
+    assertEqual(calls, 1);
+});
+
+test('_onChange receives correct canUndo/canRedo state at call time', () => {
+    const um = new UndoManager();
+    let seenCanUndo = null;
+    let seenCanRedo = null;
+    um._onChange = () => {
+        seenCanUndo = um.canUndo();
+        seenCanRedo = um.canRedo();
+    };
+    um.push({ type: 'SAVE' });
+    assert(seenCanUndo === true, 'canUndo should be true inside onChange after push');
+    assert(seenCanRedo === false, 'canRedo should be false inside onChange after push (redo cleared)');
+});
+
+test('_onChange not called when null', () => {
+    const um = new UndoManager();
+    um._onChange = null;
+    // Should not throw
+    um.push({ type: 'SAVE' });
+    um.pop();
+    um.clear();
+});
+
+// ---------------------------------------------------------------------------
+// Tests: full undo/redo cycle
+// ---------------------------------------------------------------------------
+
+console.log('\nUndoManager — full undo/redo cycle');
+
+test('undo then redo restores original state', () => {
+    const um = new UndoManager();
+    const op = { type: 'RENAME', label: 'Rename "a" to "b"' };
+    um.push(op);
+
+    // Simulate undo: pop from undo, push to redo
+    const undone = um.pop();
+    um.pushRedo(undone);
+    assert(!um.canUndo(), 'undo stack should be empty after undo');
+    assert(um.canRedo(), 'redo stack should have the op');
+
+    // Simulate redo: pop from redo, push back to undo via pushFromRedo
+    const redone = um.popRedo();
+    um.pushFromRedo(redone);
+    assert(um.canUndo(), 'undo stack should have op back after redo');
+    assert(!um.canRedo(), 'redo stack should be empty after redo');
+    assertEqual(um.peek(), op);
+});
+
+test('new action after undo discards redo history', () => {
+    const um = new UndoManager();
+    um.push({ type: 'SAVE', label: 'original' });
+
+    const undone = um.pop();
+    um.pushRedo(undone);
+    assert(um.canRedo());
+
+    um.push({ type: 'DELETE', label: 'new action' });
+    assert(!um.canRedo(), 'redo history should be gone after new user action');
+    assert(um.canUndo());
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/test_undo_manager.js
+++ b/tests/test_undo_manager.js
@@ -35,6 +35,11 @@ class UndoManager {
         if (this._stack.length > this._maxHistory) this._stack.shift();
         this._notify();
     }
+    restoreToUndo(op) {
+        this._stack.push(op);
+        if (this._stack.length > this._maxHistory) this._stack.shift();
+        this._notify();
+    }
     canUndo() { return this._stack.length > 0; }
     canRedo() { return this._redoStack.length > 0; }
     peek() { return this._stack[this._stack.length - 1] || null; }
@@ -192,6 +197,14 @@ test('push() clears the redo stack', () => {
     assert(um.canRedo(), 'redo should be available before push');
     um.push({ type: 'DELETE', label: 'new action' });
     assert(!um.canRedo(), 'new user action should clear redo history');
+});
+
+test('restoreToUndo() adds to undo stack without clearing redo stack', () => {
+    const um = new UndoManager();
+    um.pushRedo({ type: 'MOVE', label: 'next redo' });
+    um.restoreToUndo({ type: 'SAVE', label: 'failed op put back' });
+    assert(um.canUndo(), 'undo stack should have the restored op');
+    assert(um.canRedo(), 'redo stack must be preserved — this is the key difference from push()');
 });
 
 test('pushFromRedo() adds to undo stack without clearing redo stack', () => {

--- a/tests/test_undo_manager.js
+++ b/tests/test_undo_manager.js
@@ -1,0 +1,243 @@
+/**
+ * Unit tests for UndoManager — run with: node tests/test_undo_manager.js
+ *
+ * Tests the stack-based undo state management logic in isolation.
+ * No DOM or fetch dependencies.
+ */
+
+// ---------------------------------------------------------------------------
+// Inline UndoManager (mirrors the class in index.html)
+// ---------------------------------------------------------------------------
+
+class UndoManager {
+    constructor(maxHistory = 50) {
+        this._stack = [];
+        this._maxHistory = maxHistory;
+    }
+    push(op) {
+        this._stack.push(op);
+        if (this._stack.length > this._maxHistory) this._stack.shift();
+    }
+    pop() { return this._stack.pop() || null; }
+    canUndo() { return this._stack.length > 0; }
+    peek() { return this._stack[this._stack.length - 1] || null; }
+    clear() { this._stack = []; }
+    get size() { return this._stack.length; }
+}
+
+// ---------------------------------------------------------------------------
+// Minimal test runner
+// ---------------------------------------------------------------------------
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+    try {
+        fn();
+        console.log(`  PASS  ${name}`);
+        passed++;
+    } catch (err) {
+        console.error(`  FAIL  ${name}`);
+        console.error(`        ${err.message}`);
+        failed++;
+    }
+}
+
+function assert(condition, msg) {
+    if (!condition) throw new Error(msg || 'Assertion failed');
+}
+
+function assertEqual(actual, expected, msg) {
+    if (actual !== expected) {
+        throw new Error(msg || `Expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests: initial state
+// ---------------------------------------------------------------------------
+
+console.log('\nUndoManager — initial state');
+
+test('canUndo() is false when empty', () => {
+    const um = new UndoManager();
+    assert(!um.canUndo(), 'should not be undoable when empty');
+});
+
+test('size is 0 when empty', () => {
+    const um = new UndoManager();
+    assertEqual(um.size, 0);
+});
+
+test('pop() returns null when empty', () => {
+    const um = new UndoManager();
+    assertEqual(um.pop(), null);
+});
+
+test('peek() returns null when empty', () => {
+    const um = new UndoManager();
+    assertEqual(um.peek(), null);
+});
+
+// ---------------------------------------------------------------------------
+// Tests: push and pop
+// ---------------------------------------------------------------------------
+
+console.log('\nUndoManager — push and pop');
+
+test('canUndo() is true after push', () => {
+    const um = new UndoManager();
+    um.push({ type: 'RENAME', label: 'Rename "a" to "b"' });
+    assert(um.canUndo());
+});
+
+test('size increments with each push', () => {
+    const um = new UndoManager();
+    um.push({ type: 'SAVE' });
+    um.push({ type: 'MOVE' });
+    assertEqual(um.size, 2);
+});
+
+test('pop returns last pushed operation', () => {
+    const um = new UndoManager();
+    const op1 = { type: 'SAVE', label: 'Edit "file.md"' };
+    const op2 = { type: 'RENAME', label: 'Rename "a" to "b"' };
+    um.push(op1);
+    um.push(op2);
+    assertEqual(um.pop(), op2);
+});
+
+test('pop removes the operation (LIFO)', () => {
+    const um = new UndoManager();
+    um.push({ type: 'SAVE' });
+    um.push({ type: 'MOVE' });
+    um.pop();
+    assertEqual(um.size, 1);
+});
+
+test('canUndo() is false after popping all operations', () => {
+    const um = new UndoManager();
+    um.push({ type: 'SAVE' });
+    um.pop();
+    assert(!um.canUndo());
+});
+
+test('peek returns last operation without removing it', () => {
+    const um = new UndoManager();
+    const op = { type: 'MOVE', label: 'Move "x.md"' };
+    um.push(op);
+    assertEqual(um.peek(), op);
+    assertEqual(um.size, 1, 'peek should not remove the operation');
+});
+
+// ---------------------------------------------------------------------------
+// Tests: operation types
+// ---------------------------------------------------------------------------
+
+console.log('\nUndoManager — operation payloads');
+
+test('SAVE operation stores path and previousContent', () => {
+    const um = new UndoManager();
+    const op = { type: 'SAVE', path: 'notes/foo.md', previousContent: 'hello', label: 'Edit "foo.md"' };
+    um.push(op);
+    const popped = um.pop();
+    assertEqual(popped.type, 'SAVE');
+    assertEqual(popped.path, 'notes/foo.md');
+    assertEqual(popped.previousContent, 'hello');
+});
+
+test('MOVE operation stores moves array with originalParent and newPath', () => {
+    const um = new UndoManager();
+    const op = {
+        type: 'MOVE',
+        moves: [{ originalPath: 'a/f.md', originalParent: 'a', itemName: 'f.md', newPath: 'b/f.md' }],
+        label: 'Move "f.md" to b'
+    };
+    um.push(op);
+    const popped = um.pop();
+    assertEqual(popped.moves[0].originalParent, 'a');
+    assertEqual(popped.moves[0].newPath, 'b/f.md');
+});
+
+test('RENAME operation stores originalName, newName, newPath', () => {
+    const um = new UndoManager();
+    const op = {
+        type: 'RENAME',
+        originalPath: 'docs/old.md',
+        originalName: 'old.md',
+        newName: 'new.md',
+        newPath: 'docs/new.md',
+        parentFolder: 'docs',
+        label: 'Rename "old.md" to "new.md"'
+    };
+    um.push(op);
+    const popped = um.pop();
+    assertEqual(popped.originalName, 'old.md');
+    assertEqual(popped.newPath, 'docs/new.md');
+});
+
+test('CREATE_FILE operation stores created path', () => {
+    const um = new UndoManager();
+    const op = { type: 'CREATE_FILE', path: 'notes/new.md', label: 'New file "new.md"' };
+    um.push(op);
+    const popped = um.pop();
+    assertEqual(popped.type, 'CREATE_FILE');
+    assertEqual(popped.path, 'notes/new.md');
+});
+
+test('CREATE_FOLDER operation stores created path', () => {
+    const um = new UndoManager();
+    const op = { type: 'CREATE_FOLDER', path: 'projects/new-dir', label: 'New folder "new-dir"' };
+    um.push(op);
+    assertEqual(um.pop().path, 'projects/new-dir');
+});
+
+// ---------------------------------------------------------------------------
+// Tests: history cap
+// ---------------------------------------------------------------------------
+
+console.log('\nUndoManager — history cap');
+
+test('enforces maxHistory limit by evicting the oldest entry', () => {
+    const um = new UndoManager(3);
+    um.push({ type: 'SAVE', label: 'first' });
+    um.push({ type: 'SAVE', label: 'second' });
+    um.push({ type: 'SAVE', label: 'third' });
+    um.push({ type: 'SAVE', label: 'fourth' }); // evicts 'first'
+    assertEqual(um.size, 3);
+    // Pop all three; 'first' should not be present
+    const labels = [um.pop().label, um.pop().label, um.pop().label];
+    assert(!labels.includes('first'), 'oldest entry should have been evicted');
+    assert(labels.includes('second'));
+    assert(labels.includes('third'));
+    assert(labels.includes('fourth'));
+});
+
+test('size never exceeds maxHistory', () => {
+    const um = new UndoManager(5);
+    for (let i = 0; i < 20; i++) um.push({ type: 'SAVE', label: `op-${i}` });
+    assert(um.size <= 5, `size ${um.size} should be <= 5`);
+});
+
+// ---------------------------------------------------------------------------
+// Tests: clear
+// ---------------------------------------------------------------------------
+
+console.log('\nUndoManager — clear');
+
+test('clear() empties the stack', () => {
+    const um = new UndoManager();
+    um.push({ type: 'SAVE' });
+    um.push({ type: 'MOVE' });
+    um.clear();
+    assertEqual(um.size, 0);
+    assert(!um.canUndo());
+});
+
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+
+console.log(`\n${passed + failed} tests: ${passed} passed, ${failed} failed\n`);
+if (failed > 0) process.exit(1);

--- a/tests/test_undo_operations.py
+++ b/tests/test_undo_operations.py
@@ -1,0 +1,274 @@
+"""Integration tests for file API operations used by the undo system.
+
+Each test exercises a forward operation followed by its undo (reverse call),
+verifying that the filesystem returns to its original state.
+"""
+
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def web_client(tmp_path: Path):
+    from fastapi.testclient import TestClient
+
+    from santai_cli.core.project import SantaiProject
+    from santai_cli.web.app import create_app
+
+    project = SantaiProject(root=tmp_path, name=tmp_path.name)
+    app = create_app(project)
+    return TestClient(app), project
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_file(project, rel_path: str, content: str) -> Path:
+    """Create a file with *content* inside the project root."""
+    p = project.root / rel_path
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+# ---------------------------------------------------------------------------
+# SAVE (text edit) — undo restores previous content
+# ---------------------------------------------------------------------------
+
+
+def test_undo_save_restores_previous_content(web_client):
+    client, project = web_client
+
+    _write_file(project, "notes/hello.md", "original content")
+
+    # Forward: save new content
+    resp = client.post(
+        "/api/files/save?path=notes/hello.md",
+        json={"content": "updated content"},
+    )
+    assert resp.status_code == 200
+    assert (project.root / "notes/hello.md").read_text() == "updated content"
+
+    # Undo: restore old content (same endpoint, old content as body)
+    resp = client.post(
+        "/api/files/save?path=notes/hello.md",
+        json={"content": "original content"},
+    )
+    assert resp.status_code == 200
+    assert (project.root / "notes/hello.md").read_text() == "original content"
+
+
+def test_undo_save_rejects_invalid_path(web_client):
+    client, _ = web_client
+    resp = client.post(
+        "/api/files/save?path=../../etc/passwd",
+        json={"content": "hack"},
+    )
+    assert resp.status_code in (400, 403, 404, 422)
+
+
+# ---------------------------------------------------------------------------
+# RENAME — undo renames back to original name
+# ---------------------------------------------------------------------------
+
+
+def test_undo_rename_restores_original_name(web_client):
+    client, project = web_client
+
+    _write_file(project, "docs/original.md", "content")
+
+    # Forward: rename to new-name.md
+    resp = client.post(
+        "/api/files/rename",
+        json={"old_path": "docs/original.md", "new_name": "renamed.md"},
+    )
+    assert resp.status_code == 200
+    assert (project.root / "docs/renamed.md").exists()
+    assert not (project.root / "docs/original.md").exists()
+
+    # Undo: rename back to original.md
+    resp = client.post(
+        "/api/files/rename",
+        json={"old_path": "docs/renamed.md", "new_name": "original.md"},
+    )
+    assert resp.status_code == 200
+    assert (project.root / "docs/original.md").exists()
+    assert not (project.root / "docs/renamed.md").exists()
+
+
+def test_undo_rename_folder_restores_original_name(web_client):
+    client, project = web_client
+
+    (project.root / "old-folder").mkdir()
+    (project.root / "old-folder/file.md").write_text("hi")
+
+    resp = client.post(
+        "/api/files/rename",
+        json={"old_path": "old-folder", "new_name": "new-folder"},
+    )
+    assert resp.status_code == 200
+    assert (project.root / "new-folder").is_dir()
+
+    # Undo
+    resp = client.post(
+        "/api/files/rename",
+        json={"old_path": "new-folder", "new_name": "old-folder"},
+    )
+    assert resp.status_code == 200
+    assert (project.root / "old-folder").is_dir()
+    assert not (project.root / "new-folder").exists()
+
+
+# ---------------------------------------------------------------------------
+# MOVE — undo moves items back to their original location
+# ---------------------------------------------------------------------------
+
+
+def test_undo_move_file_restores_original_location(web_client):
+    client, project = web_client
+
+    _write_file(project, "src/file.md", "hello")
+    (project.root / "dest").mkdir()
+
+    # Forward: move src/file.md → dest/
+    resp = client.post(
+        "/api/files/move",
+        json={"source_path": "src/file.md", "target_folder": "dest"},
+    )
+    assert resp.status_code == 200
+    assert (project.root / "dest/file.md").exists()
+    assert not (project.root / "src/file.md").exists()
+
+    # Undo: move dest/file.md → src/
+    resp = client.post(
+        "/api/files/move",
+        json={"source_path": "dest/file.md", "target_folder": "src"},
+    )
+    assert resp.status_code == 200
+    assert (project.root / "src/file.md").exists()
+    assert not (project.root / "dest/file.md").exists()
+
+
+def test_undo_move_folder_restores_original_location(web_client):
+    client, project = web_client
+
+    (project.root / "source-dir").mkdir()
+    (project.root / "source-dir/child.md").write_text("data")
+    (project.root / "archive").mkdir()
+
+    # Forward: move source-dir into archive/
+    resp = client.post(
+        "/api/files/move",
+        json={"source_path": "source-dir", "target_folder": "archive"},
+    )
+    assert resp.status_code == 200
+    assert (project.root / "archive/source-dir").is_dir()
+
+    # Undo: move archive/source-dir back to root (empty target = root)
+    resp = client.post(
+        "/api/files/move",
+        json={"source_path": "archive/source-dir", "target_folder": ""},
+    )
+    assert resp.status_code == 200
+    assert (project.root / "source-dir").is_dir()
+    assert not (project.root / "archive/source-dir").exists()
+
+
+# ---------------------------------------------------------------------------
+# CREATE_FILE — undo deletes the created file
+# ---------------------------------------------------------------------------
+
+
+def test_undo_create_file_deletes_it(web_client):
+    client, project = web_client
+
+    # Forward: create new file
+    resp = client.post(
+        "/api/files/touch",
+        json={"path": "", "name": "new-note.md"},
+    )
+    assert resp.status_code == 200
+    created_path = resp.json().get("path", "new-note.md")
+    assert (project.root / created_path).exists()
+
+    # Undo: delete the file
+    resp = client.delete(f"/api/files?path={created_path}")
+    assert resp.status_code == 200
+    assert not (project.root / created_path).exists()
+
+
+def test_undo_create_file_in_subfolder(web_client):
+    client, project = web_client
+
+    (project.root / "notes").mkdir()
+    resp = client.post(
+        "/api/files/touch",
+        json={"path": "notes", "name": "memo.md"},
+    )
+    assert resp.status_code == 200
+    assert (project.root / "notes/memo.md").exists()
+
+    resp = client.delete("/api/files?path=notes/memo.md")
+    assert resp.status_code == 200
+    assert not (project.root / "notes/memo.md").exists()
+
+
+# ---------------------------------------------------------------------------
+# CREATE_FOLDER — undo deletes the created folder
+# ---------------------------------------------------------------------------
+
+
+def test_undo_create_folder_deletes_it(web_client):
+    client, project = web_client
+
+    resp = client.post(
+        "/api/files/mkdir",
+        json={"path": "", "name": "new-project"},
+    )
+    assert resp.status_code == 200
+    assert (project.root / "new-project").is_dir()
+
+    resp = client.delete("/api/files?path=new-project")
+    assert resp.status_code == 200
+    assert not (project.root / "new-project").exists()
+
+
+def test_undo_create_nested_folder(web_client):
+    client, project = web_client
+
+    (project.root / "parent").mkdir()
+    resp = client.post(
+        "/api/files/mkdir",
+        json={"path": "parent", "name": "child"},
+    )
+    assert resp.status_code == 200
+    assert (project.root / "parent/child").is_dir()
+
+    resp = client.delete("/api/files?path=parent/child")
+    assert resp.status_code == 200
+    assert not (project.root / "parent/child").exists()
+
+
+# ---------------------------------------------------------------------------
+# Keyboard shortcut integration: Ctrl/Cmd+Z should not interfere with edits
+# (Tested via frontend JS; these Python tests cover the API surface only.)
+# ---------------------------------------------------------------------------
+
+
+def test_save_endpoint_is_idempotent_for_same_content(web_client):
+    """Saving the same content twice is safe (no-op from undo perspective)."""
+    client, project = web_client
+    _write_file(project, "file.md", "hello")
+
+    resp1 = client.post("/api/files/save?path=file.md", json={"content": "hello"})
+    resp2 = client.post("/api/files/save?path=file.md", json={"content": "hello"})
+    assert resp1.status_code == 200
+    assert resp2.status_code == 200
+    assert (project.root / "file.md").read_text() == "hello"

--- a/tests/test_undo_operations.py
+++ b/tests/test_undo_operations.py
@@ -1,7 +1,9 @@
-"""Integration tests for file API operations used by the undo system.
+"""Integration tests for the inverse-roundtrip behaviour of the file API.
 
-Each test exercises a forward operation followed by its undo (reverse call),
-verifying that the filesystem returns to its original state.
+Each test exercises a forward operation followed by its manual reverse call,
+verifying that the filesystem returns to its original state. These tests cover
+the API primitives that the JS undo system relies on — they do not exercise the
+JS snapshot/restore logic or UndoManager state machine.
 """
 
 from pathlib import Path
@@ -43,7 +45,7 @@ def _write_file(project, rel_path: str, content: str) -> Path:
 # ---------------------------------------------------------------------------
 
 
-def test_undo_save_restores_previous_content(web_client):
+def test_inverse_roundtrip_save_restores_previous_content(web_client):
     client, project = web_client
 
     _write_file(project, "notes/hello.md", "original content")
@@ -65,7 +67,7 @@ def test_undo_save_restores_previous_content(web_client):
     assert (project.root / "notes/hello.md").read_text() == "original content"
 
 
-def test_undo_save_rejects_invalid_path(web_client):
+def test_inverse_roundtrip_save_rejects_invalid_path(web_client):
     client, _ = web_client
     resp = client.post(
         "/api/files/save?path=../../etc/passwd",
@@ -79,7 +81,7 @@ def test_undo_save_rejects_invalid_path(web_client):
 # ---------------------------------------------------------------------------
 
 
-def test_undo_rename_restores_original_name(web_client):
+def test_inverse_roundtrip_rename_restores_original_name(web_client):
     client, project = web_client
 
     _write_file(project, "docs/original.md", "content")
@@ -103,7 +105,7 @@ def test_undo_rename_restores_original_name(web_client):
     assert not (project.root / "docs/renamed.md").exists()
 
 
-def test_undo_rename_folder_restores_original_name(web_client):
+def test_inverse_roundtrip_rename_folder_restores_original_name(web_client):
     client, project = web_client
 
     (project.root / "old-folder").mkdir()
@@ -131,7 +133,7 @@ def test_undo_rename_folder_restores_original_name(web_client):
 # ---------------------------------------------------------------------------
 
 
-def test_undo_move_file_restores_original_location(web_client):
+def test_inverse_roundtrip_move_file_restores_original_location(web_client):
     client, project = web_client
 
     _write_file(project, "src/file.md", "hello")
@@ -156,7 +158,7 @@ def test_undo_move_file_restores_original_location(web_client):
     assert not (project.root / "dest/file.md").exists()
 
 
-def test_undo_move_folder_restores_original_location(web_client):
+def test_inverse_roundtrip_move_folder_restores_original_location(web_client):
     client, project = web_client
 
     (project.root / "source-dir").mkdir()
@@ -186,7 +188,7 @@ def test_undo_move_folder_restores_original_location(web_client):
 # ---------------------------------------------------------------------------
 
 
-def test_undo_create_file_deletes_it(web_client):
+def test_inverse_roundtrip_create_file_deletes_it(web_client):
     client, project = web_client
 
     # Forward: create new file
@@ -204,7 +206,7 @@ def test_undo_create_file_deletes_it(web_client):
     assert not (project.root / created_path).exists()
 
 
-def test_undo_create_file_in_subfolder(web_client):
+def test_inverse_roundtrip_create_file_in_subfolder(web_client):
     client, project = web_client
 
     (project.root / "notes").mkdir()
@@ -225,7 +227,7 @@ def test_undo_create_file_in_subfolder(web_client):
 # ---------------------------------------------------------------------------
 
 
-def test_undo_create_folder_deletes_it(web_client):
+def test_inverse_roundtrip_create_folder_deletes_it(web_client):
     client, project = web_client
 
     resp = client.post(
@@ -240,7 +242,7 @@ def test_undo_create_folder_deletes_it(web_client):
     assert not (project.root / "new-project").exists()
 
 
-def test_undo_create_nested_folder(web_client):
+def test_inverse_roundtrip_create_nested_folder(web_client):
     client, project = web_client
 
     (project.root / "parent").mkdir()


### PR DESCRIPTION
### Summary
This PR adds a full undo/redo system to the file browser and bulk deletion support for the file tree.

  Undo / Redo
  - Cmd+Z / Ctrl+Z undoes the last file operation; Cmd+Shift+Z redoes it
  - Covered operations: rename, move, delete (single and bulk), file save, create file/folder
  - Toast notifications show what was undone/redone with a one-click Undo/Redo button; the button only appears on toast hover to reduce visual noise
  - Bulk undo/redo (multi-delete, multi-move) shows step-by-step progress toasts ("Restoring 2/5…")

  Multi-select in the file grid
  - Cmd+A selects all items in the current folder
  - Escape clears the selection
  - Clicking empty grid space clears the selection and resets the shift-range anchor
  - Deleting with multiple items selected triggers a bulk delete with a single undo step
  - Dragging multiple selected items moves them all in one operation, undoable in one Cmd+Z
---
### Test Plan

  Undo basics
  - [ ] Create a new file → press Cmd+Z → confirm file is removed
  - [ ] Create a new folder → press Cmd+Z → confirm folder is removed
  - [ ] Edit a file's content in the preview → save → press Cmd+Z → confirm content reverts
  - [ ] Drag a file into a subfolder → press Cmd+Z → confirm file is back in its original location

  Redo
  - [ ] Perform a rename → undo it → press Cmd+Shift+Z → confirm rename is re-applied
  - [ ] Perform a file deletion → undo it → press Cmd+Shift+Z → confirm file is deleted again
  
  Toast Undo button
  - [ ] After deleting a file, the toast message appears; hover over it to reveal the Undo button
 example: <img width="285" height="84" alt="image" src="https://github.com/user-attachments/assets/473245bb-a195-4579-9669-e555feefdb72" />

  - [ ] Clicking the Undo button in the toast message restores the file;
  - [ ] Click the Undo button in the toast message, hover over it to reveal the Redo button
 example: <img width="426" height="75" alt="image" src="https://github.com/user-attachments/assets/5df84127-32f6-4329-95a1-c02d10619484" />

  - [ ] Clicking the Redo button in the toast message is successful

  Multi-select
  - [ ] In the file tree click on a file within a folder → Cmd+A → confirm all items in the current folder are selected
  - [ ] In the file tree click on a file within a folder → Cmd+A → Escape → confirm all items are deselected

  Bulk delete
  - [ ] Cmd+click 3 items → click the delete button on any of them → confirm all 3 are deleted in one action
  - [ ] Press Cmd+Z → confirm all 3 are restored in a single undo (progress toasts "Restoring 1/3…" etc. should flash if not instantaneously restoring)
example: <img width="256" height="95" alt="image" src="https://github.com/user-attachments/assets/2a3c9d92-313a-4bc8-add5-5f4214423e15" />
 
  - [ ] Press Cmd+Shift+Z → confirm all 3 are deleted again with progress toasts (if not instant)

  Bulk move
  - [ ] Cmd+click 3 files → drag them into a subfolder → confirm all 3 move
  - [ ] Press Cmd+Z once → confirm all 3 return to their original location (single undo step, not 3 Cmd+Zs)