### PR TITLE
ci: add manual workflow trigger to publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
Adds `workflow_dispatch` so the publish workflow can be triggered manually.